### PR TITLE
afpd: ignore permission options without UNIX privileges

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -1294,9 +1294,15 @@ this writing).
 
 file perm = *mode* **(V)**; directory perm = *mode* **(V)**
 
-> Add(or) with the client requested permissions: **file perm** is for files
-only, **directory perm** is for directories only. Don't use with
-"**unix priv = no**".
+> Add (bitwise OR) this mode to permissions requested by the client:
+**file perm** applies to files only, and **directory perm** applies to
+directories only. These options can grant permission bits, but cannot remove
+bits requested by the client or set a fixed mode. For example, a client
+requesting mode `0644` with `file perm = 0222` results in mode `0666`.
+>
+> The modes are applied when the client changes permissions; they are not
+initial creation modes. See **umask** to mask permission bits. These options
+are ignored with "**unix priv = no**".
 >
 > **Example**: Volume for a collaborative workgroup
 
@@ -1305,7 +1311,8 @@ only, **directory perm** is for directories only. Don't use with
 
 umask = *mode* **(V)**
 
-> Set perm mask. Don't use with "**unix priv = no**".
+> Set a permission mask, which removes bits from modes to which it is applied.
+This option is ignored with "**unix priv = no**".
 
 preexec = *command* **(V)**
 

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -128,10 +128,10 @@ static int netatalk_mkdir(const struct vol *vol, const char *name)
             return AFPERR_MISC;
         }
 
-        int mode = (DIRBITS & (~S_ISGID & st.st_mode)) | (0777 & ~vol->v_umask);
+        int mode = (DIRBITS & (~S_ISGID & st.st_mode)) | (0777 & ~vol_umask(vol));
         LOG(log_maxdebug, logtype_afpd,
             "netatalk_mkdir(\"%s\") {parent mode: %04o, vol umask: %04o}",
-            name, st.st_mode, vol->v_umask);
+            name, st.st_mode, vol_umask(vol));
         ret = mkdir(name, mode);
     } else {
         ret = ad_mkdir(name, DIRBITS | 0777);
@@ -2700,7 +2700,7 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap,
             ma.ma_world = *buf++;
             ma.ma_group = *buf++;
             ma.ma_owner = *buf++;
-            mpriv = mtoumode(&ma) | vol->v_dperm;
+            mpriv = mtoumode(&ma) | vol_dperm(vol);
             break;
 
         /* Ignore what the client thinks we should do to the
@@ -2727,7 +2727,7 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap,
                 change_mdate = 1;
                 memcpy(&upriv, buf, sizeof(upriv));
                 buf += sizeof(upriv);
-                upriv = ntohl(upriv) | vol->v_dperm;
+                upriv = ntohl(upriv) | vol_dperm(vol);
                 break;
             }
 

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -1231,7 +1231,7 @@ int afp_moveandrename(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
 
         /* if unix priv don't try to match perm with dest folder */
         if (!isdir && !vol_unix_priv(vol)) {
-            int  admode = ad_mode("", 0777) | vol->v_fperm;
+            int  admode = ad_mode("", 0777) | vol_fperm(vol);
             setfilmode(vol, upath, admode, path->st_valid ? &path->st : NULL);
             vol->vfs->vfs_setfilmode(vol, upath, admode, path->st_valid ? &path->st : NULL);
         }

--- a/etc/afpd/unix.c
+++ b/etc/afpd/unix.c
@@ -188,7 +188,7 @@ int setfilunixmode(const struct vol *vol, struct path *path, mode_t mode)
         return -1;
     }
 
-    mode |= vol->v_fperm;
+    mode |= vol_fperm(vol);
 
     if (setfilmode(vol, path->u_name, mode, &path->st) < 0) {
         return -1;
@@ -203,9 +203,9 @@ int setfilunixmode(const struct vol *vol, struct path *path, mode_t mode)
 int setdirunixmode(const struct vol *vol, char *name, mode_t mode)
 {
     LOG(log_debug, logtype_afpd, "setdirunixmode('%s', mode:%04o) {v_dperm:%04o}",
-        fullpathname(name), mode, vol->v_dperm);
-    mode |= vol->v_dperm | DIRBITS;
-    mode &= ~vol->v_umask;
+        fullpathname(name), mode, vol_dperm(vol));
+    mode |= vol_dperm(vol) | DIRBITS;
+    mode &= ~vol_umask(vol);
 
     if (dir_rx_set(mode)) {
         /* extending right? dir first then .AppleDouble in rf_setdirmode */

--- a/include/atalk/volume.h
+++ b/include/atalk/volume.h
@@ -224,7 +224,11 @@ typedef enum {
 #define utf8_encoding(obj) ((obj)->afp_version >= 30)
 
 #define vol_nodev(vol) (((vol)->v_flags & AFPVOL_NODEV) ? 1 : 0)
-#define vol_unix_priv(vol) ((vol)->v_obj->afp_version >= 30 && ((vol)->v_flags & AFPVOL_UNIX_PRIV))
+#define vol_unix_priv_enabled(vol) (((vol)->v_flags & AFPVOL_UNIX_PRIV) ? 1 : 0)
+#define vol_unix_priv(vol) ((vol)->v_obj->afp_version >= 30 && vol_unix_priv_enabled(vol))
+#define vol_umask(vol) (vol_unix_priv_enabled(vol) ? (vol)->v_umask : 0)
+#define vol_dperm(vol) (vol_unix_priv_enabled(vol) ? (vol)->v_dperm : 0)
+#define vol_fperm(vol) (vol_unix_priv_enabled(vol) ? (vol)->v_fperm : 0)
 #define vol_inv_dots(vol) (((vol)->v_flags & AFPVOL_INV_DOTS) ? 1 : 0)
 #define vol_syml_opt(vol) (((vol)->v_flags & AFPVOL_FOLLOWSYM) ? 0 : O_NOFOLLOW)
 #define vol_chmod_opt(vol) (((vol)->v_flags & AFPVOL_CHMOD_PRESERVE_ACL) ? O_NETATALK_ACL : \

--- a/libatalk/cnid/cnid.c
+++ b/libatalk/cnid/cnid.c
@@ -130,7 +130,7 @@ struct _cnid_db *cnid_open(struct vol *vol, char *type, int flags)
             return NULL;
         }
 
-        if (cnid_dir(vol->v_path, vol->v_umask) < 0) {
+        if (cnid_dir(vol->v_path, vol_umask(vol)) < 0) {
             if (setegid(gid) < 0 || seteuid(uid) < 0) {
                 LOG(log_error, logtype_afpd, "can't seteuid back %s", strerror(errno));
                 exit(EXITERR_SYS);

--- a/libatalk/vfs/ea_ad.c
+++ b/libatalk/vfs/ea_ad.c
@@ -427,7 +427,7 @@ static int write_ea(const struct ea *ea,
 
     LOG(log_maxdebug, logtype_afpd, "write_ea('%s')", eaname);
 
-    if ((fd = open(eaname, O_RDWR | O_CREAT, 0666 & ~ea->vol->v_umask)) == -1) {
+    if ((fd = open(eaname, O_RDWR | O_CREAT, 0666 & ~vol_umask(ea->vol))) == -1) {
         LOG(log_error, logtype_afpd, "write_ea: open error: %s", eaname);
         return AFPERR_MISC;
     }
@@ -655,7 +655,7 @@ int ea_open(const struct vol *vol,
         open_flags |= O_CREAT;
     }
 
-    ea->ea_fd = open(eaname, open_flags, 0666 & ~ea->vol->v_umask);
+    ea->ea_fd = open(eaname, open_flags, 0666 & ~vol_umask(ea->vol));
 
     if (ea->ea_fd == -1) {
         if (errno == ENOENT && !(eaflags & EA_CREATE)) {
@@ -1603,7 +1603,7 @@ int ea_copyfile(const struct vol *vol, int sfd, const char *src,
         }
 
         /* Now copy the EA */
-        if ((copy_file(sfd, srceapath, eapath, (0666 & ~vol->v_umask))) < 0) {
+        if (copy_file(sfd, srceapath, eapath, 0666 & ~vol_umask(vol)) < 0) {
             LOG(log_error, logtype_afpd, "ea_copyfile('%s/%s'): copying EA '%s' to '%s'",
                 src, dst, srceapath, eapath);
             ret = AFPERR_MISC;

--- a/libatalk/vfs/unix.c
+++ b/libatalk/vfs/unix.c
@@ -52,7 +52,7 @@ int setfilmode(const struct vol *vol, const char *name, mode_t mode,
     mode |= st->st_mode & ~mask;
 
     if (ochmod((char *)name,
-               mode & ~vol->v_umask,
+               mode & ~vol_umask(vol),
                st,
                vol_syml_opt(vol) | vol_chmod_opt(vol)
               ) < 0 && errno != EPERM) {

--- a/libatalk/vfs/vfs.c
+++ b/libatalk/vfs/vfs.c
@@ -197,7 +197,7 @@ static int RF_setdirunixmode_adouble(const struct vol *vol, const char *name,
 
     if (dir_rx_set(mode)) {
         if (ochmod(ad_dir(adouble),
-                   (DIRBITS | mode) & ~vol->v_umask,
+                   (DIRBITS | mode) & ~vol_umask(vol),
                    st,
                    vol_syml_opt(vol) | vol_chmod_opt(vol)
                   ) < 0) {
@@ -211,7 +211,7 @@ static int RF_setdirunixmode_adouble(const struct vol *vol, const char *name,
 
     if (!dir_rx_set(mode)) {
         if (ochmod(ad_dir(adouble),
-                   (DIRBITS | mode) & ~vol->v_umask,
+                   (DIRBITS | mode) & ~vol_umask(vol),
                    st,
                    vol_syml_opt(vol) | vol_chmod_opt(vol)
                   ) < 0) {
@@ -253,7 +253,7 @@ static int RF_setdirmode_adouble(const struct vol *vol, const char *name,
 
     if (dir_rx_set(mode)) {
         if (ochmod(ad_dir(adouble),
-                   (DIRBITS | mode) & ~vol->v_umask,
+                   (DIRBITS | mode) & ~vol_umask(vol),
                    st,
                    vol_syml_opt(vol) | vol_chmod_opt(vol)
                   ) < 0) {
@@ -268,7 +268,7 @@ static int RF_setdirmode_adouble(const struct vol *vol, const char *name,
 
     if (!dir_rx_set(mode)) {
         if (ochmod(ad_dir(adouble),
-                   (DIRBITS | mode) & ~vol->v_umask,
+                   (DIRBITS | mode) & ~vol_umask(vol),
                    st,
                    vol_syml_opt(vol) | vol_chmod_opt(vol)
                   ) < 0) {

--- a/test/afpd/subtests_conf.c
+++ b/test/afpd/subtests_conf.c
@@ -340,6 +340,125 @@ cleanup:
     return failed;
 }
 
+/* utest_conf_permission_options_require_unix_priv: file perm, directory
+ * perm, and umask are meaningful only on UNIX-privilege volumes. A
+ * no-UNIX-privilege volume retains the configured values, but the live
+ * accessors suppress all three options (including explicitly configured zero
+ * masks). */
+int utest_conf_permission_options_require_unix_priv(void)
+{
+    static const struct {
+        const char *unix_priv;
+        const char *umask;
+        const char *file_perm;
+        const char *directory_perm;
+        mode_t expected_umask;
+        mode_t expected_file_perm;
+        mode_t expected_directory_perm;
+        int expect_unix_priv;
+    } cases[] = {
+        {"no",  "0077", "0222", "0444", 0077, 0222, 0444, 0},
+        {"no",  "0000", "0000", "0000", 0,    0,    0,    0},
+        {"yes", "0077", "0222", "0444", 0077, 0222, 0444, 1},
+        {"no",  NULL,   NULL,   NULL,   0,    0,    0,    0},
+    };
+    AFPObj obj;
+    char logpath[64];
+    char body[1024];
+    char *voldir = conf_mkvoldir();
+    int failed = -1;
+
+    if (voldir == NULL || conf_mklog(logpath, sizeof(logpath)) != 0) {
+        free(voldir);
+        return TEST_SKIP;
+    }
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        char umask_line[32] = "";
+        char file_perm_line[32] = "";
+        char directory_perm_line[32] = "";
+
+        if (cases[i].umask) {
+            snprintf(umask_line, sizeof(umask_line), "umask = %s\n",
+                     cases[i].umask);
+        }
+
+        if (cases[i].file_perm) {
+            snprintf(file_perm_line, sizeof(file_perm_line), "file perm = %s\n",
+                     cases[i].file_perm);
+        }
+
+        if (cases[i].directory_perm) {
+            snprintf(directory_perm_line, sizeof(directory_perm_line),
+                     "directory perm = %s\n", cases[i].directory_perm);
+        }
+
+        int n = snprintf(body, sizeof(body),
+                         "[utestvol]\n"
+                         "path = %s\n"
+                         "ea = none\n"
+                         "unix priv = %s\n"
+                         "%s"
+                         "%s"
+                         "%s",
+                         voldir, cases[i].unix_priv,
+                         umask_line, file_perm_line, directory_perm_line);
+
+        if (n < 0 || (size_t)n >= sizeof(body)) {
+            goto cleanup;
+        }
+
+        conf_log_truncate(logpath);
+
+        if (conf_parse_fixture_vols(&obj, body, logpath) != 0) {
+            goto cleanup;
+        }
+
+        const struct vol *vol = conf_vol_by_name("utestvol");
+        int unix_priv = vol && (vol->v_flags & AFPVOL_UNIX_PRIV) ? 1 : 0;
+        mode_t effective_umask = vol ? vol_umask(vol) : 0;
+        mode_t effective_file_perm = vol ? vol_fperm(vol) : 0;
+        mode_t effective_directory_perm = vol ? vol_dperm(vol) : 0;
+        mode_t expected_effective_umask = cases[i].expect_unix_priv
+                                          ? cases[i].expected_umask : 0;
+        mode_t expected_effective_file_perm = cases[i].expect_unix_priv
+                                              ? cases[i].expected_file_perm : 0;
+        mode_t expected_effective_directory_perm = cases[i].expect_unix_priv
+            ? cases[i].expected_directory_perm : 0;
+
+        if (vol == NULL || unix_priv != cases[i].expect_unix_priv
+                || vol->v_umask != cases[i].expected_umask
+                || vol->v_fperm != cases[i].expected_file_perm
+                || vol->v_dperm != cases[i].expected_directory_perm
+                || effective_umask != expected_effective_umask
+                || effective_file_perm != expected_effective_file_perm
+                || effective_directory_perm != expected_effective_directory_perm) {
+            fprintf(test_stream(),
+                    "# utest_conf_permission_options_require_unix_priv: case %zu: "
+                    "unix priv %d/%d umask %04o/%04o (%04o) file %04o/%04o (%04o) "
+                    "directory %04o/%04o (%04o)\n",
+                    i, unix_priv, cases[i].expect_unix_priv,
+                    vol ? vol->v_umask : 0, cases[i].expected_umask,
+                    effective_umask,
+                    vol ? vol->v_fperm : 0, cases[i].expected_file_perm,
+                    effective_file_perm,
+                    vol ? vol->v_dperm : 0, cases[i].expected_directory_perm,
+                    effective_directory_perm);
+            conf_teardown(&obj, NULL);
+            goto cleanup;
+        }
+
+        conf_teardown(&obj, NULL);
+    }
+
+    failed = 0;
+cleanup:
+    unlink(logpath);
+    rmdir(voldir);
+    free(voldir);
+    return failed;
+}
+
 
 /* utest_conf_ea_fallback: the ea (G)/(V) resolution chain, one loaded
  * volume per case.

--- a/test/afpd/subtests_conf.h
+++ b/test/afpd/subtests_conf.h
@@ -8,6 +8,7 @@
 extern void conf_testutil_set_lastvid(uint16_t vid);
 
 extern int utest_conf_parse_bool(void);
+extern int utest_conf_permission_options_require_unix_priv(void);
 extern int utest_conf_ea_fallback(void);
 extern int utest_conf_strict_locking_keys(void);
 extern int utest_conf_samba_defaults(void);

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -468,6 +468,8 @@ int main(int argc, char *argv[])
      * lock/fork tests. */
     TEST_int_or_skip(utest_conf_parse_bool(), 0,
                      "conf_parse_bool: strict boolean spellings, invalid values warn");
+    TEST_int_or_skip(utest_conf_permission_options_require_unix_priv(), 0,
+                     "volume permission options are ignored when unix priv is disabled");
     TEST_int_or_skip(utest_conf_ea_fallback(), 0,
                      "ea resolves volume -> preset -> [Global] -> auto-detect");
     TEST_int_or_skip(utest_conf_strict_locking_keys(), 0,


### PR DESCRIPTION
Make all runtime uses of the volume umask, file perm, and directory perm options go through accessors that return zero unless the volume enables UNIX privileges. This preserves the configured values while preventing these permission modifications from affecting volumes configured with unix priv = no.

In the afp.conf man page, document the bitwise-OR behavior and their interaction with unix priv.

Add test coverage for for the effective configuration values.

Thanks to @ypfjyhh1523 for the report.