### PR TITLE
ci: don't let dependabot run the TSAN Spectest job

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -219,7 +219,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: build-container-tsan
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
       checks: write


### PR DESCRIPTION
the TSAN Spectest job requires credentials that we do not expose to non project members