### PR TITLE
testsuite: introduce Junit XML test reporting for spectest

### DIFF
--- a/.github/scripts/vm_spectest.sh
+++ b/.github/scripts/vm_spectest.sh
@@ -62,6 +62,8 @@ echo "==== Running AFP spec test (AFP 3.4) ===="
 set +e
 # TEST_FLAGS holds multiple flags (e.g. "-c /path" or "-a"); must split.
 # shellcheck disable=SC2086
+JUNIT_REPORT_PATH="$PWD/afp-spectest.junit.xml"
+rm -f "$JUNIT_REPORT_PATH"
 afp_spectest $TEST_FLAGS \
     -"$AFP_VERSION" \
     -h "$AFP_HOST" \
@@ -70,8 +72,12 @@ afp_spectest $TEST_FLAGS \
     -d "$AFP_USER2" \
     -w "$AFP_PASS" \
     -s "$SHARE_NAME" \
-    -S "$SHARE_NAME2"
+    -S "$SHARE_NAME2" \
+    -j "$JUNIT_REPORT_PATH"
 SPECTEST_RC=$?
+if [ -f "$JUNIT_REPORT_PATH" ]; then
+    chmod 0644 "$JUNIT_REPORT_PATH"
+fi
 set -e
 
 echo "==== afpd.log (tail) ===="

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,12 @@ jobs:
         run: meson compile -C build
       - name: Test
         run: meson test -C build
+      - name: Summarize test results
+        if: always()
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
+        with:
+          paths: build/meson-logs/testlog.junit.xml
+          folded: true
       - name: Run memory profiling
         run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
@@ -184,6 +190,12 @@ jobs:
         run: meson compile -C build
       - name: Test
         run: meson test -C build
+      - name: Summarize test results
+        if: always()
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
+        with:
+          paths: build/meson-logs/testlog.junit.xml
+          folded: true
       - name: Install
         run: meson install -C build
       - name: Check netatalk capabilities
@@ -281,6 +293,12 @@ jobs:
         run: meson compile -C build
       - name: Test
         run: meson test -C build
+      - name: Summarize test results
+        if: always()
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
+        with:
+          paths: build/meson-logs/testlog.junit.xml
+          folded: true
       - name: Run memory profiling
         run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
@@ -372,6 +390,12 @@ jobs:
         run: meson compile -C build
       - name: Test
         run: meson test -C build
+      - name: Summarize test results
+        if: always()
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
+        with:
+          paths: build/meson-logs/testlog.junit.xml
+          folded: true
       - name: Run memory profiling
         run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
@@ -467,6 +491,12 @@ jobs:
         run: meson compile -C build
       - name: Test
         run: meson test -C build
+      - name: Summarize test results
+        if: always()
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
+        with:
+          paths: build/meson-logs/testlog.junit.xml
+          folded: true
       - name: Install
         run: meson install -C build
       - name: Check netatalk capabilities
@@ -549,6 +579,12 @@ jobs:
         run: file build/etc/afpd/afpd | grep -q 'ELF 32-bit'
       - name: Test
         run: meson test -C build
+      - name: Summarize test results
+        if: always()
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
+        with:
+          paths: build/meson-logs/testlog.junit.xml
+          folded: true
       - name: Install
         run: meson install -C build
       - name: Check netatalk capabilities

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -186,6 +186,23 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: type=raw,value=${{ github.sha }}
       - name: Build and push container image
+        id: build-and-push
+        continue-on-error: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: distrib/docker/testsuite_deb.Dockerfile
+          push: true
+          build-args: |
+            EXTRA_MESON_ARGS=-Db_sanitize=thread
+            EXTRA_RUN_DEPS=libtsan2
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
+      - name: Wait before retrying container image push
+        if: ${{ steps.build-and-push.outcome == 'failure' }}
+        run: sleep 10
+      - name: Retry container image push
+        if: ${{ steps.build-and-push.outcome == 'failure' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -203,6 +220,9 @@ jobs:
     timeout-minutes: 60
     needs: build-container-tsan
     if: ${{ !github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Lower ASLR entropy for TSAN shadow-memory compatibility
         run: sudo sysctl vm.mmap_rnd_bits=28
@@ -218,6 +238,8 @@ jobs:
               -e SHARE_NAME=test1 -e SHARE_NAME2=test2 \
               -e INSECURE_AUTH=1 -e DISABLE_TIMEMACHINE=1 \
               -e TESTSUITE=spec -e AFP_VERSION=7 \
+              -v "$RUNNER_TEMP:/reports" \
+              -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
               -e AFP_CNID_BACKEND=sqlite \
               -e TSAN_OPTIONS="halt_on_error=1 abort_on_error=1" \
               ${{ env.REGISTRY }}/${IMAGE_NAME}:${{ github.sha }}
@@ -232,6 +254,17 @@ jobs:
               -e AFP_CNID_BACKEND=sqlite \
               -e TSAN_OPTIONS="halt_on_error=1 abort_on_error=1" \
               ${{ env.REGISTRY }}/${IMAGE_NAME}:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   build-container-debug:
     name: Build debug profiling container
@@ -259,6 +292,20 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: type=raw,value=${{ github.sha }}
       - name: Build and push container image
+        id: build-and-push
+        continue-on-error: true
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: distrib/docker/debug_alp.Dockerfile
+          push: true
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
+      - name: Wait before retrying container image push
+        if: ${{ steps.build-and-push.outcome == 'failure' }}
+        run: sleep 10
+      - name: Retry container image push
+        if: ${{ steps.build-and-push.outcome == 'failure' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -275,6 +322,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: write
+      checks: write
     outputs:
       self_time: ${{ steps.flamegraph-summary.outputs.SELF_TIME }}
       self_time_warning: ${{ steps.flamegraph-summary.outputs.SELF_TIME_WARNING }}
@@ -307,6 +355,8 @@ jobs:
               -e AFP_CNID_BACKEND=sqlite \
               -e AFP_CNID_TMPFS=1 \
               -e TESTSUITE=spec \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
               -e AFP_VERSION=7 \
               -e FLAMEGRAPH=1 \
               ${{ env.REGISTRY }}/netatalk/netatalk-debug:${{ github.sha }} \
@@ -381,6 +431,17 @@ jobs:
           commit-prefix: flamegraph
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
+
   afp-spectest-dbd-afp34-prod:
     name: AFP spec test (cnid:dbd) AFP 3.4 - Alpine (Client/Server, PerfConfig)
     needs:
@@ -389,6 +450,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Create Docker network
         run: |
@@ -427,11 +491,24 @@ jobs:
               -e SHARE_NAME=test1 \
               -e SHARE_NAME2=test2 \
               -e TESTSUITE=spec \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
               -e VERBOSE=1 \
               -e AFP_VERSION=7 \
               -e AFP_REMOTE=1 \
               -e AFP_HOST=afp_server \
               ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-mysql-afp34-prod:
     name: AFP spec test (cnid:mysql) AFP 3.4 - Alpine (Client/Server/Database, PerfConfig)
@@ -441,6 +518,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Create container network
         run: |
@@ -491,6 +571,8 @@ jobs:
               -e SHARE_NAME=test1 \
               -e SHARE_NAME2=test2 \
               -e TESTSUITE=spec \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
               -e VERBOSE=1 \
               -e AFP_VERSION=7 \
               -e AFP_REMOTE=1 \
@@ -498,6 +580,17 @@ jobs:
               -e AFP_CNID_SQL_HOST=mariadb \
               -e AFP_CNID_SQL_PASS="$DB_PASSWD" \
               ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-sqlite-afp34-prod:
     name: AFP spec test (cnid:sqlite) AFP 3.4 - Alpine (Client/Server, PerfConfig)
@@ -507,6 +600,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Create Docker network
         run: |
@@ -546,11 +642,24 @@ jobs:
               -e SHARE_NAME=test1 \
               -e SHARE_NAME2=test2 \
               -e TESTSUITE=spec \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
               -e VERBOSE=1 \
               -e AFP_VERSION=7 \
               -e AFP_REMOTE=1 \
               -e AFP_HOST=afp_server \
               ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-mysql-afp34-debian:
     name: AFP spec test (cnid:mysql) AFP 3.4 - Debian
@@ -558,6 +667,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Create container network
         run: |
@@ -585,6 +697,8 @@ jobs:
               -e INSECURE_AUTH=1 \
               -e DISABLE_TIMEMACHINE=1 \
               -e TESTSUITE=spec \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
               -e VERBOSE=1 \
               -e AFP_VERSION=7 \
               -e AFP_REMOTE=1 \
@@ -596,12 +710,26 @@ jobs:
               -e AFP_CNID_SQL_PASS="$DB_PASSWD" \
               ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
+
   afp-spectest-sqlite-afp34-debian:
     name: AFP spec test (cnid:sqlite) AFP 3.4 - Debian
     needs: build-container-testsuite-debian
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -617,6 +745,8 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -624,12 +754,26 @@ jobs:
             -e AFP_CONVERT_APPLEDOUBLE=yes \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
+
   afp-spectest-afp34:
     name: AFP spec test (ea:sys) AFP 3.4 - Alpine
     needs: build-container-testsuite
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -644,11 +788,24 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   samba-interop:
     name: samba-client and netatalk-client interop (ea:samba) - Debian
@@ -680,6 +837,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -694,6 +854,8 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -701,12 +863,26 @@ jobs:
             -e AFP_STRICT_LOCKING="yes" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
+
   afp-spectest-sqlite-afp34:
     name: AFP spec test (cnid:sqlite) AFP 3.4 - Alpine
     needs: build-container-testsuite
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -722,11 +898,24 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-afp34-debian:
     name: AFP spec test (ea:sys) AFP 3.4 - Debian
@@ -734,6 +923,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -748,11 +940,24 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-adtest-afp34:
     name: AFP spec test (ea:ad) AFP 3.4 - Alpine
@@ -760,6 +965,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -776,6 +984,8 @@ jobs:
             -e DISABLE_TIMEMACHINE="1" \
             -e AFP_ADOUBLE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -784,12 +994,26 @@ jobs:
             -e AFP_DIRCACHE_RFORK_MAXSIZE="5120" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
+
   afp-adtest-afp34-debian:
     name: AFP spec test (ea:ad) AFP 3.4 - Debian
     needs: build-container-testsuite-debian
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -806,11 +1030,24 @@ jobs:
             -e DISABLE_TIMEMACHINE="1" \
             -e AFP_ADOUBLE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-afp33:
     name: AFP spec test (ea:sys) AFP 3.3 - Alpine
@@ -818,6 +1055,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -832,6 +1072,8 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="6" \
             -e AFP_EXTMAP="1" \
@@ -839,12 +1081,26 @@ jobs:
             -e AFP_CONVERT_APPLEDOUBLE=yes \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
+
   afp-spectest-afp32:
     name: AFP spec test (ea:sys) AFP 3.2 - Alpine
     needs: build-container-testsuite
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -859,6 +1115,8 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="5" \
             -e AFP_EXTMAP="1" \
@@ -866,12 +1124,26 @@ jobs:
             -e AFP_CONVERT_APPLEDOUBLE=yes \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
+
   afp-spectest-afp31:
     name: AFP spec test (ea:sys) AFP 3.1 - Alpine
     needs: build-container-testsuite
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -886,11 +1158,24 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="4" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-afp30:
     name: AFP spec test (ea:sys) AFP 3.0 - Alpine
@@ -898,6 +1183,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -912,11 +1200,24 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="3" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-afp30-debian:
     name: AFP spec test (ea:sys) AFP 3.0 - Debian
@@ -924,6 +1225,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -938,11 +1242,24 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="3" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-dhx-afp30:
     name: AFP spec test (DHCAST128) AFP 3.0 - Alpine
@@ -950,6 +1267,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -964,12 +1284,25 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e AFP_TESTSUITE_UAM="dhx" \
             -e VERBOSE="1" \
             -e AFP_VERSION="3" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-dhx-afp34-debian:
     name: AFP spec test (DHCAST128) AFP 3.4 - Debian
@@ -977,6 +1310,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -991,12 +1327,25 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e AFP_TESTSUITE_UAM="dhx" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-dhx2-afp31:
     name: AFP spec test (DHX2) AFP 3.1 - Alpine
@@ -1004,6 +1353,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1018,6 +1370,8 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e AFP_TESTSUITE_UAM="dhx2" \
             -e VERBOSE="1" \
             -e AFP_VERSION="4" \
@@ -1025,12 +1379,26 @@ jobs:
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
+
   afp-spectest-dhx2-afp34-debian:
     name: AFP spec test (DHX2) AFP 3.4 - Debian
     needs: build-container-testsuite-debian
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1045,12 +1413,25 @@ jobs:
             -e SHARE_NAME2="test2" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e AFP_TESTSUITE_UAM="dhx2" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-afp22:
     name: AFP spec test (ea:sys) AFP 2.2 - Alpine
@@ -1058,6 +1439,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1072,11 +1456,24 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="2" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-afp21:
     name: AFP spec test (ea:sys) AFP 2.1 - Alpine
@@ -1084,6 +1481,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1098,11 +1498,24 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-spectest-afp21-debian:
     name: AFP spec test (ea:sys) AFP 2.1 - Debian
@@ -1110,6 +1523,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1124,11 +1540,24 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-adtest-afp21:
     name: AFP spec test (ea:ad) AFP 2.1 - Alpine
@@ -1136,6 +1565,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1152,11 +1584,24 @@ jobs:
             -e DISABLE_TIMEMACHINE="1" \
             -e AFP_ADOUBLE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-adtest-afp21-debian:
     name: AFP spec test (ea:ad) AFP 2.1 - Debian
@@ -1164,6 +1609,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1180,11 +1628,24 @@ jobs:
             -e DISABLE_TIMEMACHINE="1" \
             -e AFP_ADOUBLE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
             -e AFP_EXTMAP="1" \
             -e AFP_DIRCACHESIZE="1024" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-rotest-afp34:
     name: AFP spec test (readonly) AFP 3.4 - Alpine
@@ -1192,6 +1653,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1203,10 +1667,23 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e AFP_READONLY="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e AFP_SUBTESTS="Readonly" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-rotest-afp21:
     name: AFP spec test (readonly) AFP 2.1 - Alpine
@@ -1214,6 +1691,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1225,10 +1705,23 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e AFP_READONLY="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e AFP_SUBTESTS="Readonly" \
             -e VERBOSE="1" \
             -e AFP_VERSION="1" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-sleeptest-afp34:
     name: AFP spec test (sleep) AFP 3.4 - Alpine
@@ -1236,6 +1729,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1246,11 +1742,24 @@ jobs:
             -e SHARE_NAME="test1" \
             -e AFP_UAMS="uams_dhx2.so" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e AFP_SUBTESTS="FPZzzzz" \
             -e AFP_TESTSUITE_UAM="dhx2" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-sleeptest-afp30:
     name: AFP spec test (sleep) AFP 3.0 - Alpine
@@ -1258,6 +1767,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1268,11 +1780,24 @@ jobs:
             -e SHARE_NAME="test1" \
             -e AFP_UAMS="uams_dhx.so" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e AFP_SUBTESTS="FPZzzzz" \
             -e AFP_TESTSUITE_UAM="dhx" \
             -e VERBOSE="1" \
             -e AFP_VERSION="3" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
   afp-logintest-afp34:
     name: AFP login test AFP 3.4 - Alpine
@@ -1939,6 +2464,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Run Netatalk testsuite with ARC stress test
         run: |
@@ -1953,6 +2481,8 @@ jobs:
             -e INSECURE_AUTH="1" \
             -e DISABLE_TIMEMACHINE="1" \
             -e TESTSUITE="spec" \
+            -v "$RUNNER_TEMP:/reports" \
+            -e AFP_JUNIT_REPORT_PATH=/reports/afp-spectest.junit.xml \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             -e AFP_EXTMAP="1" \
@@ -1962,3 +2492,13 @@ jobs:
             -e AFP_DIRCACHE_RFORK_BUDGET="102400" \
             -e AFP_DIRCACHE_RFORK_MAXSIZE="5120" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+      - name: Checkout repository for test report
+        if: ${{ !cancelled() }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit

--- a/.github/workflows/spectest-macos.yml
+++ b/.github/workflows/spectest-macos.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 env:
   AFP_USER: atalk1
@@ -220,6 +221,8 @@ jobs:
 
       - name: Run AFP spec test (AFP 3.4)
         run: |
+          REPORT_PATH="$RUNNER_TEMP/afp-spectest.junit.xml"
+          set +e
           sudo afp_spectest \
             -7 \
             -h localhost \
@@ -229,7 +232,19 @@ jobs:
             -w "$AFP_PASS" \
             -s test1 \
             -S test2 \
-            -c /private/tmp/afptest/test1
+            -c /private/tmp/afptest/test1 \
+            -j "$REPORT_PATH"
+          TEST_STATUS=$?
+          sudo chown "$(id -u):$(id -g)" "$REPORT_PATH"
+          exit "$TEST_STATUS"
+
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (macOS)
+          path: ${{ runner.temp }}/afp-spectest.junit.xml
+          reporter: java-junit
 
       - name: Show netatalk log after test
         if: always()

--- a/.github/workflows/spectest-vms.yml
+++ b/.github/workflows/spectest-vms.yml
@@ -21,9 +21,6 @@ on:
       - synchronize
       - reopened
 
-permissions:
-  contents: read
-
 env:
   CMARK_TARBALL_URL: https://github.com/commonmark/cmark/archive/refs/tags/0.31.2.tar.gz
   INIPARSER_TARBALL_URL: https://gitlab.com/iniparser/iniparser/-/archive/v4.2.6/iniparser-v4.2.6.tar.gz
@@ -36,6 +33,9 @@ jobs:
     name: AFP Spectest - DragonFlyBSD (sys:ad, HAMMER2)
     runs-on: ubuntu-latest
     timeout-minutes: 24
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -108,6 +108,13 @@ jobs:
           export SERVICE_START="/usr/local/etc/rc.d/netatalk onestart"
           export SERVICE_STOP="/usr/local/etc/rc.d/netatalk onestop"
           sh ./.github/scripts/vm_spectest.sh
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: afp-spectest.junit.xml
+          reporter: java-junit
       - name: Upload meson logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -119,6 +126,9 @@ jobs:
     name: AFP Spectest - FreeBSD (PerfConfig, UFS)
     runs-on: ubuntu-latest
     timeout-minutes: 24
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -188,6 +198,13 @@ jobs:
           export SERVICE_START="/usr/local/etc/rc.d/netatalk onestart"
           export SERVICE_STOP="/usr/local/etc/rc.d/netatalk onestop"
           sh ./.github/scripts/vm_spectest.sh
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: afp-spectest.junit.xml
+          reporter: java-junit
       - name: Upload meson logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -199,6 +216,9 @@ jobs:
     name: AFP Spectest - FreeBSD (PerfConfig, ZFS)
     runs-on: ubuntu-latest
     timeout-minutes: 24
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -276,6 +296,13 @@ jobs:
           export SERVICE_START="/usr/local/etc/rc.d/netatalk onestart"
           export SERVICE_STOP="/usr/local/etc/rc.d/netatalk onestop"
           sh ./.github/scripts/vm_spectest.sh
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: afp-spectest.junit.xml
+          reporter: java-junit
       - name: Upload meson logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -287,6 +314,9 @@ jobs:
     name: AFP Spectest - NetBSD (sys:ad, FFS)
     runs-on: ubuntu-latest
     timeout-minutes: 24
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -359,6 +389,13 @@ jobs:
           export SERVICE_START="service netatalk onestart"
           export SERVICE_STOP="service netatalk onestop"
           sh ./.github/scripts/vm_spectest.sh
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: afp-spectest.junit.xml
+          reporter: java-junit
       - name: Upload meson logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -370,6 +407,9 @@ jobs:
     name: AFP Spectest - OpenBSD (sys:ad, FFS)
     runs-on: ubuntu-latest
     timeout-minutes: 24
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -439,6 +479,13 @@ jobs:
           export SERVICE_START="rcctl -d start netatalk"
           export SERVICE_STOP="rcctl -d stop netatalk"
           sh ./.github/scripts/vm_spectest.sh
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: afp-spectest.junit.xml
+          reporter: java-junit
       - name: Upload meson logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -450,6 +497,9 @@ jobs:
     name: AFP Spectest - OmniOS (sys:ad, ZFS)
     runs-on: ubuntu-latest
     timeout-minutes: 24
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -533,6 +583,13 @@ jobs:
           export SERVICE_START="svcadm enable -s svc:/network/netatalk:default"
           export SERVICE_STOP="svcadm disable -s svc:/network/netatalk:default"
           sh ./.github/scripts/vm_spectest.sh
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: afp-spectest.junit.xml
+          reporter: java-junit
       - name: Upload meson logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -544,6 +601,9 @@ jobs:
     name: AFP Spectest - OpenIndiana (sys:ad, ZFS)
     runs-on: ubuntu-latest
     timeout-minutes: 24
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -621,6 +681,13 @@ jobs:
           export SERVICE_START="svcadm enable -s svc:/network/netatalk:default"
           export SERVICE_STOP="svcadm disable -s svc:/network/netatalk:default"
           sh ./.github/scripts/vm_spectest.sh
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: afp-spectest.junit.xml
+          reporter: java-junit
       - name: Upload meson logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -632,6 +699,9 @@ jobs:
     name: AFP Spectest - Solaris (sys:ad, ZFS)
     runs-on: ubuntu-latest
     timeout-minutes: 24
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -711,6 +781,13 @@ jobs:
           export SERVICE_START="svcadm enable -s svc:/network/netatalk:default"
           export SERVICE_STOP="svcadm disable -s svc:/network/netatalk:default"
           sh ./.github/scripts/vm_spectest.sh
+      - name: Publish AFP spec test results
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: AFP Spectest (${{ github.job }})
+          path: afp-spectest.junit.xml
+          reporter: java-junit
       - name: Upload meson logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/distrib/docker/debug_entrypoint_netatalk.sh
+++ b/distrib/docker/debug_entrypoint_netatalk.sh
@@ -327,8 +327,14 @@ else
             if [ -n "$AFP_SUBTESTS" ]; then
                 set -- "$@" -f "$AFP_SUBTESTS"
             fi
+            if [ -n "$AFP_JUNIT_REPORT_PATH" ]; then
+                set -- "$@" -j "$AFP_JUNIT_REPORT_PATH"
+            fi
             afp_spectest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
+            if [ -n "$AFP_JUNIT_REPORT_PATH" ] && [ -f "$AFP_JUNIT_REPORT_PATH" ]; then
+                chmod 0644 "$AFP_JUNIT_REPORT_PATH"
+            fi
             ;;
         login)
             set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \

--- a/distrib/docker/entrypoint_netatalk.sh
+++ b/distrib/docker/entrypoint_netatalk.sh
@@ -68,8 +68,14 @@ else
             if [ -n "$AFP_SUBTESTS" ]; then
                 set -- "$@" -f "$AFP_SUBTESTS"
             fi
+            if [ -n "$AFP_JUNIT_REPORT_PATH" ]; then
+                set -- "$@" -j "$AFP_JUNIT_REPORT_PATH"
+            fi
             afp_spectest $TEST_FLAGS "$@"
             TEST_EXIT_CODE=$?
+            if [ -n "$AFP_JUNIT_REPORT_PATH" ] && [ -f "$AFP_JUNIT_REPORT_PATH" ]; then
+                chmod 0644 "$AFP_JUNIT_REPORT_PATH"
+            fi
             ;;
         login)
             set -- -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" \

--- a/doc/manpages/man1/afp_spectest.1.md
+++ b/doc/manpages/man1/afp_spectest.1.md
@@ -5,7 +5,7 @@ afp_spectest — AFP specification compliance test suite
 # Synopsis
 
 **afp_spectest** [-1234567aCEiLmVv] [-A *uam*] [-h *host*] [-H *host2*] [-p *port*] [-s *volume*] [-c *path to volume*]
-[-S *volume2*] [-u *user*] [-d *user2*] [-w *password*] [-f *test*]
+[-S *volume2*] [-u *user*] [-d *user2*] [-w *password*] [-f *test*] [-j *path*]
 
 **afp_spectest** -l
 
@@ -73,6 +73,11 @@ Single tests or entire testsets can be executed with the **-f** option.
 
 **-i**
 : Interactive mode – prompt user before each test (used for debugging)
+
+**-j** *path*
+: Write the completed test results as a JUnit XML file at *path*. The
+  existing terminal output and return codes are unchanged. The destination must
+  be a file path; standard output (`-`) is not supported.
 
 **-l**
 : List all available testsets and exit

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -14,6 +14,7 @@ libafptest_sources = [
     'afpcmd.c',
     'afphelper.c',
     'testhelper.c',
+    'testreport.c',
 ]
 
 # Spotlight-only testsuite additions. The talloc dependency and the
@@ -53,6 +54,13 @@ libafptest = static_library(
     dependencies: libafptest_deps,
     link_with: libatalk,
 )
+
+testreport_test = executable(
+    'testreport_test',
+    ['testreport_test.c', 'testreport.c'],
+    include_directories: root_includes,
+)
+test('testreport', testreport_test)
 
 afparg_sources = [
     'afparg.c',

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -1,11 +1,17 @@
+#include <errno.h>
 #include <dlfcn.h>
 #include <getopt.h>
+#include <string.h>
 
 #include "afpclient.h"
 #include "afptest_uam.h"
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
+#include "testreport.h"
+
+static void report_runner_failure(const char *name, const char *message);
+static int finish_report(int code);
 
 uint16_t VolID;
 static DSI *dsi;
@@ -248,6 +254,7 @@ static void run_one(char *name)
 
     if (!token) {
         test_nottested();
+        report_runner_failure("runner.selector", "empty test selector");
         return;
     }
 
@@ -257,6 +264,7 @@ static void run_one(char *name)
 
     if (VolID == 0xffff) {
         test_nottested();
+        report_runner_failure("runner.open-volume", "unable to open test volume");
         return;
     }
 
@@ -293,6 +301,7 @@ static void run_one(char *name)
 
         if (!fn) {
             test_nottested();
+            report_runner_failure(token, "unknown test selector");
         } else {
             press_enter(token);
             (*fn)();
@@ -318,6 +327,7 @@ static void run_all()
 
     if (VolID == 0xffff) {
         test_nottested();
+        report_runner_failure("runner.open-volume", "unable to open test volume");
         return;
     }
 
@@ -353,15 +363,31 @@ enum ad_format adouble = AD_EA;
 
 char *vers = "AFP3.4";
 char *uam = "Cleartxt Passwrd";
+static char *JunitXML;
 /* Also used by tests that create or reconnect their own AFP sessions. */
 const char *afptest_uam;
+
+static void report_runner_failure(const char *name, const char *message)
+{
+    testreport_record_case(name, TESTREPORT_NOT_TESTED, message);
+}
+
+static int finish_report(int code)
+{
+    if (testreport_finalize()) {
+        fprintf(stderr, "Unable to write JUnit XML report: %s\n", strerror(errno));
+        return 1;
+    }
+
+    return code;
+}
 
 /* =============================== */
 void usage(char *av0)
 {
     fprintf(stdout,
             "usage:\t%s [-1234567aCEiLlmVv] [-A uam] [-h host] [-H host2] [-p port] [-s vol] [-c vol path] [-S vol2] "
-            "[-u user] [-d user2] [-w password] [-F testsuite] [-f test]\n", av0);
+            "[-u user] [-d user2] [-w password] [-F testsuite] [-f test] [-j path]\n", av0);
     fprintf(stdout,
             "\t-A\tafptest UAM name or alias (ClearTxt: clrtxt; DHCAST128: dhx; DHX2: dhx2)\n");
     fprintf(stdout, "\t-a\tvolume is using AppleDouble metadata and not EA\n");
@@ -385,6 +411,7 @@ void usage(char *av0)
     fprintf(stdout, "\t-v\tverbose\n");
     fprintf(stdout, "\t-V\tvery verbose\n");
     fprintf(stdout, "\t-f\ttest or testset to run\n");
+    fprintf(stdout, "\t-j PATH\twrite an opt-in JUnit XML report to PATH\n");
     fprintf(stdout, "\t-l\tlist testsets\n");
     fprintf(stdout,
             "\t-L\tserver has 'strict locking = yes'; run byte-range read-lock conflict tests\n");
@@ -406,7 +433,8 @@ int main(int ac, char **av)
         usage(av[0]);
     }
 
-    while ((cc = getopt(ac, av, "1234567aCEiLlmVvA:c:d:f:H:h:p:S:s:u:w:")) != EOF) {
+    while ((cc = getopt(ac, av,
+                        "1234567aCEiLlmVvA:c:d:f:H:h:j:p:S:s:u:w:")) != EOF) {
         switch (cc) {
         case '1':
             vers = "AFPVersion 2.1";
@@ -530,6 +558,10 @@ int main(int ac, char **av)
             Password = strdup(optarg);
             break;
 
+        case 'j':
+            JunitXML = strdup(optarg);
+            break;
+
         default :
             usage(av[0]);
         }
@@ -537,9 +569,15 @@ int main(int ac, char **av)
 
     Loglevel = AFP_LOG_INFO;
 
+    if (testreport_configure(JunitXML, "afp_spectest")) {
+        fprintf(stderr, "Invalid JUnit XML output path: %s\n",
+                JunitXML ? JunitXML : "");
+        return 1;
+    }
+
     if (List) {
         list_tests();
-        exit(2);
+        return finish_report(2);
     }
 
     if (!Quiet) {
@@ -565,7 +603,8 @@ int main(int ac, char **av)
      ************************************/
 
     if ((Conn = (CONN *)calloc(1, sizeof(CONN))) == NULL) {
-        return 1;
+        report_runner_failure("runner.connect", "unable to allocate connection");
+        return finish_report(1);
     }
 
     int sock;
@@ -574,7 +613,8 @@ int main(int ac, char **av)
     sock = OpenClientSocket(Server, Port);
 
     if (sock < 0) {
-        return 2;
+        report_runner_failure("runner.connect", "unable to connect to AFP server");
+        return finish_report(2);
     }
 
     Dsi->socket = sock;
@@ -589,7 +629,8 @@ int main(int ac, char **av)
 
     if (ret) {
         printf("Login failed\n");
-        exit(1);
+        report_runner_failure("runner.login", "AFP login failed");
+        return finish_report(1);
     }
 
     Conn->afp_version = Version;
@@ -602,7 +643,9 @@ int main(int ac, char **av)
 
     if (User2) {
         if ((Conn2 = (CONN *)calloc(1, sizeof(CONN))) == NULL) {
-            return 1;
+            report_runner_failure("runner.connect-user2",
+                                  "unable to allocate second connection");
+            return finish_report(1);
         }
 
         int sock2;
@@ -610,7 +653,9 @@ int main(int ac, char **av)
         sock2 = OpenClientSocket(Server2 ? Server2 : Server, Port);
 
         if (sock2 < 0) {
-            return 1;
+            report_runner_failure("runner.connect-user2",
+                                  "unable to connect second AFP session");
+            return finish_report(1);
         }
 
         Dsi2->socket = sock2;
@@ -626,7 +671,8 @@ int main(int ac, char **av)
 
         if (ret) {
             printf("Login failed\n");
-            exit(1);
+            report_runner_failure("runner.login-user2", "second AFP login failed");
+            return finish_report(1);
         }
 
         Conn2->afp_version = Version;
@@ -678,5 +724,5 @@ int main(int ac, char **av)
         }
     }
 
-    return ExitCode;
+    return finish_report(ExitCode);
 }

--- a/test/testsuite/testhelper.c
+++ b/test/testsuite/testhelper.c
@@ -7,6 +7,7 @@
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
+#include "testreport.h"
 #include "afpclient.h"
 #include "afphelper.h"
 #include "testhelper.h"
@@ -15,6 +16,8 @@ static int CurTestResult;
 static char *Why;
 #define SKIPPED_MSG_BUFSIZE 256
 static char skipped_msg_buf[SKIPPED_MSG_BUFSIZE];
+static char failure_location[256];
+static char skip_reason[SKIPPED_MSG_BUFSIZE];
 
 /* ------------------------- */
 void test_skipped(int why)
@@ -150,6 +153,7 @@ void test_skipped(int why)
         snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), "SKIPPED (%s)", s);
     }
 
+    strlcpy(skip_reason, s, sizeof(skip_reason));
     CurTestResult = 3;
 }
 
@@ -157,13 +161,14 @@ void test_skipped(int why)
 void test_failed_at(const char *file, int line)
 {
     fprintf(stderr, "\n*** ERROR: test_failed() called at %s:%d ***\n", file, line);
-    
+
     if (!Quiet) {
         fprintf(stderr, "\tFAILED\n");
     }
 
     ExitCode = 1;
     CurTestResult = 1;
+    snprintf(failure_location, sizeof(failure_location), "%s:%d", file, line);
 }
 
 /* ------------------------- */
@@ -183,6 +188,8 @@ void test_nottested(void)
 /* ------------------------- */
 void enter_test(void)
 {
+    testreport_begin_case();
+
     if (EmptyVol) {
         clear_volume(VolID, Conn);
 
@@ -193,12 +200,15 @@ void enter_test(void)
 
     CurTestResult = 0;
     Why = "";
+    failure_location[0] = '\0';
+    skip_reason[0] = '\0';
 }
 
 /* ------------------------- */
 void exit_test(char *name)
 {
     char *s;
+    char unknown_result[64];
 
     switch (CurTestResult) {
     case 0:
@@ -223,10 +233,7 @@ void exit_test(char *name)
             s = "FAILED";
         }
 
-        fprintf(stdout, "%s - ", name);
-        fprintf(stdout, "%s%s\n", s, Why);
-        fflush(stdout);
-        return;
+        break;
 
     case 2:
         strlcpy(NotTestedTests[NotTestedCount], name, 255);
@@ -249,13 +256,14 @@ void exit_test(char *name)
         break;
 
     default:
-        fprintf(stdout, "%s - ", name);
-        fprintf(stdout, "UNKNOWN RESULT (%d)%s\n", CurTestResult, Why);
-        fflush(stdout);
-        return;
+        snprintf(unknown_result, sizeof(unknown_result), "UNKNOWN RESULT (%d)",
+                 CurTestResult);
+        s = unknown_result;
+        break;
     }
 
     fprintf(stdout, "%s - ", name);
     fprintf(stdout, "%s%s\n", s, Why);
     fflush(stdout);
+    testreport_end_case(name, CurTestResult, failure_location, skip_reason);
 }

--- a/test/testsuite/testreport.c
+++ b/test/testsuite/testreport.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "testreport.h"
+
+struct testreport_case {
+    char *name;
+    char *message;
+    enum testreport_result result;
+    double duration;
+};
+
+static char *report_path;
+static char *report_suite;
+static struct testreport_case *report_cases;
+static size_t report_case_count;
+static size_t report_case_capacity;
+static bool report_failed;
+static struct timespec report_started;
+static struct timespec case_started;
+
+static char *xstrdup(const char *s)
+{
+    char *copy;
+
+    if (!s) {
+        s = "";
+    }
+
+    copy = strdup(s);
+    return copy;
+}
+
+static double elapsed(const struct timespec *start, const struct timespec *end)
+{
+    return (double)(end->tv_sec - start->tv_sec) +
+           (double)(end->tv_nsec - start->tv_nsec) / 1000000000.0;
+}
+
+static void now(struct timespec *ts)
+{
+    clock_gettime(CLOCK_MONOTONIC, ts);
+}
+
+static void clear_cases(void)
+{
+    for (size_t i = 0; i < report_case_count; i++) {
+        free(report_cases[i].name);
+        free(report_cases[i].message);
+    }
+
+    free(report_cases);
+    report_cases = NULL;
+    report_case_count = 0;
+    report_case_capacity = 0;
+}
+
+int testreport_configure(const char *path, const char *suite_name)
+{
+    free(report_path);
+    free(report_suite);
+    report_path = NULL;
+    report_suite = NULL;
+    clear_cases();
+    report_failed = false;
+
+    if (!path) {
+        return 0;
+    }
+
+    if (!*path || !strcmp(path, "-")) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    report_path = xstrdup(path);
+    report_suite = xstrdup(suite_name);
+
+    if (!report_path || !report_suite) {
+        free(report_path);
+        free(report_suite);
+        report_path = NULL;
+        report_suite = NULL;
+        errno = ENOMEM;
+        return -1;
+    }
+
+    now(&report_started);
+    return 0;
+}
+
+void testreport_begin_case(void)
+{
+    if (report_path) {
+        now(&case_started);
+    }
+}
+
+static void add_case(const char *name, enum testreport_result result,
+                     double duration, const char *message)
+{
+    struct testreport_case *cases;
+    struct testreport_case *item;
+
+    if (!report_path) {
+        return;
+    }
+
+    if (report_case_count == report_case_capacity) {
+        size_t capacity = report_case_capacity ? report_case_capacity * 2 : 64;
+        cases = realloc(report_cases, capacity * sizeof(*report_cases));
+
+        if (!cases) {
+            report_failed = true;
+            return;
+        }
+
+        report_cases = cases;
+        report_case_capacity = capacity;
+    }
+
+    item = &report_cases[report_case_count++];
+    item->name = xstrdup(name);
+    item->message = xstrdup(message);
+    item->result = result;
+    item->duration = duration;
+
+    if (!item->name || !item->message) {
+        free(item->name);
+        free(item->message);
+        report_case_count--;
+        report_failed = true;
+    }
+}
+
+void testreport_end_case(const char *name, enum testreport_result result,
+                         const char *failure_location,
+                         const char *skip_reason)
+{
+    struct timespec finished;
+    const char *message = "";
+
+    if (!report_path) {
+        return;
+    }
+
+    if (result == TESTREPORT_FAILED) {
+        message = failure_location;
+    } else if (result == TESTREPORT_SKIPPED) {
+        message = skip_reason;
+    } else if (result == TESTREPORT_NOT_TESTED) {
+        message = "test setup failed";
+    }
+
+    now(&finished);
+    add_case(name, result, elapsed(&case_started, &finished), message);
+}
+
+void testreport_record_case(const char *name, enum testreport_result result,
+                            const char *message)
+{
+    add_case(name, result, 0.0, message);
+}
+
+static void xml_escape(FILE *stream, const char *text)
+{
+    const unsigned char *p;
+
+    if (!text) {
+        return;
+    }
+
+    p = (const unsigned char *)text;
+
+    for (; *p; p++) {
+        switch (*p) {
+        case '&':
+            fputs("&amp;", stream);
+            break;
+
+        case '<':
+            fputs("&lt;", stream);
+            break;
+
+        case '>':
+            fputs("&gt;", stream);
+            break;
+
+        case '\"':
+            fputs("&quot;", stream);
+            break;
+
+        case '\'':
+            fputs("&apos;", stream);
+            break;
+
+        default:
+            if (*p >= 0x20 || *p == '\n' || *p == '\r' || *p == '\t') {
+                fputc(*p, stream);
+            }
+        }
+    }
+}
+
+static int write_report(FILE *stream)
+{
+    size_t i;
+    unsigned int failures = 0, errors = 0, skipped = 0;
+    struct timespec finished;
+
+    for (i = 0; i < report_case_count; i++) {
+        if (report_cases[i].result == TESTREPORT_FAILED) {
+            failures++;
+        } else if (report_cases[i].result == TESTREPORT_NOT_TESTED) {
+            errors++;
+        } else if (report_cases[i].result == TESTREPORT_SKIPPED) {
+            skipped++;
+        }
+    }
+
+    now(&finished);
+    fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuite name=\"", stream);
+    xml_escape(stream, report_suite);
+    fprintf(stream,
+            "\" tests=\"%zu\" failures=\"%u\" errors=\"%u\" skipped=\"%u\" time=\"%.6f\">\n",
+            report_case_count, failures, errors, skipped,
+            elapsed(&report_started, &finished));
+
+    for (i = 0; i < report_case_count; i++) {
+        const struct testreport_case *item = &report_cases[i];
+        fputs("  <testcase classname=\"", stream);
+        xml_escape(stream, report_suite);
+        fputs("\" name=\"", stream);
+        xml_escape(stream, item->name);
+        fprintf(stream, "\" time=\"%.6f\">", item->duration);
+
+        if (item->result == TESTREPORT_FAILED) {
+            fputs("<failure type=\"assertion\" message=\"", stream);
+            xml_escape(stream, item->message);
+            fputs("\"/>", stream);
+        } else if (item->result == TESTREPORT_NOT_TESTED) {
+            fputs("<error type=\"setup\" message=\"", stream);
+            xml_escape(stream, item->message);
+            fputs("\"/>", stream);
+        } else if (item->result == TESTREPORT_SKIPPED) {
+            fputs("<skipped message=\"", stream);
+            xml_escape(stream, item->message);
+            fputs("\"/>", stream);
+        }
+
+        fputs("</testcase>\n", stream);
+    }
+
+    return fputs("</testsuite>\n", stream) == EOF ? -1 : 0;
+}
+
+int testreport_finalize(void)
+{
+    char *temporary;
+    size_t temporary_size;
+    int fd;
+    FILE *stream;
+    int result = 0;
+
+    if (!report_path) {
+        return 0;
+    }
+
+    if (report_failed) {
+        errno = ENOMEM;
+        clear_cases();
+        free(report_path);
+        free(report_suite);
+        report_path = NULL;
+        report_suite = NULL;
+        return -1;
+    }
+
+    temporary_size = strlen(report_path) + sizeof(".tmp.XXXXXX");
+    temporary = malloc(temporary_size);
+
+    if (!temporary) {
+        return -1;
+    }
+
+    snprintf(temporary, temporary_size, "%s.tmp.XXXXXX", report_path);
+    fd = mkstemp(temporary);
+
+    if (fd < 0) {
+        free(temporary);
+        return -1;
+    }
+
+    stream = fdopen(fd, "w");
+
+    if (!stream) {
+        close(fd);
+        unlink(temporary);
+        result = -1;
+    } else {
+        if (write_report(stream) || fflush(stream) || fsync(fd)) {
+            result = -1;
+        }
+
+        if (fclose(stream)) {
+            result = -1;
+        }
+
+        if (result) {
+            unlink(temporary);
+        } else if (rename(temporary, report_path)) {
+            unlink(temporary);
+            result = -1;
+        }
+    }
+
+    free(temporary);
+    clear_cases();
+    free(report_path);
+    free(report_suite);
+    report_path = NULL;
+    report_suite = NULL;
+    return result;
+}

--- a/test/testsuite/testreport.h
+++ b/test/testsuite/testreport.h
@@ -1,0 +1,20 @@
+#ifndef TESTREPORT_H
+#define TESTREPORT_H
+
+enum testreport_result {
+    TESTREPORT_PASSED = 0,
+    TESTREPORT_FAILED = 1,
+    TESTREPORT_NOT_TESTED = 2,
+    TESTREPORT_SKIPPED = 3,
+};
+
+int testreport_configure(const char *path, const char *suite_name);
+void testreport_begin_case(void);
+void testreport_end_case(const char *name, enum testreport_result result,
+                         const char *failure_location,
+                         const char *skip_reason);
+void testreport_record_case(const char *name, enum testreport_result result,
+                            const char *message);
+int testreport_finalize(void);
+
+#endif

--- a/test/testsuite/testreport_test.c
+++ b/test/testsuite/testreport_test.c
@@ -1,0 +1,90 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "testreport.h"
+
+static char *read_file(const char *path)
+{
+    FILE *stream;
+    long size;
+    char *contents;
+    stream = fopen(path, "r");
+
+    if (!stream || fseek(stream, 0, SEEK_END) || (size = ftell(stream)) < 0 ||
+            fseek(stream, 0, SEEK_SET)) {
+        return NULL;
+    }
+
+    contents = malloc((size_t)size + 1);
+
+    if (!contents || fread(contents, 1, (size_t)size, stream) != (size_t)size) {
+        free(contents);
+        fclose(stream);
+        return NULL;
+    }
+
+    contents[size] = '\0';
+    fclose(stream);
+    return contents;
+}
+
+int main(void)
+{
+    char path[] = "netatalk-testreport-XXXXXX";
+    char *contents;
+    int fd;
+    fd = mkstemp(path);
+
+    if (fd < 0) {
+        return 1;
+    }
+
+    close(fd);
+    unlink(path);
+    testreport_end_case("disabled", TESTREPORT_PASSED, NULL, NULL);
+
+    if (access(path, F_OK) == 0 || testreport_finalize()) {
+        return 1;
+    }
+
+    if (testreport_configure(path, "suite & <name>")) {
+        return 1;
+    }
+
+    testreport_begin_case();
+    testreport_end_case("pass & <one>", TESTREPORT_PASSED, NULL, NULL);
+    testreport_begin_case();
+    testreport_end_case("failure", TESTREPORT_FAILED, "file.c:42", NULL);
+    testreport_begin_case();
+    testreport_end_case("skip", TESTREPORT_SKIPPED, NULL,
+                        "needs <server> & credentials");
+    testreport_begin_case();
+    testreport_end_case("setup", TESTREPORT_NOT_TESTED, NULL, NULL);
+
+    if (testreport_finalize()) {
+        return 1;
+    }
+
+    contents = read_file(path);
+    unlink(path);
+
+    if (!contents) {
+        return 1;
+    }
+
+    if (!strstr(contents, "tests=\"4\" failures=\"1\" errors=\"1\" skipped=\"1\"")
+            ||
+            !strstr(contents, "pass &amp; &lt;one&gt;") ||
+            !strstr(contents, "suite &amp; &lt;name&gt;") ||
+            !strstr(contents, "message=\"file.c:42\"") ||
+            !strstr(contents, "needs &lt;server&gt; &amp; credentials") ||
+            !strstr(contents, "<error type=\"setup\"")) {
+        free(contents);
+        return 1;
+    }
+
+    free(contents);
+    return 0;
+}


### PR DESCRIPTION
the -j argument takes a file path to the xml files where to save Junit compatible XML test results

have each spectest CI job post its test report to PR workflow run summary pages, and do the same for the preexisting TAP unit test reports