### PR TITLE
consistently render the AFP sleep command as FPZzzzz

### DIFF
--- a/doc/manpages/man1/afp_spectest.1.md
+++ b/doc/manpages/man1/afp_spectest.1.md
@@ -125,12 +125,12 @@ the lines for the mappings that you want to enable in this configuration file.
 
 ## Sleep tests
 
-The *FPzzz* testset contain tests for AFP sleep mode and timeouts.
+The *FPZzzzz* testset contain tests for AFP sleep mode and timeouts.
 Since they by necessity take much longer than other tests,
 they are not included when you execute the full spectest suite.
 Rather, you must run the testset separately using the *-f* parameter:
 
-    afp_spectest -f FPzzz
+    afp_spectest -f FPZzzzz
 
 ## Readonly tests
 

--- a/doc/po/afp_spectest.1.md.ja.po
+++ b/doc/po/afp_spectest.1.md.ja.po
@@ -528,12 +528,12 @@ msgstr "スリープテスト"
 #. type: Plain text
 #: manpages/man1/afp_spectest.1.md:128
 msgid ""
-"The *FPzzz* testset contain tests for AFP sleep mode and timeouts.  Since "
+"The *FPZzzzz* testset contain tests for AFP sleep mode and timeouts.  Since "
 "they by necessity take much longer than other tests, they are not included "
 "when you execute the full spectest suite.  Rather, you must run the testset "
 "separately using the *-f* parameter:"
 msgstr ""
-"*FPzzz* テストセットは、AFP スリープモードとタイムアウトを検証するテスト項目"
+"*FPZzzzz* テストセットは、AFP スリープモードとタイムアウトを検証するテスト項目"
 "になっている。これらのテストは必然的に実行に時間がかかるため、spectest スイー"
 "トの実行時にはデフォルトでは実行されない。実行するには *-f* パラメータを使用"
 "する必要がある。"
@@ -541,7 +541,7 @@ msgstr ""
 #. type: Plain text
 #: manpages/man1/afp_spectest.1.md:130
 #, no-wrap
-msgid "    afp_spectest -f FPzzz\n"
+msgid "    afp_spectest -f FPZzzzz\n"
 msgstr ""
 
 #. type: Title ##

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -289,9 +289,9 @@ static int set_auth_switch(const AFPObj *obj, int expired)
         case 22:
             /*
              * If first connection to a server is done in classic AFP2.2 version is used
-             * but OSX uses AFP3.x FPzzz command !
+             * but OSX uses AFP3.x FPZzzzz command !
              */
-            uam_afpserver_action(AFP_ZZZ,  UAM_AFPSERVER_POSTAUTH, afp_zzz, NULL);
+            uam_afpserver_action(AFP_ZZZZZ,  UAM_AFPSERVER_POSTAUTH, afp_zzzzz, NULL);
             break;
         }
     } else {
@@ -412,8 +412,8 @@ static int login(AFPObj *obj, struct passwd *pwd, void (*logout)(void),
 }
 
 /* ---------------------- */
-int afp_zzz(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,
-            size_t *rbuflen)
+int afp_zzzzz(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,
+              size_t *rbuflen)
 {
     uint32_t data;
     DSI *dsi = (DSI *)AFPobj->dsi;
@@ -437,7 +437,7 @@ int afp_zzz(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,
     if (data & AFPZZZ_EXT_WAKEUP) {
         /* wakeup request from exetended sleep */
         if (dsi->flags & DSI_EXTSLEEP) {
-            LOG(log_note, logtype_afpd, "afp_zzz: waking up from extended sleep");
+            LOG(log_note, logtype_afpd, "afp_zzzzz: waking up from extended sleep");
             dsi->flags &= ~(DSI_SLEEPING | DSI_EXTSLEEP);
             ipc_child_state(obj, DSI_RUNNING);
         }
@@ -446,11 +446,11 @@ int afp_zzz(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,
         dsi->flags |= DSI_SLEEPING;
 
         if (data & AFPZZZ_EXT_SLEEP) {
-            LOG(log_note, logtype_afpd, "afp_zzz: entering extended sleep");
+            LOG(log_note, logtype_afpd, "afp_zzzzz: entering extended sleep");
             dsi->flags |= DSI_EXTSLEEP;
             ipc_child_state(obj, DSI_EXTSLEEP);
         } else {
-            LOG(log_note, logtype_afpd, "afp_zzz: entering normal sleep");
+            LOG(log_note, logtype_afpd, "afp_zzzzz: entering normal sleep");
             ipc_child_state(obj, DSI_SLEEPING);
         }
     }

--- a/etc/afpd/auth.h
+++ b/etc/afpd/auth.h
@@ -56,7 +56,7 @@ int afp_getsession(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,
                    size_t *rbuflen);
 int afp_disconnect(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,
                    size_t *rbuflen);
-int afp_zzz(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,
-            size_t *rbuflen);
+int afp_zzzzz(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,
+              size_t *rbuflen);
 
 #endif /* auth.h */

--- a/include/atalk/afp.h
+++ b/include/atalk/afp.h
@@ -198,7 +198,7 @@ typedef enum {
 #define AFP_SPOTLIGHT_PRIVATE   76
 #define AFP_SYNCDIR             78
 #define AFP_SYNCFORK            79
-#define AFP_ZZZ                 122
+#define AFP_ZZZZZ               122
 
 /* version 3.2 */
 #define AFP_GETEXTATTR          69

--- a/include/atalk/dsi.h
+++ b/include/atalk/dsi.h
@@ -152,8 +152,8 @@ typedef struct DSI {
 /* DSI session State flags */
 #define DSI_DATA             (1 << 0) /*!< we have received a DSI command */
 #define DSI_RUNNING          (1 << 1) /*!< we have received a AFP command */
-#define DSI_SLEEPING         (1 << 2) /*!< we're sleeping after FPZzz */
-#define DSI_EXTSLEEP         (1 << 3) /*!< we're sleeping after FPZzz */
+#define DSI_SLEEPING         (1 << 2) /*!< we're sleeping after FPZzzzz */
+#define DSI_EXTSLEEP         (1 << 3) /*!< we're sleeping after FPZzzzz */
 #define DSI_DISCONNECTED     (1 << 4) /*!< we're in diconnected state after a socket error */
 #define DSI_DIE              (1 << 5) /*!< SIGUSR1, going down in 5 minutes */
 #define DSI_NOREPLY          (1 << 6) /*!< in dsi_write we generate our own replies */

--- a/libatalk/util/afp_util.c
+++ b/libatalk/util/afp_util.c
@@ -200,8 +200,8 @@ const char *AfpNum2name(int num)
     case AFP_ENUMERATE_EXT2:
         return "AFP_ENUMERATE_EXT2";   /*  68 */
 
-    case AFP_ZZZ  :
-        return "AFP_ZZZ";	    /* 122 */
+    case AFP_ZZZZZ  :
+        return "AFP_ZZZZZ"      ;      /* 122 */
 
     /* version 3.2 */
     case AFP_GETEXTATTR         :

--- a/test/testsuite/FPGetSessionToken.c
+++ b/test/testsuite/FPGetSessionToken.c
@@ -103,7 +103,7 @@ STATIC void test221()
     }
 
     FAIL(FPGetSessionToken(Conn, 3, 0, 5, "token"))
-    FAIL(FPzzz(Conn, 0))
+    FAIL(FPZzzzz(Conn, 0))
 test_exit:
     exit_test("FPGetSessionToken:test221: AFP 3.1 get session token");
 }

--- a/test/testsuite/FPZzzzz.c
+++ b/test/testsuite/FPZzzzz.c
@@ -12,8 +12,9 @@ extern char *uam;
 
 static volatile int sigp = 0;
 
-static void pipe_handler()
+static void pipe_handler(int signum)
 {
+    (void)signum;
     sigp = 1;
 }
 
@@ -24,8 +25,6 @@ STATIC void test223()
     uint16_t vol = VolID;
     unsigned int ret;
     struct sigaction action;
-    DSI *dsi;
-    int sock;
     uint32_t time = 12345;
     ENTER_TEST
 
@@ -117,7 +116,6 @@ STATIC void test224()
     uint16_t vol = VolID;
     unsigned int ret;
     struct sigaction action;
-    int sock;
     uint32_t time = 12345;
     ENTER_TEST
 
@@ -206,10 +204,7 @@ STATIC void test239()
 {
     char *name = "t239 file";
     uint16_t vol = VolID;
-    unsigned int ret;
     struct sigaction action;
-    DSI *dsi;
-    int sock;
     ENTER_TEST
 
     if (!Test) {
@@ -241,7 +236,6 @@ STATIC void test239()
     FAIL(FPZzzzz(Conn, 2))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
-fin:
     action.sa_handler = SIG_DFL;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;

--- a/test/testsuite/FPZzzzz.c
+++ b/test/testsuite/FPZzzzz.c
@@ -31,7 +31,7 @@ STATIC void test223()
 
     if (!Test) {
         if (!Quiet) {
-            fprintf(stdout, "Run sleep tests with: -f FPzzz_test.\n");
+            fprintf(stdout, "Run sleep tests with: -f FPZzzzz.\n");
         }
 
         test_skipped(T_SINGLE);
@@ -54,7 +54,7 @@ STATIC void test223()
 
     /* Get session token */
     FAIL(FPGetSessionToken(Conn, 3, time, strlen("test223"), "test223"))
-    FAIL(FPzzz(Conn, 0))
+    FAIL(FPZzzzz(Conn, 0))
     fprintf(stdout, "sleep more than 2 mn\n");
     sleep(60 * 3);
     ret = FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name);
@@ -107,7 +107,7 @@ fin:
     }
 
 test_exit:
-    exit_test("FPzzz:test223: AFP 3.x enter sleep mode");
+    exit_test("FPZzzzz:test223: AFP 3.x enter sleep mode");
 }
 
 /* ------------------------- */
@@ -123,7 +123,7 @@ STATIC void test224()
 
     if (!Test) {
         if (!Quiet) {
-            fprintf(stdout, "Run sleep tests with: -f FPzzz_test.\n");
+            fprintf(stdout, "Run sleep tests with: -f FPZzzzz.\n");
         }
 
         test_skipped(T_SINGLE);
@@ -198,7 +198,7 @@ fin:
     }
 
 test_exit:
-    exit_test("FPzzz:test224: disconnected after 2 mn");
+    exit_test("FPZzzzz:test224: disconnected after 2 mn");
 }
 
 /* ------------------------- */
@@ -214,7 +214,7 @@ STATIC void test239()
 
     if (!Test) {
         if (!Quiet) {
-            fprintf(stdout, "Run sleep tests with: -f FPzzz_test.\n");
+            fprintf(stdout, "Run sleep tests with: -f FPZzzzz.\n");
         }
 
         test_skipped(T_SINGLE);
@@ -235,10 +235,10 @@ STATIC void test239()
         goto test_exit;
     }
 
-    FAIL(FPzzz(Conn, 1))
+    FAIL(FPZzzzz(Conn, 1))
     fprintf(stdout, "sleep more than 2 mn\n");
     sleep(60 * 3);
-    FAIL(FPzzz(Conn, 2))
+    FAIL(FPZzzzz(Conn, 2))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 fin:
@@ -251,11 +251,11 @@ fin:
     }
 
 test_exit:
-    exit_test("FPzzz:test239: AFP 3.x enter extended sleep");
+    exit_test("FPZzzzz:test239: AFP 3.x enter extended sleep");
 }
 
 /* ----------- */
-void FPzzz_test()
+void FPZzzzz_test()
 {
     ENTER_TESTSET
     test223();

--- a/test/testsuite/afpclient.c
+++ b/test/testsuite/afpclient.c
@@ -819,14 +819,14 @@ unsigned int AFPLogOut(CONN *conn)
 }
 
 /* ------------------------------- */
-unsigned int AFPzzz(CONN *conn, int flag)
+unsigned int AFPZzzzz(CONN *conn, int flag)
 {
     int 		ofs = 0;
     DSI			*dsi = &conn->dsi;
     uint32_t   temp;
     assert(conn);
     SendInit(dsi);
-    dsi->commands[ofs++] = AFP_ZZZ;
+    dsi->commands[ofs++] = AFP_ZZZZZ;
     dsi->commands[ofs++] = 0;
     temp = flag;
     temp = htonl(temp);

--- a/test/testsuite/afpclient.h
+++ b/test/testsuite/afpclient.h
@@ -291,7 +291,7 @@ unsigned int AFPLogOut(CONN *conn);
 unsigned int AFPChangePW(CONN *conn, char *uam, char *usr, char *opwd,
                          char *pwd);
 
-unsigned int AFPzzz(CONN *conn, int);
+unsigned int AFPZzzzz(CONN *conn, int);
 
 unsigned int AFPGetSrvrInfo(CONN *conn);
 unsigned int AFPGetSrvrParms(CONN *conn);

--- a/test/testsuite/afpcmd.c
+++ b/test/testsuite/afpcmd.c
@@ -459,8 +459,8 @@ const char *AfpNum2name(int num)
     case AFP_ENUMERATE_EXT2:
         return "AFP_ENUMERATE_EXT2";   /*  68 */
 
-    case AFP_ZZZ           :
-        return "AFP_ZZZ           ";	/* 122 */
+    case AFP_ZZZZZ         :
+        return "AFP_ZZZZZ         ";   /* 122 */
 
     /* version 3.2 */
     case AFP_GETACL        :
@@ -643,17 +643,17 @@ unsigned int FPLogOut(CONN *conn)
 }
 
 /* ------------------------------- */
-unsigned int FPzzz(CONN *conn, int flag)
+unsigned int FPZzzzz(CONN *conn, int flag)
 {
     unsigned int ret;
     DSI *dsi;
     dsi = &conn->dsi;
 
     if (!Quiet) {
-        fprintf(stdout, "[%s] FPzzz enter sleep mode (flag: %i)\n", __func__, flag);
+        fprintf(stdout, "[%s] FPZzzzz enter sleep mode (flag: %i)\n", __func__, flag);
     }
 
-    ret = AFPzzz(conn, flag);
+    ret = AFPZzzzz(conn, flag);
     dump_header(dsi);
     return ret;
 }

--- a/test/testsuite/afpcmd.h
+++ b/test/testsuite/afpcmd.h
@@ -29,7 +29,7 @@ extern unsigned int FPopenLogin(CONN *conn, char *vers, char *uam, char *usr,
                                 char *pwd);
 extern unsigned int FPopenLoginExt(CONN *conn, char *vers, char *uam, char *usr,
                                    char *pwd);
-extern unsigned int FPzzz(CONN *conn, int);
+extern unsigned int FPZzzzz(CONN *conn, int);
 extern unsigned int FPLogOut(CONN *conn);
 extern unsigned int FPMapID(CONN *conn, char fn, int id);
 extern unsigned int FPMapName(CONN *conn, char fn, char *name);

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -199,7 +199,7 @@ spectest_sources = [
     'FPSync.c',
     'FPWrite.c',
     'FPWriteExt.c',
-    'FPzzz.c',
+    'FPZzzzz.c',
     'T2_Dircache_attack.c',
     'T2_FPByteRangeLock.c',
     'T2_FPCopyFile.c',

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -86,7 +86,7 @@ EXT_FN(FPSetVolParms);
 EXT_FN(FPSync);
 EXT_FN(FPWrite);
 EXT_FN(FPWriteExt);
-EXT_FN(FPzzz);
+EXT_FN(FPZzzzz);
 
 EXT_FN(T2FPByteRangeLock);
 EXT_FN(T2FPCopyFile);
@@ -179,7 +179,7 @@ static struct test_fn Test_list[] = {
     FN_N(FPSync)
     FN_N(FPWrite)
     FN_N(FPWriteExt)
-    FN_N(FPzzz)
+    FN_N(FPZzzzz)
 
     FN_N(T2FPByteRangeLock)
     FN_N(T2FPCreateFile)


### PR DESCRIPTION
the AFP 3.4 reference document refers to the sleep command as FPZzzzz with five z's, the first one capitalized

clean up dead code and minor bugs in FPZzzzz test code flagged when the file was renamed