### PR TITLE
afpd: a stock config gets the documented 64K dircache

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@ Netatalk Changelog
 Changes in 4.6.0
 ----------------
 
+* FIX: afpd: a stock configuration now gets the documented 64K-entry
+  directory cache; a stale compiled default silently capped it at 8K
+  entries. Explicit `dircache size` settings are unaffected
 * UPD: afpd: `ea` is now a (G)/(V) option; a value in [Global] applies to all
   volumes and can be overridden per volume. A `[Global] ea =` setting that
   previous releases silently ignored now takes effect

--- a/contrib/webmin_module/edit_global_section.cgi
+++ b/contrib/webmin_module/edit_global_section.cgi
@@ -537,7 +537,7 @@ print &ui_table_row(
 @values = get_parameter_of_section($afpconfRef, $sectionRef, 'dircache size', \%in);
 print &ui_table_row(
                     $text{'edit_global_section_dircachesize'},
-                    "<input name='p_dircache size' type='number' min='0' max='2097152' value='"
+                    "<input name='p_dircache size' type='number' min='0' max='1048576' value='"
                     . $values[0] . "'>" . " "
                     . ($values[2] ? html_escape($values[2]) . ": " . html_escape($values[1]) : '') . "\n"
 );

--- a/contrib/webmin_module/lang/en
+++ b/contrib/webmin_module/lang/en
@@ -230,7 +230,7 @@ edit_global_section_cnid_mysql_db=CNID MySQL database name
 edit_global_section_cnid_scheme=CNID scheme
 edit_global_section_cnid_server=CNID server IP address and port
 edit_global_section_dbus_daemon=D-Bus daemon directory
-edit_global_section_dircachesize=Directory cache size (bytes)
+edit_global_section_dircachesize=Directory cache size (entries)
 edit_global_section_dircache_mode=Directory cache replacement algorithm
 edit_global_section_dircache_rfork_budget=Resource fork cache memory budget (KB, 0=disabled)
 edit_global_section_dircache_rfork_maxsize=Max resource fork size to cache per entry (KB)

--- a/doc/developer/dircache.md
+++ b/doc/developer/dircache.md
@@ -168,13 +168,13 @@ Every recursive lookup also results in many more stat calls.
 So even opening a small folder directly,
 still requires stat'ing every level of the whole path to be pushed into the page cache.
 
-If the dircache max size is small (by default just 8192 entries), as you move around your file share,
+If the dircache is smaller than your working set, as you move around your file share,
 old entries are pushed off (evicted) as new ones are added.
 This high entry rotation is known as "scan eviction" and means by the time you want to go back to a previous directory
 and read a cached entry, it has likely already been evicted which can cause a cascade effect of recursive lookups
 and stats calls to restore the broken cached paths if parent entries are evicted.
-So unless your whole file server has less than 8192 file and directories,
-it is recommended to increase the `dircache size` value in [afp.conf](https://netatalk.io/manual/en/afp.conf.5).
+It is recommended to increase the `dircache size` value (default 65536 entries) in
+[afp.conf](https://netatalk.io/manual/en/afp.conf.5) to match your common working set.
 
 Future releases will increase the maximum size of the dircache once existing performance issues are addressed.
 We are also considering retaining directories over files during eviction
@@ -399,7 +399,7 @@ These metrics are reported for both cache modes:
 
 - **entries**: Current number of cached entries at shutdown
 - **max_entries**: Peak entries reached during the session (high-water mark)
-- **config_max**: Maximum cache size from afp.conf configuration
+- **config_max_entries**: Maximum cache size (in entries) from afp.conf configuration
 - **lookups**: Total cache lookup operations performed
 - **validations**: Approximate filesystem validations performed (based on `dircache validation freq`)
 - **added**: Entries added to cache
@@ -423,7 +423,7 @@ LRU mode provides straightforward hit/miss metrics:
 
 ```txt
 dircache statistics (LRU): (user: jdoe) entries: 98234, max_entries: 131072,
-config_max: 131072, lookups: 2458716, hits: 1806407 (73.5%), misses: 652309 (26.5%),
+config_max_entries: 131072, lookups: 2458716, hits: 1806407 (73.5%), misses: 652309 (26.5%),
 validations: ~24587 (1.0%), added: 152341, removed: 54107, expunged: 8921,
 invalid_on_use: 234, evicted: 53873, covered_cancelled: 67, validation_freq: 100
 ```
@@ -472,7 +472,7 @@ but performance is improved across virtually all workload patterns.
 
 ```txt
 dircache statistics (ARC): (user: jdoe) entries: 98234, ghost_entries: 32838,
-max_entries: 131072, config_max: 131072, lookups: 2458716, hits: 1954327 (79.5%),
+max_entries: 131072, config_max_entries: 131072, lookups: 2458716, hits: 1954327 (79.5%),
 ghost_hits: 322351 (13.1%), total_hits: (92.6%), misses: 182038 (7.4%),
 validations: 21365 (0.9%), added: 152341, removed: 54107, expunged: 7234,
 invalid_on_use: 187, evicted: 53873, covered_cancelled: 67, validation_freq: 100

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -95,10 +95,12 @@
  * Indexes
  * =======
  *
- * The maximum dircache size is:
- * max(DEFAULT_DIRCACHE_SIZE, min(size, MAX_DIRCACHE_SIZE)).
- * It is a hashtable which we use to store "struct dir"s in. If the cache get full, oldest
- * entries are evicted in chunks of DIRCACHE_FREE.
+ * The maximum dircache size resolves from the requested size: unset or
+ * below MIN_DIRCACHE_SIZE uses DEFAULT_DIRCACHE_SIZE, in-range values
+ * round up to the next power of two, larger requests clamp to
+ * MAX_DIRCACHE_SIZE. It is a hashtable which we use to store "struct
+ * dir"s in. If the cache gets full, oldest entries are evicted in
+ * chunks of DIRCACHE_FREE_QUANTUM.
  *
  * We have/need two indexes:
  * - a DID/name index on the main dircache, another hashtable
@@ -2032,10 +2034,51 @@ void dircache_promote(struct dir *dir)
 }
 
 /*!
+ * @brief Resolve a requested dircache size to the effective maximum
+ *
+ * Unset or below-minimum sizes use DEFAULT_DIRCACHE_SIZE, in-range
+ * sizes round up to the next power of two, oversize requests clamp
+ * to MAX_DIRCACHE_SIZE.
+ *
+ * @param[in] reqsize   requested maximum size from afp.conf
+ *
+ * @returns the effective maximum cache size
+ */
+unsigned int dircache_resolve_size(int reqsize)
+{
+    unsigned int size;
+
+    if (reqsize > 0 && reqsize >= MIN_DIRCACHE_SIZE
+            && reqsize <= MAX_DIRCACHE_SIZE) {
+        size = MIN_DIRCACHE_SIZE;
+
+        while (size < reqsize && size < MAX_DIRCACHE_SIZE) {
+            size *= 2;
+        }
+    } else if (reqsize > MAX_DIRCACHE_SIZE) {
+        size = MAX_DIRCACHE_SIZE;
+        LOG(log_warning, logtype_afpd,
+            "dircache_resolve_size: requested size %d exceeds maximum %d, using maximum",
+            reqsize, MAX_DIRCACHE_SIZE);
+    } else {
+        size = DEFAULT_DIRCACHE_SIZE;
+
+        if (reqsize > 0 && reqsize < MIN_DIRCACHE_SIZE) {
+            LOG(log_warning, logtype_afpd,
+                "dircache_resolve_size: requested size %d below minimum %d, using default %d",
+                reqsize, MIN_DIRCACHE_SIZE, DEFAULT_DIRCACHE_SIZE);
+        }
+    }
+
+    return size;
+}
+
+/*!
  * @brief Initialize the dircache and indexes
  *
- * This is called in child afpd initialization. The maximum cache size will be
- * max(DEFAULT_DIRCACHE_SIZE, min(size, MAX_DIRCACHE_SIZE)).
+ * This is called in child afpd initialization. Unset or below-minimum
+ * sizes use DEFAULT_DIRCACHE_SIZE, in-range sizes round up to the next
+ * power of two, oversize requests clamp to MAX_DIRCACHE_SIZE.
  * It initializes a hashtable which we use to store a directory cache in.
  * It also initializes two indexes:
  * - a DID/name index on the main dircache
@@ -2056,34 +2099,7 @@ int dircache_init(int reqsize)
         use_arc = 1;
     }
 
-    /* Initialize the main dircache with requested size
-     * Bounds: MIN_DIRCACHE_SIZE (1K) to MAX_DIRCACHE_SIZE (1M)
-     * Default: DEFAULT_DIRCACHE_SIZE (64K) if reqsize <= 0 or out of bounds */
-    if (reqsize > 0 && reqsize >= MIN_DIRCACHE_SIZE
-            && reqsize <= MAX_DIRCACHE_SIZE) {
-        /* Use requested size, rounding up to next power of 2 if needed */
-        dircache_maxsize = MIN_DIRCACHE_SIZE;
-
-        while (dircache_maxsize < reqsize && dircache_maxsize < MAX_DIRCACHE_SIZE) {
-            dircache_maxsize *= 2;
-        }
-    } else if (reqsize > MAX_DIRCACHE_SIZE) {
-        /* Requested size too large, use maximum */
-        dircache_maxsize = MAX_DIRCACHE_SIZE;
-        LOG(log_warning, logtype_afpd,
-            "dircache_init: requested size %d exceeds maximum %d, using maximum",
-            reqsize, MAX_DIRCACHE_SIZE);
-    } else {
-        /* Use default (reqsize <= 0 or < MIN_DIRCACHE_SIZE) */
-        dircache_maxsize = DEFAULT_DIRCACHE_SIZE;
-
-        if (reqsize > 0 && reqsize < MIN_DIRCACHE_SIZE) {
-            LOG(log_warning, logtype_afpd,
-                "dircache_init: requested size %d below minimum %d, using default %d",
-                reqsize, MIN_DIRCACHE_SIZE, DEFAULT_DIRCACHE_SIZE);
-        }
-    }
-
+    dircache_maxsize = dircache_resolve_size(reqsize);
     /* Determine hash table size based on mode:
      * LRU: hash_size = c (only cached entries)
      * ARC: hash_size = 2c (c cached + c ghosts per ARC paper) */
@@ -2242,7 +2258,7 @@ void log_dircache_stat(void)
                                    (double)dircache_stat.lookups) * 100.0 : 0.0;
         LOG(log_info, logtype_afpd,
             "dircache statistics (ARC): (user: %s) "
-            "entries: %zu, ghost_entries: %zu, max_entries: %lu (%lu KB), config_max: %zu, "
+            "entries: %zu, ghost_entries: %zu, max_entries: %lu (%lu KB), config_max_entries: %zu, "
             "lookups: %llu, hits: %llu (%.1f%%), ghost_hits: %llu (%.1f%%), total_hits: (%.1f%%), misses: %llu (%.1f%%), "
             "validations: %llu (%.1f%%), "
             "added: %llu, removed: %llu, expunged: %llu, invalid_on_use: %llu, "
@@ -2315,7 +2331,7 @@ void log_dircache_stat(void)
                             ((double)dircache_stat.misses / (double)dircache_stat.lookups) * 100.0 : 0.0;
         LOG(log_info, logtype_afpd,
             "dircache statistics (LRU): (user: %s) "
-            "entries: %lu, max_entries: %lu (%lu KB), config_max: %u, lookups: %llu, hits: %llu (%.1f%%), misses: %llu (%.1f%%), "
+            "entries: %lu, max_entries: %lu (%lu KB), config_max_entries: %u, lookups: %llu, hits: %llu (%.1f%%), misses: %llu (%.1f%%), "
             "validations: %llu (%.1f%%), "
             "added: %llu, removed: %llu, expunged: %llu, invalid_on_use: %llu, evicted: %llu, "
             "covered_cancelled: %llu, validation_freq: %u",

--- a/etc/afpd/dircache.h
+++ b/etc/afpd/dircache.h
@@ -22,9 +22,9 @@
 #include <atalk/globals.h>
 #include <atalk/volume.h>
 
-/* Dircache size bounds */
+/* Dircache size bounds; the default is DEFAULT_DIRCACHE_SIZE in
+ * atalk/globals.h (included above) */
 #define MIN_DIRCACHE_SIZE 1024             /* 1K minimum (testing/constrained systems) */
-#define DEFAULT_DIRCACHE_SIZE 65536        /* 64K default (production) */
 #define MAX_DIRCACHE_SIZE 1048576          /* 1M maximum (high-memory servers) */
 #define DIRCACHE_FREE_QUANTUM 256
 
@@ -48,6 +48,7 @@ extern struct dir *dircache_search_by_name(const struct vol *,
 
 extern void       dircache_dump(void);
 extern void       log_dircache_stat(void);
+extern unsigned int dircache_resolve_size(int reqsize);
 extern int        dircache_set_validation_params(unsigned int freq);
 extern void       dircache_reset_validation_counter(void);
 extern void       dircache_report_invalid_entry(struct dir *dir);

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -50,7 +50,7 @@
 #define CNID_PATH_OVERHEAD 12  /* CNID protocol header size for path resolution */
 #define CNID_MAX_PATH_LEN (CNID_PATH_OVERHEAD + MAXPATHLEN + 1)  /* Maximum path length for CNID operations */
 
-#define DEFAULT_MAX_DIRCACHE_SIZE 8192
+#define DEFAULT_DIRCACHE_SIZE 65536    /*!< default 'dircache size' (entries) */
 
 /* Directory cache validation settings */
 #define DEFAULT_DIRCACHE_VALIDATION_FREQ    1     /*!< Validate every Nth access (default 1 for backward compatibility) */

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -3273,7 +3273,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
                                               NULL, -1);
 
         if (options->dircachesize == -1) {
-            options->dircachesize = DEFAULT_MAX_DIRCACHE_SIZE;
+            options->dircachesize = DEFAULT_DIRCACHE_SIZE;
         } else {
             LOG(log_warning, logtype_afpd,
                 "Using deprecated 'dircachesize' option, please update to 'dircache size'");

--- a/test/afpd/subtests_conf.c
+++ b/test/afpd/subtests_conf.c
@@ -40,6 +40,7 @@
 #include <atalk/util.h>
 #include <atalk/volume.h>
 
+#include "dircache.h"
 #include "peer_lock.h"
 #include "subtests_conf.h"
 #include "test.h"
@@ -1281,4 +1282,34 @@ cleanup:
     rmdir(voldir);
     free(voldir);
     return failed;
+}
+
+/* utest_conf_dircache_resolve_size: bounds behaviour of the pure size
+ * resolution helper; touches no dircache state (the binary's live
+ * dircache from test.c stays intact). */
+int utest_conf_dircache_resolve_size(void)
+{
+    static const struct {
+        int reqsize;
+        unsigned int expect;
+    } cases[] = {
+        {-1, 65536},        /* unset: default */
+        {512, 65536},       /* below minimum: default, with warning */
+        {1024, 1024},       /* minimum accepted verbatim */
+        {100000, 131072},   /* in range: next power of two */
+        {2000000, 1048576}, /* above maximum: clamp, with warning */
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        unsigned int got = dircache_resolve_size(cases[i].reqsize);
+
+        if (got != cases[i].expect) {
+            fprintf(test_stream(),
+                    "# utest_conf_dircache_resolve_size: %d -> %u, want %u\n",
+                    cases[i].reqsize, got, cases[i].expect);
+            return -1;
+        }
+    }
+
+    return 0;
 }

--- a/test/afpd/subtests_conf.h
+++ b/test/afpd/subtests_conf.h
@@ -19,5 +19,6 @@ extern int utest_conf_samba_ea_failure_keeps_vid(void);
 extern int utest_conf_samba_defaults_not_leaked_on_failed_volume(void);
 extern int utest_conf_samba_future_defaults(void);
 extern int utest_conf_load_afp_conf_vols_locked(void);
+extern int utest_conf_dircache_resolve_size(void);
 
 #endif /* SUBTESTS_CONF_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -490,6 +490,8 @@ int main(int argc, char *argv[])
                      "ea = samba reverts performance-oriented compiled defaults (freq 100, rfork on)");
     TEST_int_or_skip(utest_conf_load_afp_conf_vols_locked(), 0,
                      "config loader fails closed under lock contention, state-neutral");
+    TEST_int_or_skip(utest_conf_dircache_resolve_size(), 0,
+                     "dircache_resolve_size: default, minimum, round-up, clamp");
     TEST(afp_options_parse_cmdline(&obj, 3, &args[0]),
          "parse afpd command-line options");
     TEST_int(afp_config_parse(&obj, NULL), 0,


### PR DESCRIPTION
## Root cause

Two constants both mean "the dircache size default", and they drifted apart:

- `DEFAULT_DIRCACHE_SIZE = 65536` in `etc/afpd/dircache.h` — what `dircache_init()` applies, and what the man page, the docker image, and the webmin module all document.
- `DEFAULT_MAX_DIRCACHE_SIZE = 8192` in `include/atalk/globals.h` — what an unset `dircache size` actually resolves to in `afp_config_parse()`.

Because 8192 is above the 1024 minimum, `dircache_init()` accepted it verbatim — so **every stock configuration has been running an 8× smaller directory cache than documented**. Explicit `dircache size` settings were never affected.

## How the drift got here

| when | commit | what happened |
|---|---|---|
| 2012-02-17 | 6655a7d0 | volume loading moved to libatalk, bringing the config-side default constant (8192) with it — the documented default at the time |
| later | 9aa80804 | the dircache work raised the documented default to 65536 (man page and `dircache.h`), but the config-side constant in `globals.h` was not part of that change |

Two constants meaning "the default" diverged, and nothing tied them together.

## Defect → fix

| defect | fix |
|---|---|
| stock config resolves 8192 while all documentation says 65536; nothing prevents the two constants drifting apart again | collapsed into a **single** `DEFAULT_DIRCACHE_SIZE = 65536` in `globals.h`, which `dircache.h` already includes — one definition, nothing to drift |
| size-bounds behaviour was untestable (`dircache_maxsize` is a static set inside `dircache_init()`, which also builds live cache state) | resolution extracted into a pure `dircache_resolve_size()` helper; `dircache_init()` calls it |
| two stale comments describe the resolution as `max(DEFAULT_DIRCACHE_SIZE, min(size, MAX_DIRCACHE_SIZE))` — never the actual algorithm — and reference a nonexistent `DIRCACHE_FREE` | comments now describe the real resolution (unset/below-min → default, in-range → round up to power of two, oversize → clamp); `DIRCACHE_FREE_QUANTUM` |
| webmin labels the option "(bytes)" though the unit is entries, and its form cap (2097152) exceeds `MAX_DIRCACHE_SIZE` (1048576) | label and cap corrected |
| the shutdown statistics lines print the configured cache maximum unit-less (`config_max:`), inviting the same bytes-vs-entries misreading | renamed to `config_max_entries:` in both the ARC and LRU lines; lantest only matches the line prefix, so nothing parses the old label; `doc/developer/dircache.md` field list and examples updated |
| `doc/developer/dircache.md` still described the dircache as "by default just 8192 entries" — the very stale default this PR fixes | reworded to the corrected 65536 default |

## Behaviour changes

- Stock install: 8K → 64K-entry dircache (roughly ~1.5 MB → ~12 MB under LRU at full occupancy).
- Explicit `dircache size` values: unchanged. Bounds unchanged: minimum 1024 (deliberately kept — the spectest CI legs run `dircache size = 1024` to exercise cache exhaustion and eviction), maximum 1048576, in-range values still round up to the next power of two.
- The man page bounds line was already correct and is untouched.

## Size resolution

| requested `dircache size` | `dircache_resolve_size()` result |
|---|---|
| unset (≤ 0) | 65536 |
| 1 – 1023 | 65536, with a warning |
| 1024 – 1048576 | rounded up to the next power of two |
| > 1048576 | clamped to 1048576, with a warning |

## Testing

- New unit test `utest_conf_dircache_resolve_size` in `test/afpd/subtests_conf.c`: bounds matrix over the pure helper — `-1 → 65536`, `512 → 65536` (warn), `1024 → 1024`, `100000 → 131072`, `2000000 → 1048576` (clamp warn)
- `meson test` (Alpine container, CI build flags): 3/3 suites, 88 afpd subtests passed
- AFP spectest, ea=sys and ea=ad legs (single container, CI env including `dircache size = 1024`): both exit 0, zero failures



