### PR TITLE
testsuite: add DHX and DHX2 auth support to AFP test runners

### DIFF
--- a/.github/scripts/vm_spectest.sh
+++ b/.github/scripts/vm_spectest.sh
@@ -39,7 +39,7 @@ export SERVER_NAME=Netatalk
 export AFP_HOST=127.0.0.1
 export AFP_PORT=548
 export AFP_VERSION=7
-export TESTSUITE=spectest
+export TESTSUITE=spec
 export VERBOSE=1
 
 # copy the extmap template if absent so env_setup can activate it

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -217,7 +217,7 @@ jobs:
               -e AFP_GROUP=afpusers \
               -e SHARE_NAME=test1 -e SHARE_NAME2=test2 \
               -e INSECURE_AUTH=1 -e DISABLE_TIMEMACHINE=1 \
-              -e TESTSUITE=spectest -e AFP_VERSION=7 \
+              -e TESTSUITE=spec -e AFP_VERSION=7 \
               -e AFP_CNID_BACKEND=sqlite \
               -e TSAN_OPTIONS="halt_on_error=1 abort_on_error=1" \
               ${{ env.REGISTRY }}/${IMAGE_NAME}:${{ github.sha }}
@@ -306,7 +306,7 @@ jobs:
               -e AFP_DIRCACHE_RFORK_MAXSIZE=1024 \
               -e AFP_CNID_BACKEND=sqlite \
               -e AFP_CNID_TMPFS=1 \
-              -e TESTSUITE=spectest \
+              -e TESTSUITE=spec \
               -e AFP_VERSION=7 \
               -e FLAMEGRAPH=1 \
               ${{ env.REGISTRY }}/netatalk/netatalk-debug:${{ github.sha }} \
@@ -426,7 +426,7 @@ jobs:
               -e AFP_GROUP=afpusers \
               -e SHARE_NAME=test1 \
               -e SHARE_NAME2=test2 \
-              -e TESTSUITE=spectest \
+              -e TESTSUITE=spec \
               -e VERBOSE=1 \
               -e AFP_VERSION=7 \
               -e AFP_REMOTE=1 \
@@ -490,7 +490,7 @@ jobs:
               -e AFP_GROUP=afpusers \
               -e SHARE_NAME=test1 \
               -e SHARE_NAME2=test2 \
-              -e TESTSUITE=spectest \
+              -e TESTSUITE=spec \
               -e VERBOSE=1 \
               -e AFP_VERSION=7 \
               -e AFP_REMOTE=1 \
@@ -545,7 +545,7 @@ jobs:
               -e AFP_GROUP=afpusers \
               -e SHARE_NAME=test1 \
               -e SHARE_NAME2=test2 \
-              -e TESTSUITE=spectest \
+              -e TESTSUITE=spec \
               -e VERBOSE=1 \
               -e AFP_VERSION=7 \
               -e AFP_REMOTE=1 \
@@ -584,7 +584,7 @@ jobs:
               -e SHARE_NAME2=test2 \
               -e INSECURE_AUTH=1 \
               -e DISABLE_TIMEMACHINE=1 \
-              -e TESTSUITE=spectest \
+              -e TESTSUITE=spec \
               -e VERBOSE=1 \
               -e AFP_VERSION=7 \
               -e AFP_REMOTE=1 \
@@ -616,7 +616,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -643,7 +643,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -693,7 +693,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -721,7 +721,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -747,7 +747,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -775,7 +775,7 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e AFP_ADOUBLE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -805,7 +805,7 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e AFP_ADOUBLE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -831,7 +831,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="6" \
             -e AFP_EXTMAP="1" \
@@ -858,7 +858,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="5" \
             -e AFP_EXTMAP="1" \
@@ -885,7 +885,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="4" \
             -e AFP_EXTMAP="1" \
@@ -911,7 +911,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="3" \
             -e AFP_EXTMAP="1" \
@@ -937,9 +937,117 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="3" \
+            -e AFP_EXTMAP="1" \
+            -e AFP_DIRCACHESIZE="1024" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+
+  afp-spectest-dhx-afp30:
+    name: AFP spec test (DHCAST128) AFP 3.0 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_PASS2="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_UAMS="uams_dhx.so" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e TESTSUITE="spec" \
+            -e AFP_TESTSUITE_UAM="dhx" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="3" \
+            -e AFP_EXTMAP="1" \
+            -e AFP_DIRCACHESIZE="1024" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+  afp-spectest-dhx-afp34-debian:
+    name: AFP spec test (DHCAST128) AFP 3.4 - Debian
+    needs: build-container-testsuite-debian
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_PASS2="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_UAMS="uams_dhx.so" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e TESTSUITE="spec" \
+            -e AFP_TESTSUITE_UAM="dhx" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="7" \
+            -e AFP_EXTMAP="1" \
+            -e AFP_DIRCACHESIZE="1024" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+
+  afp-spectest-dhx2-afp31:
+    name: AFP spec test (DHX2) AFP 3.1 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_PASS2="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_UAMS="uams_dhx2.so" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e TESTSUITE="spec" \
+            -e AFP_TESTSUITE_UAM="dhx2" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="4" \
+            -e AFP_EXTMAP="1" \
+            -e AFP_DIRCACHESIZE="1024" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+  afp-spectest-dhx2-afp34-debian:
+    name: AFP spec test (DHX2) AFP 3.4 - Debian
+    needs: build-container-testsuite-debian
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_PASS2="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_UAMS="uams_dhx2.so" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e TESTSUITE="spec" \
+            -e AFP_TESTSUITE_UAM="dhx2" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
@@ -963,7 +1071,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="2" \
             -e AFP_EXTMAP="1" \
@@ -989,7 +1097,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
             -e AFP_EXTMAP="1" \
@@ -1015,7 +1123,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
             -e AFP_EXTMAP="1" \
@@ -1043,7 +1151,7 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e AFP_ADOUBLE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
             -e AFP_EXTMAP="1" \
@@ -1071,7 +1179,7 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e AFP_ADOUBLE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
             -e AFP_EXTMAP="1" \
@@ -1094,7 +1202,8 @@ jobs:
             -e SHARE_NAME="test1" \
             -e INSECURE_AUTH="1" \
             -e AFP_READONLY="1" \
-            -e TESTSUITE="readonly" \
+            -e TESTSUITE="spec" \
+            -e AFP_SUBTESTS="Readonly" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
@@ -1115,9 +1224,54 @@ jobs:
             -e SHARE_NAME="test1" \
             -e INSECURE_AUTH="1" \
             -e AFP_READONLY="1" \
-            -e TESTSUITE="readonly" \
+            -e TESTSUITE="spec" \
+            -e AFP_SUBTESTS="Readonly" \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+  afp-sleeptest-afp34:
+    name: AFP spec test (sleep) AFP 3.4 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e AFP_UAMS="uams_dhx2.so" \
+            -e TESTSUITE="spec" \
+            -e AFP_SUBTESTS="FPZzzzz" \
+            -e AFP_TESTSUITE_UAM="dhx2" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="7" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+  afp-sleeptest-afp30:
+    name: AFP spec test (sleep) AFP 3.0 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e AFP_UAMS="uams_dhx.so" \
+            -e TESTSUITE="spec" \
+            -e AFP_SUBTESTS="FPZzzzz" \
+            -e AFP_TESTSUITE_UAM="dhx" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="3" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
   afp-logintest-afp34:
@@ -1456,6 +1610,7 @@ jobs:
             -e SHARE_NAME="test1" \
             -e INSECURE_AUTH="1" \
             -e TESTSUITE="speed" \
+            -e AFP_SUBTESTS="Read,Write,Copy,ServerCopy" \
             -e AFP_VERSION="${{ env.AFP_VERSION }}" \
             -e AFP_CNID_BACKEND="${{ env.AFP_CNID_BACKEND }}" \
             -e AFP_CNID_TMPFS=1 \
@@ -1797,7 +1952,7 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
-            -e TESTSUITE="spectest" \
+            -e TESTSUITE="spec" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \

--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -291,7 +291,9 @@ Set this environment variable to a specific value or string.
 | AFP_UNIX_CHARSET                | Server filesystem charset (default: UTF8); see afp.conf man page       |
 | AFP_VOL_CHARSET                 | Volume charset (default: UTF8); see afp.conf man page                  |
 | **Test Suite Configuration** |                                                                           |
-| TESTSUITE                       | Run test suite on startup: *spectest*, *lan*, *speed*, *login*, *readonly* |
+| TESTSUITE                       | Run test suite on startup: *spec*, *lan*, *speed*, or *login*          |
+| AFP_SUBTESTS                    | Optional comma separated list of tests to run                          |
+| AFP_TESTSUITE_UAM               | UAM selector or protocol name: *clrtxt*, *dhx*, or *dhx2*              |
 | AFP_VERSION                     | AFP protocol version for tests: 1-7 (default: 7 = AFP 3.4)             |
 | AFP_HOST                        | AFP server hostname/IP for tests (default: 127.0.0.1)                  |
 | AFP_PORT                        | AFP server port for tests (default: 548)                               |
@@ -320,6 +322,7 @@ Set these environment variables to a non-zero value to enable, ex. "1"
 | **Advanced Configuration** |                                                                                            |
 | MANUAL_CONFIG       | Enable manual management of configurations; overrides most other options                       |
 | VERBOSE             | Enable verbose test output                                                                     |
+| VERY_VERBOSE        | Enable verbose test output that includes transport layer logging                               |
 | SERVER_LOGS         | Display afpd server logs after test completion                                                 |
 | IO_MONITORING       | Enable I/O monitoring for lantest (requires \-\-privileged)                                       |
 | DEBUG_ENTRY_SCRIPT  | Enable bash debug mode (set -x) for entrypoint script                                          |

--- a/distrib/docker/debug_entrypoint_netatalk.sh
+++ b/distrib/docker/debug_entrypoint_netatalk.sh
@@ -304,31 +304,58 @@ else
     echo ""
     # Temporarily disable exit-on-error to ensure we can dump logs even if test fails
     set +e
-    set -x
     TEST_START=$(date +%s)
     TEST_EXIT_CODE=0
     case "$TESTSUITE" in
-        spectest)
-            afp_spectest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -d "$AFP_USER2" -w "$AFP_PASS" -s "$SHARE_NAME" -S "$SHARE_NAME2"
-            TEST_EXIT_CODE=$?
-            ;;
-        readonly)
-            echo "testfile uno" > /mnt/afpshare/first.txt
-            echo "testfile dos" > /mnt/afpshare/second.txt
-            mkdir /mnt/afpshare/third
-            afp_spectest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -f Readonly_test
+        spec)
+            if [ "$AFP_SUBTESTS" = "Readonly" ]; then
+                echo "testfile uno" > /mnt/afpshare/first.txt
+                echo "testfile dos" > /mnt/afpshare/second.txt
+                mkdir /mnt/afpshare/third
+            fi
+            set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \
+                -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME"
+            if [ -n "$AFP_USER2" ]; then
+                set -- "$@" -d "$AFP_USER2"
+            fi
+            if [ -n "$SHARE_NAME2" ]; then
+                set -- "$@" -S "$SHARE_NAME2"
+            fi
+            if [ -n "$AFP_TESTSUITE_UAM" ]; then
+                set -- "$@" -A "$AFP_TESTSUITE_UAM"
+            fi
+            if [ -n "$AFP_SUBTESTS" ]; then
+                set -- "$@" -f "$AFP_SUBTESTS"
+            fi
+            afp_spectest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
             ;;
         login)
-            afp_logintest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS"
+            set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \
+                -u "$AFP_USER" -w "$AFP_PASS"
+            afp_logintest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
             ;;
         lan)
-            afp_lantest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME"
+            set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \
+                -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME"
+            if [ -n "$AFP_TESTSUITE_UAM" ]; then
+                set -- "$@" -A "$AFP_TESTSUITE_UAM"
+            fi
+            afp_lantest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
             ;;
         speed)
-            afp_speedtest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -n 10 -f Read,Write,Copy,ServerCopy
+            set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \
+                -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" \
+                -n 10
+            if [ -n "$AFP_TESTSUITE_UAM" ]; then
+                set -- "$@" -A "$AFP_TESTSUITE_UAM"
+            fi
+            if [ -n "$AFP_SUBTESTS" ]; then
+                set -- "$@" -f "$AFP_SUBTESTS"
+            fi
+            afp_speedtest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
             ;;
         *)
@@ -336,7 +363,6 @@ else
             TEST_EXIT_CODE=1
             ;;
     esac
-    set +x
     set -e
 
     TEST_END=$(date +%s)

--- a/distrib/docker/entrypoint_netatalk.sh
+++ b/distrib/docker/entrypoint_netatalk.sh
@@ -46,30 +46,58 @@ else
     echo ""
     # Temporarily disable exit-on-error to ensure we can dump logs even if test fails
     set +e
-    set -x
     TEST_EXIT_CODE=0
     case "$TESTSUITE" in
-        spectest)
-            afp_spectest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -d "$AFP_USER2" -w "$AFP_PASS" -s "$SHARE_NAME" -S "$SHARE_NAME2"
-            TEST_EXIT_CODE=$?
-            ;;
-        readonly)
-            echo "testfile uno" > /mnt/afpshare/first.txt
-            echo "testfile dos" > /mnt/afpshare/second.txt
-            mkdir /mnt/afpshare/third
-            afp_spectest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -f Readonly_test
+        spec)
+            if [ "$AFP_SUBTESTS" = "Readonly" ]; then
+                echo "testfile uno" > /mnt/afpshare/first.txt
+                echo "testfile dos" > /mnt/afpshare/second.txt
+                mkdir /mnt/afpshare/third
+            fi
+            set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \
+                -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME"
+            if [ -n "$AFP_USER2" ]; then
+                set -- "$@" -d "$AFP_USER2"
+            fi
+            if [ -n "$SHARE_NAME2" ]; then
+                set -- "$@" -S "$SHARE_NAME2"
+            fi
+            if [ -n "$AFP_TESTSUITE_UAM" ]; then
+                set -- "$@" -A "$AFP_TESTSUITE_UAM"
+            fi
+            if [ -n "$AFP_SUBTESTS" ]; then
+                set -- "$@" -f "$AFP_SUBTESTS"
+            fi
+            afp_spectest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
             ;;
         login)
-            afp_logintest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS"
+            set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \
+                -u "$AFP_USER" -w "$AFP_PASS"
+            afp_logintest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
             ;;
         lan)
-            afp_lantest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -n "${AFP_TEST_ITERATIONS:-10}"
+            set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \
+                -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" \
+                -n "${AFP_TEST_ITERATIONS:-10}"
+            if [ -n "$AFP_TESTSUITE_UAM" ]; then
+                set -- "$@" -A "$AFP_TESTSUITE_UAM"
+            fi
+            afp_lantest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
             ;;
         speed)
-            afp_speedtest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -n "${AFP_TEST_ITERATIONS:-10}" -f Read,Write,Copy,ServerCopy
+            set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \
+                -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" \
+                -n "${AFP_TEST_ITERATIONS:-10}"
+            if [ -n "$AFP_TESTSUITE_UAM" ]; then
+                set -- "$@" -A "$AFP_TESTSUITE_UAM"
+            fi
+            if [ -n "$AFP_SUBTESTS" ]; then
+                set -- "$@" -f "$AFP_SUBTESTS"
+            fi
+            afp_speedtest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
             ;;
         *)
@@ -77,7 +105,6 @@ else
             TEST_EXIT_CODE=1
             ;;
     esac
-    set +x
     set -e
 
     echo "==== TESTS (${TESTSUITE}) COMPLETED (exit code: $TEST_EXIT_CODE) ===="

--- a/distrib/docker/env_setup_netatalk.sh
+++ b/distrib/docker/env_setup_netatalk.sh
@@ -399,8 +399,11 @@ rm -f "$NETATALK_LOCKDIR/netatalk" "$NETATALK_LOCKDIR/atalkd" "$NETATALK_LOCKDIR
 echo "*** Configuring Netatalk"
 ATALK_NAME="${SERVER_NAME:-$(hostname | cut -d. -f1)}"
 
-# Prepend so a -c (CSV, forces quiet) later in TEST_FLAGS wins over -v
+# Prepend so a -c (CSV, forces quiet) later in TEST_FLAGS wins over verbosity.
+# VERBOSE enables normal test output (-v); VERY_VERBOSE also enables the
+# testsuite's detailed diagnostic logging (-V).
 [ -n "$VERBOSE" ] && TEST_FLAGS="-v $TEST_FLAGS"
+[ -n "$VERY_VERBOSE" ] && TEST_FLAGS="-V $TEST_FLAGS"
 
 if [ -z "$AFP_HOST" ]; then
     AFP_HOST="127.0.0.1"

--- a/doc/developer/profiling.md
+++ b/doc/developer/profiling.md
@@ -41,7 +41,7 @@ docker run --rm --privileged --network host \
     --env AFP_VERSION=7 \
     --env AFP_GROUP=afpusers \
     --env TZ=Europe/London \
-    --env TESTSUITE=spectest \
+    --env TESTSUITE=spec \
     --env INSECURE_AUTH=1 \
     --env DISABLE_TIMEMACHINE=1 \
     --env FLAMEGRAPH=1 \

--- a/doc/manpages/man1/afp_lantest.1.md
+++ b/doc/manpages/man1/afp_lantest.1.md
@@ -4,7 +4,7 @@ afp_lantest — AFP LAN performance and directory cache testing tool
 
 # Synopsis
 
-**afp_lantest** [-34567bcGgKVv] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*]
+**afp_lantest** [-34567bcGgKVv] [-A *uam*] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*]
 [-n *iterations*] [-f *tests*] [-F *bigfile*]
 
 # Description
@@ -33,6 +33,11 @@ features.
 
 **-7**
 : Use AFP 3.4 protocol version (default)
+
+**-A** *uam*
+: Select authentication with the specified UAM name or alias.
+  Use *clrtxt* for the legacy ClearTxt login path, *dhx* for DHCAST128, and
+  *dhx2* for DHX2.
 
 **-b**
 : Debug mode
@@ -81,11 +86,13 @@ features.
 
 # Configuration
 
-The test runner AFP client only supports the ClearTxt UAM currently.
-Configure the UAM in netatalk's afp.conf:
+By default, the test runner uses ClearTxt; **-A clrtxt** selects that same
+legacy login path explicitly. Pass **-A dhx** or **-A dhx2** to use the
+corresponding native encrypted UAM. Configure the selected UAM in
+netatalk's afp.conf:
 
     [Global]
-    uam list = uams_clrtxt.so
+    uam list = uams_dhx.so uams_dhx2.so uams_clrtxt.so
 
 # Available Tests
 

--- a/doc/manpages/man1/afp_spectest.1.md
+++ b/doc/manpages/man1/afp_spectest.1.md
@@ -4,7 +4,7 @@ afp_spectest — AFP specification compliance test suite
 
 # Synopsis
 
-**afp_spectest** [-1234567aCEiLmVv] [-h *host*] [-H *host2*] [-p *port*] [-s *volume*] [-c *path to volume*]
+**afp_spectest** [-1234567aCEiLmVv] [-A *uam*] [-h *host*] [-H *host2*] [-p *port*] [-s *volume*] [-c *path to volume*]
 [-S *volume2*] [-u *user*] [-d *user2*] [-w *password*] [-f *test*]
 
 **afp_spectest** -l
@@ -42,6 +42,11 @@ Single tests or entire testsets can be executed with the **-f** option.
 
 **-a**
 : Server under test uses AppleDouble v2 metadata and not filesystem EA
+
+**-A** *uam*
+: Select authentication with the specified UAM name or alias.
+  Use *clrtxt* for the legacy ClearTxt login path, *dhx* for DHCAST128, and
+  *dhx2* for DHX2.
 
 **-c** *path*
 : Local filesystem path to test volume (required for tier 2 tests)
@@ -202,7 +207,8 @@ against a native AppleShare AFP server or Netatalk.
 ## Configure environment
 
 Below is a sample configuration for running the AFP spec tests.
-Presently, only ClearTxt and Guest authentication is supported in the test runner.
+Note that this enables insecure ClearTxt, Guest, and DHCAST128 (DHX) authentication,
+which is not recommended for production use.
 
 - 2 users: user1, user2 with the same password
 - 1 group: afpusers
@@ -217,7 +223,7 @@ residual files in the test directories.
 Set afp.conf as follows:
 
     [Global]
-    uam list = uams_clrtxt.so uams_guest.so
+    uam list = uams_clrtxt.so uams_guest.so uams_dhx.so uams_dhx2.so
 
     [testvol1]
     ea = sys
@@ -233,16 +239,26 @@ Set afp.conf as follows:
 
 ## Running tests
 
-Run the afp_spectest against AFP server running on 10.0.0.10 for the "FPSetForkParms_test" testset with AFP 3.4
+Run the afp_spectest against AFP server running on 10.0.0.10 for
+the *FPSetForkParms* and *FPSetVolParms* testsets with AFP 3.4 and DHX2 authentication:
 
-    % afp_spectest -h 10.0.0.10 -u user1 -d user2 -w passwd -s testvol1 -S testvol2 -c /srv/afptest1 -7 -f FPSetForkParms_test
+    % afp_spectest -h 10.0.0.10 -u user1 -d user2 -w passwd -A dhx2 -s testvol1 -S testvol2 -c /srv/afptest1 -7 -f FPSetForkParms,FPSetVolParms
     ===================
-    FPSetForkParms_test
-    -------------------
+    Executing testset: FPSetForkParms_test
     FPSetForkParms:test62: SetForkParams errors - PASSED
     FPSetForkParms:test141: Setforkmode error - PASSED
     FPSetForkParms:test217: Setfork size 64 bits - PASSED
     FPSetForkParms:test306: set fork size, new size > old size - PASSED
+    ===================
+    Executing testset: FPSetVolParms_test
+    FPSetVolParms:test206: Set Volume parameters - PASSED
+    =====================
+    TEST RESULT SUMMARY
+    ---------------------
+    Passed:     5
+    Skipped:    0
+    Failed:     0
+    Not tested: 0
 
 # See Also
 

--- a/doc/manpages/man1/afp_speedtest.1.md
+++ b/doc/manpages/man1/afp_speedtest.1.md
@@ -4,7 +4,7 @@ afp_speedtest — Simple AFP file transfer benchmarking tool
 
 # Synopsis
 
-**afp_speedtest** [-1234567acDeiLTVvy] [-h *host*] [-p *port*] [-s *volume*] [-P *path*] [-S *volume2*]
+**afp_speedtest** [-1234567acDeiLTVvy] [-A *uam*] [-h *host*] [-p *port*] [-s *volume*] [-P *path*] [-S *volume2*]
 [-u *user*] [-w *password*] [-n *iterations*] [-W *warmup*] [-t *delay*] [-d *size*] [-z *sizes*]
 [-q *quantum*] [-r *requests*] [-F *file*] [-f *test*]
 
@@ -46,6 +46,11 @@ The tool supports comprehensive performance analysis including:
 
 **-7**
 : Use AFP 3.4 protocol version (default)
+
+**-A** *uam*
+: Select authentication with the specified UAM name or alias.
+  Use *clrtxt* for the legacy ClearTxt login path, *dhx* for DHCAST128, and
+  *dhx2* for DHX2.
 
 **-a**
 : Don't flush to disk after write
@@ -142,11 +147,13 @@ The tool supports comprehensive performance analysis including:
 
 # Configuration
 
-The test runner AFP client only supports the ClearTxt UAM currently.
-Configure the UAM in netatalk's afp.conf:
+By default, afp_speedtest uses ClearTxt; **-A clrtxt** selects that same
+legacy login path explicitly. Pass **-A dhx** or **-A dhx2** to use the
+corresponding native encrypted UAM. Configure the selected UAM in
+netatalk's afp.conf:
 
     [Global]
-    uam list = uams_clrtxt.so
+    uam list = uams_dhx.so uams_dhx2.so uams_clrtxt.so
 
 # Output Modes
 

--- a/doc/manpages/man1/afparg.1.md
+++ b/doc/manpages/man1/afparg.1.md
@@ -4,7 +4,7 @@ afparg — Send commands to an AFP server
 
 # Synopsis
 
-**afparg** [-1234567Vv] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*] [-f *command*]
+**afparg** [-1234567Vv] [-A *uam*] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*] [-f *command*]
 
 **afparg** -l
 
@@ -38,6 +38,11 @@ Run *afparg -l* to list available commands and their arguments.
 **-7**
 : Use AFP 3.4 protocol version (default)
 
+**-A** *uam*
+: Select authentication with the specified UAM name or alias.
+  Use *clrtxt* for the legacy ClearTxt login path, *dhx* for DHCAST128, and
+  *dhx2* for DHX2.
+
 **-f** *command* *arguments*
 : Command to execute
 
@@ -64,11 +69,13 @@ Run *afparg -l* to list available commands and their arguments.
 
 # Configuration
 
-The test runner AFP client only supports the ClearTxt UAM currently.
-Configure the UAM in netatalk's afp.conf:
+By default, afparg uses ClearTxt; **-A clrtxt** selects that same legacy login
+path explicitly. Pass **-A dhx** or **-A dhx2** to use the corresponding native
+encrypted UAM. Configure the selected UAM in netatalk's
+afp.conf:
 
     [Global]
-    uam list = uams_clrtxt.so
+    uam list = uams_dhx.so uams_dhx2.so uams_clrtxt.so
 
 # Examples
 

--- a/meson.build
+++ b/meson.build
@@ -2843,7 +2843,7 @@ summary_info = {
     '  afpd': build_afpd_tests,
     '  fuzzing': build_fuzzing,
     '  testsuite': build_testsuite,
-    '  UAM testsuite': testsuite_libafpclient.found(),
+    '  UAM logintest': testsuite_libafpclient.found(),
 }
 summary(summary_info, bool_yn: true, section: '  Tests:')
 

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -7,8 +7,10 @@
 extern char  *Server;
 extern int     Port;
 extern char    *Password;
+extern char    *User2;
 extern char *vers;
 extern char *uam;
+extern const char *afptest_uam;
 
 static volatile int sigp = 0;
 
@@ -16,7 +18,6 @@ static void pipe_handler()
 {
     sigp = 1;
 }
-
 
 /* ------------------------- */
 /* FIXME: need to recheck GetSessionToken 0 */
@@ -61,7 +62,7 @@ STATIC void test222()
     }
 
     dsi3->socket = sock;
-    ret = FPopenLoginExt(conn2, vers, uam, User, Password);
+    ret = afptest_login(conn2, vers, uam, afptest_uam, User, Password);
 
     if (ret) {
         test_nottested();
@@ -221,7 +222,7 @@ STATIC void test338()
     }
 
     loc_dsi1->socket = sock1;
-    ret = FPopenLoginExt(loc_conn1, vers, uam, User, Password);
+    ret = afptest_login(loc_conn1, vers, uam, afptest_uam, User, Password);
 
     if (ret) {
         test_nottested();
@@ -287,7 +288,7 @@ STATIC void test338()
     }
 
     loc_dsi2->socket = sock2;
-    ret = FPopenLoginExt(loc_conn2, vers, uam, User, Password);
+    ret = afptest_login(loc_conn2, vers, uam, afptest_uam, User, Password);
 
     if (ret) {
         test_nottested();
@@ -511,7 +512,6 @@ STATIC void test370()
 {
     char *name = "t370 file";
     char *ndir = "t370 dir";
-    char *no_user_uam = "No User Authent";
     uint16_t vol1;
     unsigned int ret;
     char *token = NULL;
@@ -540,6 +540,14 @@ STATIC void test370()
         goto test_exit;
     }
 
+    /* This verifies that a different authenticated user cannot invalidate
+     * another user's session. The former guest-UAM login is unavailable in
+     * UAM-specific test runs. */
+    if (!User2) {
+        test_skipped(T_CONN2);
+        goto test_exit;
+    }
+
     /* setup 2 new connections for testing */
 
     if ((loc_conn1 = (CONN *)calloc(1, sizeof(CONN))) == NULL) {
@@ -557,7 +565,7 @@ STATIC void test370()
     }
 
     loc_dsi1->socket = sock1;
-    ret = FPopenLoginExt(loc_conn1, vers, uam, User, Password);
+    ret = afptest_login(loc_conn1, vers, uam, afptest_uam, User, Password);
 
     if (ret) {
         test_nottested();
@@ -637,7 +645,7 @@ STATIC void test370()
     }
 
     loc_dsi2->socket = sock2;
-    ret = FPopenLoginExt(loc_conn2, vers, no_user_uam, "", "");
+    ret = afptest_login(loc_conn2, vers, uam, afptest_uam, User2, Password);
 
     if (ret) {
         test_nottested();
@@ -830,12 +838,7 @@ reconnect:
     }
 
     Conn->dsi.socket = sock;
-
-    if (Version >= 30) {
-        ret = FPopenLoginExt(Conn, vers, uam, User, Password);
-    } else {
-        ret = FPopenLogin(Conn, vers, uam, User, Password);
-    }
+    ret = afptest_login(Conn, vers, uam, afptest_uam, User, Password);
 
     if (ret) {
         if (!Quiet) {

--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -6,6 +6,11 @@
 
 int32_t is_there(CONN *conn, uint16_t volume, int32_t did, char *name);
 
+extern char *Password;
+extern char *vers;
+extern char *uam;
+extern const char *afptest_uam;
+
 /* ------------------------- */
 STATIC void test5()
 {
@@ -357,9 +362,6 @@ test_exit:
 
 extern char *Server;
 extern int  Port;
-extern char *Password;
-extern char *vers;
-extern char *uam;
 
 static volatile int sigp = 0;
 static int sock = -1;
@@ -441,7 +443,8 @@ static void write_test(int size)
     }
 
     dsi2->socket = sock;
-    ret = FPopenLogin(myconn, vers, uam, User, Password);
+    ret = afptest_login_plain(myconn, vers, uam, afptest_uam, User,
+                              Password);
 
     if (ret) {
         test_nottested();

--- a/test/testsuite/FPZzzzz.c
+++ b/test/testsuite/FPZzzzz.c
@@ -9,6 +9,7 @@ extern int  Port;
 extern char *Password;
 extern char *vers;
 extern char *uam;
+extern const char *afptest_uam;
 
 static volatile int sigp = 0;
 
@@ -37,8 +38,8 @@ STATIC void test223()
         goto test_exit;
     }
 
-    if (Conn->afp_version < 30 || Conn2) {
-        test_skipped(T_AFP3_CONN2);
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
         goto test_exit;
     }
 
@@ -69,11 +70,7 @@ STATIC void test223()
             goto fin;
         }
 
-        if (Conn->afp_version < 30) {
-            ret = FPopenLogin(Conn, vers, uam, User, Password);
-        } else {
-            ret = FPopenLoginExt(Conn, vers, uam, User, Password);
-        }
+        ret = afptest_login(Conn, vers, uam, afptest_uam, User, Password);
 
         if (ret) {
             test_nottested();
@@ -128,8 +125,8 @@ STATIC void test224()
         goto test_exit;
     }
 
-    if (Conn->afp_version < 30 || Conn2) {
-        test_skipped(T_AFP3_CONN2);
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
         goto test_exit;
     }
 
@@ -161,11 +158,7 @@ STATIC void test224()
             goto fin;
         }
 
-        if (Conn->afp_version < 30) {
-            ret = FPopenLogin(Conn, vers, uam, User, Password);
-        } else {
-            ret = FPopenLoginExt(Conn, vers, uam, User, Password);
-        }
+        ret = afptest_login(Conn, vers, uam, afptest_uam, User, Password);
 
         if (ret) {
             test_nottested();
@@ -216,8 +209,8 @@ STATIC void test239()
         goto test_exit;
     }
 
-    if (Conn->afp_version < 30 || Conn2) {
-        test_skipped(T_AFP3_CONN2);
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
         goto test_exit;
     }
 

--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -3,6 +3,7 @@
 #include <signal.h>
 
 #include "afpclient.h"
+#include "afptest_uam.h"
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
@@ -64,6 +65,7 @@ char    *Test = "";
 
 char *vers = "AFP3.4";
 char *uam = "Cleartxt Passwrd";
+static const char *afptest_uam;
 
 /* Unused but required in afphelper.c. Argh. */
 CONN       *Conn2;
@@ -128,8 +130,10 @@ static void run_one(char *name, char **args)
 void usage(char *av0)
 {
     fprintf(stdout,
-            "usage:\t%s [-1234567lVv] [-h host] [-p port] [-s vol] [-u user] [-w password] [-f command args]\n",
+            "usage:\t%s [-1234567lVv] [-A uam] [-h host] [-p port] [-s vol] [-u user] [-w password] [-f command args]\n",
             av0);
+    fprintf(stdout,
+            "\t-A\tafptest UAM name or alias (ClearTxt: clrtxt; DHCAST128: dhx; DHX2: dhx2)\n");
     fprintf(stdout, "\t-h\tserver host name (default localhost)\n");
     fprintf(stdout, "\t-p\tserver port (default 548)\n");
     fprintf(stdout, "\t-s\tvolume to mount\n");
@@ -159,7 +163,7 @@ int main(int ac, char **av)
         usage(av[0]);
     }
 
-    while ((cc = getopt(ac, av, "1234567lVvf:h:p:s:u:w:")) != EOF) {
+    while ((cc = getopt(ac, av, "1234567lVvA:f:h:p:s:u:w:")) != EOF) {
         switch (cc) {
         case '1':
             vers = "AFPVersion 2.1";
@@ -194,6 +198,10 @@ int main(int ac, char **av)
         case '7':
             vers = "AFP3.4";
             Version = 34;
+            break;
+
+        case 'A':
+            afptest_uam = afptest_uam_uses_legacy_login(optarg) ? NULL : optarg;
             break;
 
         case 'f' :
@@ -288,7 +296,9 @@ int main(int ac, char **av)
     Dsi->socket = sock;
 
     /* login */
-    if (Version >= 30) {
+    if (afptest_uam) {
+        ret = afptest_uam_login(Conn, vers, afptest_uam, User, Password);
+    } else if (Version >= 30) {
         ret = FPopenLoginExt(Conn, vers, uam, User, Password);
     } else {
         ret = FPopenLogin(Conn, vers, uam, User, Password);

--- a/test/testsuite/afpclient.c
+++ b/test/testsuite/afpclient.c
@@ -589,7 +589,7 @@ unsigned int AFPopenLogin(CONN *conn, const char *vers, const char *uam,
     return dsi->header.dsi_code;
 }
 
-/* Capture FPLoginExt/FPLoginCont reply block on kFPAuthContinue.
+/* Capture FPLogin/FPLoginExt/FPLoginCont reply block on kFPAuthContinue.
  * Reply payload layout (AFP Reference table 51): int16_t ID, then UAM-specific
  * UserAuthInfo. */
 static void capture_login_cont(CONN *conn)
@@ -613,6 +613,48 @@ static void capture_login_cont(CONN *conn)
 
     memcpy(conn->login_cont_data, dsi->commands + sizeof(id_be),
            conn->login_cont_len);
+}
+
+unsigned int AFPopenLoginAuth(CONN *conn, const char *vers, const char *uam,
+                              const void *auth_info, size_t auth_info_len)
+{
+    uint8_t len;
+    int ofs;
+    DSI *dsi = &conn->dsi;
+    assert(conn && vers && uam);
+
+    if (DSIOpenSession(conn)) {
+        return dsi->header.dsi_code;
+    }
+
+    SendInit(dsi);
+    ofs = 0;
+    dsi->commands[ofs++] = AFP_LOGIN;
+    len = (uint8_t)strnlen(vers, UINT8_MAX);
+    dsi->commands[ofs++] = len;
+    assert((size_t)ofs + len <= DSI_CMDSIZ);
+    memcpy(&dsi->commands[ofs], vers, len);
+    ofs += len;
+    len = (uint8_t)strnlen(uam, UINT8_MAX);
+    dsi->commands[ofs++] = len;
+    assert((size_t)ofs + len + auth_info_len <= DSI_CMDSIZ);
+    memcpy(&dsi->commands[ofs], uam, len);
+    ofs += len;
+
+    if (auth_info && auth_info_len) {
+        memcpy(&dsi->commands[ofs], auth_info, auth_info_len);
+        ofs += auth_info_len;
+    }
+
+    SetLen(dsi, ofs);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_cmd_receive(dsi);
+
+    if (dsi->header.dsi_code == htonl((uint32_t)AFPERR_AUTHCONT)) {
+        capture_login_cont(conn);
+    }
+
+    return dsi->header.dsi_code;
 }
 
 /* ---------------------------- */

--- a/test/testsuite/afpclient.h
+++ b/test/testsuite/afpclient.h
@@ -268,6 +268,12 @@ unsigned int DSICloseSession(CONN *conn);
 unsigned int AFPopenLogin(CONN *conn, const char *vers, const char *uam,
                           const char *usr, const char *pwd);
 
+/* Build an FPLogin with an arbitrary UserAuthInfo payload. Encrypted UAMs
+ * provide their username and key-exchange material in this payload. */
+unsigned int AFPopenLoginAuth(CONN *conn, const char *vers, const char *uam,
+                              const void *auth_info,
+                              size_t auth_info_len);
+
 /* Build an FPLoginExt with an arbitrary UserAuthInfo payload.
  * Callers that need plain 8-byte cleartext padding should use
  * AFPopenLoginExt_pwd() instead. */

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -8,14 +8,50 @@
 #include <atalk/compat.h>
 
 #include "afpclient.h"
+#include "afptest_uam.h"
 #include "afphelper.h"
 #include "afpcmd.h"
-#include "afphelper.h"
 #include "testhelper.h"
 
 #define AFPHELPER_NAME_MAX 255
 
 int Loglevel = AFP_LOG_INFO;
+
+static unsigned int afptest_login_with_fallback(
+    CONN *conn,
+    char *vers,
+    char *uam,
+    const char *selected_uam,
+    char *user,
+    char *password,
+    int use_login_ext)
+{
+    if (selected_uam) {
+        return afptest_uam_login(conn, vers, selected_uam, user, password);
+    }
+
+    if (use_login_ext && Version >= 30) {
+        return FPopenLoginExt(conn, vers, uam, user, password);
+    }
+
+    return FPopenLogin(conn, vers, uam, user, password);
+}
+
+unsigned int afptest_login(CONN *conn, char *vers, char *uam,
+                           const char *selected_uam, char *user,
+                           char *password)
+{
+    return afptest_login_with_fallback(conn, vers, uam, selected_uam, user,
+                                       password, 1);
+}
+
+unsigned int afptest_login_plain(CONN *conn, char *vers, char *uam,
+                                 const char *selected_uam, char *user,
+                                 char *password)
+{
+    return afptest_login_with_fallback(conn, vers, uam, selected_uam, user,
+                                       password, 0);
+}
 
 void illegal_fork(DSI *dsi, char cmd, char *name)
 {

--- a/test/testsuite/afphelper.h
+++ b/test/testsuite/afphelper.h
@@ -61,5 +61,13 @@ extern int delete_directory_tree_by_did(CONN *conn, uint16_t volume,
 extern int delete_directory_tree(CONN *conn, uint16_t volume,
                                  uint32_t parent_did, char *dirname);
 extern void clear_volume(uint16_t vol, CONN *conn);
+/* Log in with the UAM selected for the test runner. */
+extern unsigned int afptest_login(CONN *conn, char *vers, char *uam,
+                                  const char *selected_uam, char *user,
+                                  char *password);
+/* As above, but keep the historical FPLogin fallback for ClearTxt. */
+extern unsigned int afptest_login_plain(CONN *conn, char *vers, char *uam,
+                                        const char *selected_uam, char *user,
+                                        char *password);
 
 #endif

--- a/test/testsuite/afptest_uam.c
+++ b/test/testsuite/afptest_uam.c
@@ -1,0 +1,739 @@
+/*
+ * Native DHCAST128 and DHX2 authentication for the afptest client.
+ * Derived from afpfs-ng's AFP client UAM implementations.
+ *
+ * Copyright (C) 2006 Alex deVries <alexthepuffin@gmail.com>
+ * Copyright (C) 2007 Derrik Pates <dpates@dsdk12.net>
+ * Copyright (C) 2025-2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <arpa/inet.h>
+#include <pwd.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <unistd.h>
+
+#include <gcrypt.h>
+
+#include <atalk/afp.h>
+
+#include "afpclient.h"
+#include "afptest_uam.h"
+
+#define AFP_MAX_USERNAME_LEN 127
+#define UAM_NEED_LIBGCRYPT_VERSION "1.4.0"
+#define kFPAuthContinue AFPERR_AUTHCONT
+
+struct afptest_uam_server {
+    CONN *conn;
+    const char *vers;
+};
+
+struct afp_rx_buffer {
+    char *data;
+    size_t maxsize;
+    size_t size;
+};
+
+static const unsigned char dhx_c2siv[] =
+{ 'L', 'W', 'a', 'l', 'l', 'a', 'c', 'e' };
+static const unsigned char dhx_s2civ[] =
+{ 'C', 'J', 'a', 'l', 'b', 'e', 'r', 't' };
+static const unsigned char p_binary[] = {
+    0xba, 0x28, 0x73, 0xdf, 0xb0, 0x60, 0x57, 0xd4,
+    0x3f, 0x20, 0x24, 0x74, 0x4c, 0xee, 0xe7, 0x5b,
+};
+static const unsigned char g_binary[] = { 0x07 };
+
+static unsigned char copy_to_pascal(char *dest, const char *src)
+{
+    unsigned char len = (unsigned char)strnlen(src, AFP_MAX_USERNAME_LEN);
+    dest[0] = len;
+    memcpy(dest + 1, src, len);
+    return len;
+}
+
+static void afptest_copy_string(char *dest, size_t size, const char *src)
+{
+    size_t len;
+
+    if (size == 0) {
+        return;
+    }
+
+    len = strnlen(src, size - 1);
+    memcpy(dest, src, len);
+}
+
+static uint16_t afptest_read_be16(const char *src)
+{
+    uint16_t value;
+    memcpy(&value, src, sizeof(value));
+    return ntohs(value);
+}
+
+static int afptest_uam_copy_reply(struct afptest_uam_server *server,
+                                  struct afp_rx_buffer *reply)
+{
+    const CONN *conn = server->conn;
+
+    if (!reply) {
+        return 0;
+    }
+
+    if (reply->maxsize < sizeof(uint16_t) ||
+            conn->login_cont_len > reply->maxsize - sizeof(uint16_t)) {
+        return AFPERR_PARAM;
+    }
+
+    {
+        uint16_t id_be = htons(conn->login_cont_id);
+        memcpy(reply->data, &id_be, sizeof(id_be));
+        memcpy(reply->data + sizeof(id_be), conn->login_cont_data,
+               conn->login_cont_len);
+    }
+
+    reply->size = sizeof(uint16_t) + conn->login_cont_len;
+    return 0;
+}
+
+static int afptest_uam_login_initial(struct afptest_uam_server *server,
+                                     const char *uam, char *auth_info,
+                                     unsigned int auth_info_len,
+                                     struct afp_rx_buffer *reply)
+{
+    unsigned int result = AFPopenLoginAuth(server->conn, server->vers, uam,
+                                           auth_info, auth_info_len);
+    int error = (int)ntohl(result);
+
+    if (error == AFPERR_AUTHCONT) {
+        int copy_error = afptest_uam_copy_reply(server, reply);
+
+        if (copy_error != 0) {
+            return copy_error;
+        }
+    }
+
+    return error;
+}
+
+static int afptest_uam_login_cont(struct afptest_uam_server *server,
+                                  unsigned short id, char *auth_info,
+                                  unsigned int auth_info_len,
+                                  struct afp_rx_buffer *reply)
+{
+    unsigned int result;
+    int error;
+    server->conn->login_cont_id = id;
+    result = AFPLoginCont(server->conn, auth_info, auth_info_len);
+    error = (int)ntohl(result);
+
+    if (error == AFPERR_AUTHCONT) {
+        int copy_error = afptest_uam_copy_reply(server, reply);
+
+        if (copy_error != 0) {
+            return copy_error;
+        }
+    }
+
+    return error;
+}
+
+static int dhx_login(struct afptest_uam_server *server, const char *username,
+                     const char *passwd)
+{
+    if (!gcry_check_version(UAM_NEED_LIBGCRYPT_VERSION)) {
+        return AFPERR_MISC;
+    }
+
+    char *ai = NULL;
+    char *d = NULL;
+    unsigned char Ra_binary[32], K_binary[16];
+    int ai_len, ret;
+    const int Ma_len = 16, Mb_len = 16, nonce_len = 16;
+    gcry_mpi_t p = NULL, g = NULL, Ra = NULL;
+    gcry_mpi_t Ma, Mb = NULL, K, nonce = NULL, new_nonce;
+    size_t len;
+    struct afp_rx_buffer rbuf;
+    unsigned short ID;
+    gcry_cipher_hd_t ctx;
+    gcry_error_t ctxerror;
+    rbuf.data = NULL;
+    /* Allocate MPIs which are written in place; gcry_mpi_scan() creates
+     * the remaining MPIs. */
+    Ma = gcry_mpi_new(0);
+    K = gcry_mpi_new(0);
+    new_nonce = gcry_mpi_new(0);
+    /* Get p and g into a form that libgcrypt can use */
+    gcry_mpi_scan(&p, GCRYMPI_FMT_USG, p_binary, sizeof(p_binary), NULL);
+    gcry_mpi_scan(&g, GCRYMPI_FMT_USG, g_binary, sizeof(g_binary), NULL);
+    /* Get random bytes for Ra. */
+    gcry_randomize(Ra_binary, sizeof(Ra_binary), GCRY_STRONG_RANDOM);
+    /* Translate the binary form of Ra into libgcrypt's preferred form */
+    gcry_mpi_scan(&Ra, GCRYMPI_FMT_USG, Ra_binary, sizeof(Ra_binary), NULL);
+    /* Ma = g^Ra mod p <- This is our "public" key, which we exchange
+     * with the remote server to help make K, the session key. */
+    gcry_mpi_powm(Ma, g, Ra, p);
+    /* The first authinfo block contains the username followed by Ma on an
+     * even AFP-packet offset. Unlike the standalone client, calculate this
+     * from the actual FPLogin prefix rather than the address malloc chose. */
+    ai_len = 1 + (int)strnlen(username, AFP_MAX_USERNAME_LEN);
+
+    if ((1 + 1 + (int)strnlen(server->vers, UINT8_MAX) +
+            1 + (int)strlen("DHCAST128") + ai_len) & 1) {
+        ai_len++;
+    }
+
+    ai_len += Ma_len;
+    ai = calloc(1, ai_len);
+    d = ai;
+
+    if (ai == NULL) {
+        goto dhx_noctx_fail;
+    }
+
+    d += copy_to_pascal(ai, username) + 1;
+
+    if ((1 + 1 + (int)strnlen(server->vers, UINT8_MAX) +
+            1 + (int)strlen("DHCAST128") + (d - ai)) & 1) {
+        d++;
+    }
+
+    /* Extract Ma to send to the server for the exchange. */
+    gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *) d, Ma_len, &len, Ma);
+
+    if (len < (size_t) Ma_len) {
+        memmove(d + Ma_len - len, d, len);
+        memset(d, 0, Ma_len - len);
+    }
+
+    /* 2 bytes for id, 16 bytes for Mb, 32 bytes of crypted message text */
+    rbuf.maxsize = 2 + Mb_len + 32;
+    rbuf.data = calloc(1, rbuf.maxsize);
+    d = rbuf.data;
+
+    if (rbuf.data == NULL) {
+        goto dhx_noctx_fail;
+    }
+
+    rbuf.size = 0;
+    /* Send the first FPLogin request, and see what happens. */
+    ret = afptest_uam_login_initial(server, "DHCAST128", ai, ai_len, &rbuf);
+    free(ai);
+    ai = NULL;
+
+    if (ret != kFPAuthContinue) {
+        goto dhx_noctx_cleanup;
+    }
+
+    /* The block returned from the server should always be 50 bytes.
+     * If it's not, for now, choke and die loudly so we know it. */
+    if (rbuf.size != rbuf.maxsize) {
+        goto dhx_noctx_fail;
+    }
+
+    /* Extract the transaction ID from the server's reply block. */
+    ID = afptest_read_be16(d);
+    d += sizeof(ID);
+    /* Now, extract Mb (the server's "public key" part) directly into
+     * a gcry_mpi_t. */
+    gcry_mpi_scan(&Mb, GCRYMPI_FMT_USG, d, Mb_len, NULL);
+    d += Mb_len;
+    /* d now points to the ciphertext, which we'll decrypt in a bit. */
+    /* K = Mb^Ra mod p <- This nets us the "session key", which we
+     * actually use to encrypt and decrypt data. */
+    gcry_mpi_powm(K, Mb, Ra, p);
+    gcry_mpi_print(GCRYMPI_FMT_USG, K_binary, sizeof(K_binary), &len, K);
+
+    if (len < sizeof(K_binary)) {
+        memmove(K_binary + (sizeof(K_binary) - len), K_binary, len);
+        memset(K_binary, 0, sizeof(K_binary) - len);
+    }
+
+    /* Set up our encryption context. */
+    ctxerror = gcry_cipher_open(&ctx, GCRY_CIPHER_CAST5,
+                                GCRY_CIPHER_MODE_CBC, 0);
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx_noctx_fail;
+    }
+
+    /* Set the binary form of K as our key for this encryption context. */
+    ctxerror = gcry_cipher_setkey(ctx, K_binary, sizeof(K_binary));
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx_fail;
+    }
+
+    /* Set the initialization vector for server->client transfer. */
+    ctxerror = gcry_cipher_setiv(ctx, dhx_s2civ, sizeof(dhx_s2civ));
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx_fail;
+    }
+
+    /* The plaintext will hold the nonce (16 bytes) and the server's
+     * signature (16 bytes - we don't actually look at it though). */
+    len = nonce_len + 16;
+    /* Decrypt the ciphertext from the server. */
+    ctxerror = gcry_cipher_decrypt(ctx, d, len, NULL, 0);
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx_fail;
+    }
+
+    /* Pull the binary form of the nonce into a form that libgcrypt can
+     * deal with. */
+    gcry_mpi_scan(&nonce, GCRYMPI_FMT_USG, d, nonce_len, NULL);
+    /* NOTE: The following 16 bytes of plaintext, which the docs indicate
+     * as the server signature, will always contain just 0 values - Apple's
+     * docs claim that due to an error in an early implementation, it will
+     * always be that way. No point in looking at that. */
+    /* d still points into rbuf.data, which is no longer needed. */
+    free(rbuf.data);
+    rbuf.data = NULL;
+    /* Increment the nonce by 1 for sending back to the server. */
+    gcry_mpi_add_ui(new_nonce, nonce, 1);
+    /* New plaintext is 16 bytes of nonce, and (up to) 64 bytes of
+     * password (filled out with NULL values). */
+    ai_len = nonce_len + 64;
+    ai = calloc(1, ai_len);
+    d = ai;
+
+    if (ai == NULL) {
+        goto dhx_fail;
+    }
+
+    /* Pull the incremented nonce value back out into binary form. */
+    gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *) d, nonce_len, &len,
+                   new_nonce);
+
+    if (len < (size_t) nonce_len) {
+        memmove(d + nonce_len - len, d, len);
+        memset(d, 0, nonce_len - len);
+    }
+
+    d += nonce_len;
+    /* Copy the user's password into the plaintext. */
+    afptest_copy_string(d, 64, passwd);
+    /* Set the initialization vector for client->server transfer. */
+    ctxerror = gcry_cipher_setiv(ctx, dhx_c2siv, sizeof(dhx_c2siv));
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx_fail;
+    }
+
+    /* Encrypt the plaintext to create our new authinfo block. */
+    ctxerror = gcry_cipher_encrypt(ctx, ai, ai_len, NULL, 0);
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx_fail;
+    }
+
+    /* Send the FPLoginCont with the new authinfo block, sit back,
+     * cross fingers... */
+    ret = afptest_uam_login_cont(server, ID, ai, ai_len, NULL);
+    goto dhx_cleanup;
+dhx_noctx_fail:
+    ret = -1;
+    goto dhx_noctx_cleanup;
+dhx_fail:
+    ret = -1;
+dhx_cleanup:
+    gcry_cipher_close(ctx);
+dhx_noctx_cleanup:
+    gcry_mpi_release(p);
+    gcry_mpi_release(g);
+    gcry_mpi_release(Ra);
+    gcry_mpi_release(Ma);
+    gcry_mpi_release(Mb);
+    gcry_mpi_release(K);
+    gcry_mpi_release(nonce);
+    gcry_mpi_release(new_nonce);
+    free(ai);
+    free(rbuf.data);
+    return ret;
+}
+
+static int dhx2_login(struct afptest_uam_server *server, const char *username,
+                      const char *passwd)
+{
+    if (!gcry_check_version(UAM_NEED_LIBGCRYPT_VERSION)) {
+        return AFPERR_MISC;
+    }
+
+    gcry_mpi_t p = NULL, g = NULL, Mb = NULL, Ra = NULL, nonce = NULL;
+    gcry_mpi_t Ma, K, new_nonce;
+    char *ai = NULL, *d, *Ra_binary = NULL, *K_binary = NULL;
+    char *K_hash = NULL, nonce_binary[16];
+    int ai_len, hash_len, ret;
+    const int g_len = 4;
+    size_t len;
+    struct afp_rx_buffer rbuf;
+    unsigned short ID, bignum_len;
+    gcry_cipher_hd_t ctx;
+    gcry_error_t ctxerror;
+    rbuf.data = NULL;
+    /* Allocate MPIs which are written in place; gcry_mpi_scan() creates
+     * the remaining MPIs. */
+    Ma = gcry_mpi_new(0);
+    K = gcry_mpi_new(0);
+    new_nonce = gcry_mpi_new(0);
+    /* DHX2 requires the Pascal username to end on an even AFP-packet
+     * boundary.  Include the actual FPLogin prefix so the padding remains
+     * correct for every AFP version string. */
+    ai_len = (int)strnlen(username, AFP_MAX_USERNAME_LEN) + 1;
+
+    if ((1 + 1 + (int)strnlen(server->vers, UINT8_MAX) +
+            1 + (int)strlen("DHX2") + ai_len) & 1) {
+        ai_len++;
+    }
+
+    ai = calloc(1, ai_len);
+
+    if (ai == NULL) {
+        goto dhx2_noctx_fail;
+    }
+
+    copy_to_pascal(ai, username);
+    /* Reply block will contain:
+     *   Transaction ID (2 bytes, MSB)
+     *   g (4 bytes, MSB)
+     *   length of large values in bytes (2 bytes, MSB)
+     *   p (minimum 64 bytes, indicated by length value, MSB)
+     *   Mb (minimum 64 bytes, indicated by length value, MSB)
+     * We'll reserve 256 bytes for each of p and Mb, which covers
+     * primes up to 2048 bits. Known servers use 512 or 1024 bits. */
+    rbuf.maxsize = 2 + 4 + 2 + 256 * 2;
+    rbuf.data = calloc(1, rbuf.maxsize);
+    d = rbuf.data;
+
+    if (rbuf.data == NULL) {
+        goto dhx2_noctx_fail;
+    }
+
+    rbuf.size = 0;
+    /* Send the initial request in the login sequence. */
+    ret = afptest_uam_login_initial(server, "DHX2", ai, ai_len, &rbuf);
+    free(ai);
+    ai = NULL;
+
+    if (ret != kFPAuthContinue) {
+        goto dhx2_noctx_cleanup;
+    }
+
+    if (rbuf.size < 8) {
+        goto dhx2_noctx_fail;
+    }
+
+    /* Pull the transaction ID out of the reply block. */
+    ID = afptest_read_be16(d);
+    d += sizeof(ID);
+    /* Pull the value of g out of the reply block and directly into an
+     * gcry_mpi_t container for later use with libgcrypt. */
+    gcry_mpi_scan(&g, GCRYMPI_FMT_USG, d, g_len, NULL);
+    d += g_len;
+    bignum_len = afptest_read_be16(d);
+    d += sizeof(bignum_len);
+
+    if (bignum_len < 64 || bignum_len > 256 ||
+            rbuf.size != 8 + 2 * bignum_len) {
+        goto dhx2_noctx_fail;
+    }
+
+    /* Extract p into an gcry_mpi_t. */
+    gcry_mpi_scan(&p, GCRYMPI_FMT_USG, d, bignum_len, NULL);
+    d += bignum_len;
+    /* Extract Mb into an gcry_mpi_t. */
+    gcry_mpi_scan(&Mb, GCRYMPI_FMT_USG, d, bignum_len, NULL);
+    free(rbuf.data);
+    rbuf.data = NULL;
+    Ra_binary = calloc(1, bignum_len);
+
+    if (Ra_binary == NULL) {
+        goto dhx2_noctx_fail;
+    }
+
+    /* Get random bytes for Ra. */
+    gcry_randomize(Ra_binary, bignum_len, GCRY_STRONG_RANDOM);
+    /* Pull the random value we just read into an gcry_mpi_t so we can do
+     * large-value exponentiation, and generate our Ma. */
+    gcry_mpi_scan(&Ra, GCRYMPI_FMT_USG, Ra_binary, bignum_len, NULL);
+    free(Ra_binary);
+    Ra_binary = NULL;
+    /* Ma = g^Ra mod p <- This is our "public" key, which we exchange
+     * with the remote server to help make K, the session key. */
+    gcry_mpi_powm(Ma, g, Ra, p);
+    /* K = Mb^Ra mod p <- This nets us the "session key", which we
+     * actually use to encrypt and decrypt data. */
+    gcry_mpi_powm(K, Mb, Ra, p);
+    K_binary = calloc(1, bignum_len);
+
+    if (K_binary == NULL) {
+        goto dhx2_noctx_fail;
+    }
+
+    gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *) K_binary, bignum_len, &len,
+                   K);
+
+    if (len < bignum_len) {
+        memmove(K_binary + bignum_len - len, K_binary, len);
+        memset(K_binary, 0, bignum_len - len);
+    }
+
+    /* Use a one-shot hash function to generate the MD5 hash of K. */
+    hash_len = gcry_md_get_algo_dlen(GCRY_MD_MD5);
+    K_hash = calloc(1, hash_len);
+
+    if (K_hash == NULL) {
+        goto dhx2_noctx_fail;
+    }
+
+    gcry_md_hash_buffer(GCRY_MD_MD5, K_hash, K_binary, bignum_len);
+    /* Use an internal gcrypt function to create the random number, so
+     * we can do things (more) portably... */
+    gcry_create_nonce(nonce_binary, sizeof(nonce_binary));
+    /* Set up our encryption context. */
+    ctxerror = gcry_cipher_open(&ctx, GCRY_CIPHER_CAST5,
+                                GCRY_CIPHER_MODE_CBC, 0);
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx2_noctx_fail;
+    }
+
+    /* Set the hashed form of K as our key for this encryption context. */
+    ctxerror = gcry_cipher_setkey(ctx, K_hash, hash_len);
+    free(K_hash);
+    K_hash = NULL;
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx2_fail;
+    }
+
+    /* Set the initialization vector for client->server transfer. */
+    ctxerror = gcry_cipher_setiv(ctx, dhx_c2siv, sizeof(dhx_c2siv));
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx2_fail;
+    }
+
+    /* The new authinfo block will contain Ma (our "public" key part) and
+     * the encrypted form of our nonce. */
+    ai_len = bignum_len + sizeof(nonce_binary);
+    ai = calloc(1, ai_len);
+    d = ai;
+
+    if (ai == NULL) {
+        goto dhx2_fail;
+    }
+
+    gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *) d, bignum_len, &len, Ma);
+
+    if (len < bignum_len) {
+        memmove(d + bignum_len - len, d, len);
+        memset(d, 0, bignum_len - len);
+    }
+
+    d += bignum_len;
+    /* Encrypt our nonce into the new authinfo block. */
+    ctxerror = gcry_cipher_encrypt(ctx, d, sizeof(nonce_binary),
+                                   nonce_binary, sizeof(nonce_binary));
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx2_fail;
+    }
+
+    /* Reply block will contain ID, then the encrypted form of our
+     * nonce + 1 and the server's nonce. */
+    rbuf.maxsize = sizeof(ID) + sizeof(nonce_binary) * 2;
+    rbuf.data = calloc(1, rbuf.maxsize);
+    d = rbuf.data;
+
+    if (rbuf.data == NULL) {
+        goto dhx2_fail;
+    }
+
+    rbuf.size = 0;
+    ret = afptest_uam_login_cont(server, ID, ai, ai_len, &rbuf);
+    free(ai);
+    ai = NULL;
+
+    if (ret != kFPAuthContinue || rbuf.size != rbuf.maxsize) {
+        ret = -1;
+        goto dhx2_cleanup;
+    }
+
+    /* Get the new transaction ID for the last portion of the exchange. */
+    ID = afptest_read_be16(d);
+    d += sizeof(ID);
+    /* Set the initialization vector for server->client transfer. */
+    ctxerror = gcry_cipher_setiv(ctx, dhx_s2civ, sizeof(dhx_s2civ));
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx2_fail;
+    }
+
+    len = rbuf.maxsize - sizeof(ID);
+    /* Decrypt the ciphertext from the server. */
+    ctxerror = gcry_cipher_decrypt(ctx, d, len, NULL, 0);
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx2_fail;
+    }
+
+    /* Pull our nonce into an gcry_mpi_t so we can operate. */
+    gcry_mpi_scan(&nonce, GCRYMPI_FMT_USG, nonce_binary, sizeof(nonce_binary),
+                  NULL);
+    /* Increment our nonce by one. */
+    gcry_mpi_add_ui(new_nonce, nonce, 1);
+    /* Pull the incremented nonce back out into binary form. */
+    gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *) nonce_binary,
+                   sizeof(nonce_binary), &len,
+                   new_nonce);
+
+    if (len < sizeof(nonce_binary)) {
+        memmove(nonce_binary + sizeof(nonce_binary) - len,
+                nonce_binary, len);
+        memset(nonce_binary, 0, sizeof(nonce_binary) - len);
+    }
+
+    /* Compare our incremented nonce to the server's incremented copy
+     * of our original nonce value; if they don't match, something
+     * terrible has happened. */
+    if (memcmp(nonce_binary, d, 16) != 0) {
+        goto dhx2_fail;
+    }
+
+    d += sizeof(nonce_binary);
+    /* Pull the server's nonce value into an gcry_mpi_t. */
+    gcry_mpi_scan(&nonce, GCRYMPI_FMT_USG, d, sizeof(nonce_binary), NULL);
+    /* d still points into rbuf.data; let's dispose of it safely. */
+    free(rbuf.data);
+    rbuf.data = NULL;
+    /* Increment the server's nonce by one. */
+    gcry_mpi_add_ui(new_nonce, nonce, 1);
+    /* The new plaintext will need 16 bytes for the server nonce (after
+     * incrementing), followed by 256 bytes of null-filled space for the
+     * user's password. */
+    ai_len = sizeof(nonce_binary) + 256;
+    ai = calloc(1, ai_len);
+    d = ai;
+
+    if (ai == NULL) {
+        goto dhx2_fail;
+    }
+
+    /* Extract the binary form of the incremented server nonce into
+     * the plaintext buffer. */
+    gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *) d, sizeof(nonce_binary), &len,
+                   new_nonce);
+
+    if (len < sizeof(nonce_binary)) {
+        memmove(d + sizeof(nonce_binary) - len, d, len);
+        memset(d, 0, sizeof(nonce_binary) - len);
+    }
+
+    d += sizeof(nonce_binary);
+    /* Copy the user's password into the plaintext buffer. */
+    afptest_copy_string(d, 256, passwd);
+    /* Set the initialization vector for client->server transfer. */
+    ctxerror = gcry_cipher_setiv(ctx, dhx_c2siv, sizeof(dhx_c2siv));
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx2_fail;
+    }
+
+    /* Encrypt our nonce into the new authinfo block. */
+    ctxerror = gcry_cipher_encrypt(ctx, ai, ai_len, NULL, 0);
+
+    if (gcry_err_code(ctxerror) != GPG_ERR_NO_ERROR) {
+        goto dhx2_fail;
+    }
+
+    /* Send the FPLoginCont with the new authinfo block, sit back,
+     * cross fingers... */
+    ret = afptest_uam_login_cont(server, ID, ai, ai_len, NULL);
+    goto dhx2_cleanup;
+dhx2_noctx_fail:
+    ret = -1;
+    goto dhx2_noctx_cleanup;
+dhx2_fail:
+    ret = -1;
+dhx2_cleanup:
+    gcry_cipher_close(ctx);
+dhx2_noctx_cleanup:
+    gcry_mpi_release(p);
+    gcry_mpi_release(g);
+    gcry_mpi_release(Ra);
+    gcry_mpi_release(Ma);
+    gcry_mpi_release(Mb);
+    gcry_mpi_release(K);
+    gcry_mpi_release(nonce);
+    gcry_mpi_release(new_nonce);
+    free(Ra_binary);
+    free(K_binary);
+    free(K_hash);
+    free(ai);
+    free(rbuf.data);
+    return ret;
+}
+
+int afptest_uam_uses_legacy_login(const char *uam)
+{
+    return uam && (strcasecmp(uam, "clrtxt") == 0 ||
+                   strcasecmp(uam, "Cleartxt Passwrd") == 0);
+}
+
+unsigned int afptest_uam_login(CONN *conn, const char *vers,
+                               const char *uam, const char *username,
+                               const char *password)
+{
+    struct afptest_uam_server server = { .conn = conn, .vers = vers };
+    const struct passwd *entry;
+    int result;
+
+    if (!conn || !vers || !uam) {
+        return htonl((uint32_t)AFPERR_PARAM);
+    }
+
+    if (!username) {
+        entry = getpwuid(getuid());
+
+        if (!entry) {
+            return htonl((uint32_t)AFPERR_PARAM);
+        }
+
+        username = entry->pw_name;
+    }
+
+    if (!password) {
+        password = "";
+    }
+
+    if (strcasecmp(uam, "dhx") == 0 || strcasecmp(uam, "DHCAST128") == 0) {
+        result = dhx_login(&server, username, password);
+    } else if (strcasecmp(uam, "dhx2") == 0 || strcasecmp(uam, "DHX2") == 0) {
+        result = dhx2_login(&server, username, password);
+    } else {
+        return htonl((uint32_t)AFPERR_BADUAM);
+    }
+
+    return htonl((uint32_t)result);
+}

--- a/test/testsuite/afptest_uam.h
+++ b/test/testsuite/afptest_uam.h
@@ -1,0 +1,15 @@
+#ifndef AFPTEST_UAM_H
+#define AFPTEST_UAM_H
+
+#include <stdint.h>
+
+typedef struct CONN CONN;
+
+/* `-A clrtxt` or `-A "Cleartxt Passwrd"` selects each runner's legacy login path. */
+int afptest_uam_uses_legacy_login(const char *uam);
+
+unsigned int afptest_uam_login(CONN *conn, const char *vers,
+                               const char *uam, const char *username,
+                               const char *password);
+
+#endif

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -40,6 +40,7 @@
 
 /* Netatalk library includes */
 #include "afpclient.h"
+#include "afptest_uam.h"
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
@@ -2007,8 +2008,10 @@ fin1:
 void usage(char *av0)
 {
     fprintf(stdout,
-            "usage:\t%s [-34567bcGgKVv] [-h host] [-p port] [-s vol] [-u user] [-w password] "
+            "usage:\t%s [-34567bcGgKVv] [-A uam] [-h host] [-p port] [-s vol] [-u user] [-w password] "
             "[-n iterations] [-f tests] [-F bigfile]\n", av0);
+    fprintf(stdout,
+            "\t-A\tafptest UAM name or alias (ClearTxt: clrtxt; DHCAST128: dhx; DHX2: dhx2)\n");
     fprintf(stdout, "\t-h\tserver host name (default localhost)\n");
     fprintf(stdout, "\t-p\tserver port (default 548)\n");
     fprintf(stdout, "\t-s\tvolume to mount\n");
@@ -2057,12 +2060,13 @@ int main(int32_t ac, char **av)
     int32_t cc, t;
     static char *vers = "AFP3.4";
     static char *uam = "Cleartxt Passwrd";
+    const char *afptest_uam = NULL;
 
     if (ac == 1) {
         usage(av[0]);
     }
 
-    while ((cc = getopt(ac, av, "34567bcGgKVvF:f:h:n:p:s:u:w:")) != EOF) {
+    while ((cc = getopt(ac, av, "34567A:bcGgKVvF:f:h:n:p:s:u:w:")) != EOF) {
         switch (cc) {
         case '3':
             vers = "AFPX03";
@@ -2087,6 +2091,10 @@ int main(int32_t ac, char **av)
         case '7':
             vers = "AFP3.4";
             Version = 34;
+            break;
+
+        case 'A':
+            afptest_uam = afptest_uam_uses_legacy_login(optarg) ? NULL : optarg;
             break;
 
         case 'b':
@@ -2341,7 +2349,11 @@ int main(int32_t ac, char **av)
     Conn->afp_version = Version;
 
     /* Login to AFP server */
-    if (Version >= 30) {
+    if (afptest_uam) {
+        ExitCode = ntohs((uint16_t)afptest_uam_login(Conn, vers,
+                         afptest_uam, User,
+                         Password));
+    } else if (Version >= 30) {
         ExitCode = ntohs((uint16_t)FPopenLoginExt(Conn, vers, uam, User, Password));
     } else {
         ExitCode = ntohs((uint16_t)FPopenLogin(Conn, vers, uam, User, Password));

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -24,6 +24,11 @@ libafptest_extra = []
 libafptest_deps = []
 spectest_extra_c_args = []
 
+# afptest implements the DHCAST128 and DHX2 exchanges itself. The separate
+# afp_logintest UAM matrix continues to use libafpclient when it is available.
+libafptest_extra += ['afptest_uam.c']
+libafptest_deps += libgcrypt
+
 if have_spotlight
     libafptest_extra += [
         'afpcmd_spotlight.c',

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -2,6 +2,7 @@
 #include <getopt.h>
 
 #include "afpclient.h"
+#include "afptest_uam.h"
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
@@ -239,40 +240,15 @@ static void list_tests(void)
 /* ----------- */
 static void run_one(char *name)
 {
-    int i = 0;
     void *handle = NULL;
     void (*fn)(void) = NULL;
     char *error;
     char *token;
     token = strtok(name, ",");
 
-    while (Test_list[i].name != NULL) {
-        if (!strcmp(Test_list[i].name, name)) {
-            break;
-        }
-
-        i++;
-    }
-
-    if (Test_list[i].name == NULL) {
-        handle = dlopen(NULL, RTLD_NOW);
-
-        if (handle) {
-            fn = dlsym(handle, token);
-
-            if ((error = dlerror()) != NULL)  {
-                fprintf(stdout, "%s (%p)\n", error, fn);
-            }
-        } else {
-            fprintf(stdout, "%s\n", dlerror());
-        }
-
-        if (!handle || !fn) {
-            test_nottested();
-            return;
-        }
-    } else {
-        fn = Test_list[i].fn;
+    if (!token) {
+        test_nottested();
+        return;
     }
 
     dsi = &Conn->dsi;
@@ -285,17 +261,44 @@ static void run_one(char *name)
     }
 
     while (token) {
-        press_enter(token);
-        (*fn)();
-        token = strtok(NULL, ",");
+        int i = 0;
 
-        if (token && handle) {
-            fn = dlsym(handle, token);
+        /* Resolve every token: comma-separated built-in testsets may differ. */
+        while (Test_list[i].name != NULL && strcmp(Test_list[i].name, token)) {
+            i++;
+        }
 
-            if ((error = dlerror()) != NULL)  {
-                fprintf(stdout, "%s\n", error);
+        if (Test_list[i].name != NULL) {
+            fn = Test_list[i].fn;
+        } else {
+            if (!handle) {
+                handle = dlopen(NULL, RTLD_NOW);
+
+                if (!handle) {
+                    fprintf(stdout, "%s\n", dlerror());
+                }
+            }
+
+            fn = NULL;
+
+            if (handle) {
+                dlerror();
+                fn = dlsym(handle, token);
+
+                if ((error = dlerror()) != NULL)  {
+                    fprintf(stdout, "%s (%p)\n", error, fn);
+                }
             }
         }
+
+        if (!fn) {
+            test_nottested();
+        } else {
+            press_enter(token);
+            (*fn)();
+        }
+
+        token = strtok(NULL, ",");
     }
 
     if (handle) {
@@ -350,13 +353,17 @@ enum ad_format adouble = AD_EA;
 
 char *vers = "AFP3.4";
 char *uam = "Cleartxt Passwrd";
+/* Also used by tests that create or reconnect their own AFP sessions. */
+const char *afptest_uam;
 
 /* =============================== */
 void usage(char *av0)
 {
     fprintf(stdout,
-            "usage:\t%s [-1234567aCEiLlmVv] [-h host] [-H host2] [-p port] [-s vol] [-c vol path] [-S vol2] "
+            "usage:\t%s [-1234567aCEiLlmVv] [-A uam] [-h host] [-H host2] [-p port] [-s vol] [-c vol path] [-S vol2] "
             "[-u user] [-d user2] [-w password] [-F testsuite] [-f test]\n", av0);
+    fprintf(stdout,
+            "\t-A\tafptest UAM name or alias (ClearTxt: clrtxt; DHCAST128: dhx; DHX2: dhx2)\n");
     fprintf(stdout, "\t-a\tvolume is using AppleDouble metadata and not EA\n");
     fprintf(stdout, "\t-m\tserver is a Mac\n");
     fprintf(stdout, "\t-h\tserver host name (default localhost)\n");
@@ -399,7 +406,7 @@ int main(int ac, char **av)
         usage(av[0]);
     }
 
-    while ((cc = getopt(ac, av, "1234567aCEiLlmVvc:d:f:H:h:p:S:s:u:w:")) != EOF) {
+    while ((cc = getopt(ac, av, "1234567aCEiLlmVvA:c:d:f:H:h:p:S:s:u:w:")) != EOF) {
         switch (cc) {
         case '1':
             vers = "AFPVersion 2.1";
@@ -434,6 +441,10 @@ int main(int ac, char **av)
         case '7':
             vers = "AFP3.4";
             Version = 34;
+            break;
+
+        case 'A':
+            afptest_uam = afptest_uam_uses_legacy_login(optarg) ? NULL : optarg;
             break;
 
         case 'a':
@@ -568,7 +579,9 @@ int main(int ac, char **av)
 
     Dsi->socket = sock;
 
-    if (Version >= 30) {
+    if (afptest_uam) {
+        ret = afptest_uam_login(Conn, vers, afptest_uam, User, Password);
+    } else if (Version >= 30) {
         ret = FPopenLoginExt(Conn, vers, uam, User, Password);
     } else {
         ret = FPopenLogin(Conn, vers, uam, User, Password);
@@ -602,7 +615,10 @@ int main(int ac, char **av)
 
         Dsi2->socket = sock2;
 
-        if (Version >= 30) {
+        if (afptest_uam) {
+            ret = afptest_uam_login(Conn2, vers, afptest_uam, User2,
+                                    Password);
+        } else if (Version >= 30) {
             ret = FPopenLoginExt(Conn2, vers, uam, User2, Password);
         } else {
             ret = FPopenLogin(Conn2, vers, uam, User2, Password);

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -33,6 +33,7 @@
 #include <sys/socket.h>
 
 #include "afpclient.h"
+#include "afptest_uam.h"
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
@@ -1815,9 +1816,11 @@ static void run_one(char *name)
 void usage(char *av0)
 {
     fprintf(stdout,
-            "usage:\t%s [-1234567acDeiLTVvy] [-h host] [-p port] [-s vol] [-P path] [-S vol2] [-u user] [-w password] [-n iterations] [-W warmup] "
+            "usage:\t%s [-1234567acDeiLTVvy] [-A uam] [-h host] [-p port] [-s vol] [-P path] [-S vol2] [-u user] [-w password] [-n iterations] [-W warmup] "
             "[-t delay] [-d size] [-z sizes] [-q quantum] [-r requests] [-f test] [-F file] \n",
             av0);
+    fprintf(stdout,
+            "\t-A\tafptest UAM name or alias (ClearTxt: clrtxt; DHCAST128: dhx; DHX2: dhx2)\n");
     fprintf(stdout, "\t-h\tserver host name (default localhost)\n");
     fprintf(stdout, "\t-p\tserver port (default 548)\n");
     fprintf(stdout, "\t-s\tvolume/share to mount (AFP mode)\n");
@@ -1868,13 +1871,14 @@ void usage(char *av0)
 int main(int ac, char **av)
 {
     int cc;
+    const char *afptest_uam = NULL;
 
     if (ac == 1) {
         usage(av[0]);
     }
 
     while ((cc = getopt(ac, av,
-                        "1234567aceDiLTVvyd:F:f:h:n:p:P:q:r:S:s:t:u:w:W:z:")) != EOF) {
+                        "1234567A:aceDiLTVvyd:F:f:h:n:p:P:q:r:S:s:t:u:w:W:z:")) != EOF) {
         switch (cc) {
         case '1':
             vers = "AFPVersion 2.1";
@@ -1909,6 +1913,10 @@ int main(int ac, char **av)
         case '7':
             vers = "AFP3.4";
             Version = 34;
+            break;
+
+        case 'A':
+            afptest_uam = afptest_uam_uses_legacy_login(optarg) ? NULL : optarg;
             break;
 
         case 'a':
@@ -2212,7 +2220,12 @@ int main(int ac, char **av)
         Dsi->socket = sock;
 
         /* login */
-        if (Version >= 30) {
+        if (afptest_uam) {
+            if (afptest_uam_login(Conn, vers, afptest_uam, User, Password)) {
+                fprintf(stderr, "Login failed\n");
+                return 1;
+            }
+        } else if (Version >= 30) {
             FPopenLoginExt(Conn, vers, uam, User, Password);
         } else {
             FPopenLogin(Conn, vers, uam, User, Password);

--- a/test/testsuite/testhelper.c
+++ b/test/testsuite/testhelper.c
@@ -42,10 +42,6 @@ void test_skipped(int why)
         s = "AFP 3.x";
         break;
 
-    case T_AFP3_CONN2:
-        s = "AFP 3.x and no second user";
-        break;
-
     case T_AFP30:
         s = "AFP 3.0 only";
         break;

--- a/test/testsuite/testhelper.h
+++ b/test/testsuite/testhelper.h
@@ -32,8 +32,8 @@
 #define T_CONN2      1
 #define T_PATH       2
 #define T_AFP3       3
-#define T_AFP3_CONN2 4
 #if 0
+#define T_AFP3_CONN2 4
 #define T_MAC_PATH   5
 #endif
 #define T_UNIX_PREV  6


### PR DESCRIPTION
Implement the DHCAST128 and DHX2 login exchanges in libafptest and expose them through the test runner -A option. This allows testing against secured AFP servers including Mac OS X personal file sharing where ClearTxt UAM is not available.

The insecure and legacy ClearTxt auth can be selected with `-A clrtxt` which is also the default fallback when no UAM is given.

Refactor the testsuite container entrypoint to allow for subtest execution, notably for the spectest, controlled by AFP_SUBTESTS container runtime option. Rework the entry point for the Readonly and Speedtest test suite using this structure, while also adding the FPZzzzz (sleep) test suite to CI.

Introduces a VERY_VERBOSE container runtime option for the testsuite which passes -V to the test runner for testsuite debug logging.

Fix a bug in the spectest code that failed to tokenize comma separated subtests passed to the test runner with the -f parameter.