### PR TITLE
cnid: sqlite-default residual cleanup; dsi: raise the listen backlog to 128

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -478,6 +478,7 @@ jobs:
               -e AFP_DIRCACHE_RFORK_BUDGET=1048576 \
               -e AFP_DIRCACHE_RFORK_MAXSIZE=1024 \
               -e AFP_CONVERT_APPLEDOUBLE=no \
+              -e AFP_CNID_BACKEND=dbd \
               ${{ env.REGISTRY }}/netatalk/netatalk:${{ github.sha }}
       - name: Run Netatalk testsuite
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,14 @@ Netatalk Changelog
 Changes in 4.6.0
 ----------------
 
+* UPD: dsi: listen backlog raised from 20 to 128, absorbing reconnect
+  storms without dropped SYNs (the kernel still caps it at
+  net.core.somaxconn), GitHub #3267
+* UPD: cnid: the default CNID scheme has changed to *sqlite*: the build
+  system now selects sqlite > mysql > dbd among the compiled backends
+  (GitHub #3077), and the docker image's fallback for an unset
+  AFP_CNID_BACKEND now matches. The dbd backend remains available but is
+  deprecated, GitHub #3267
 * UPD: netatalk: cnid_metad is now started only when a volume uses the
   dbd CNID scheme, and started or stopped on config reload as volumes
   change; previously it always ran when the dbd backend was compiled in,

--- a/distrib/docker/env_setup_netatalk.sh
+++ b/distrib/docker/env_setup_netatalk.sh
@@ -629,7 +629,7 @@ vol charset = ${AFP_VOL_CHARSET:-UTF8}
 spotlight = $AFP_SPOTLIGHT_GLOBAL
 spotlight backend = ${AFP_SPOTLIGHT_BACKEND:-cnid}
 [${SHARE_NAME:-File Sharing}]
-cnid scheme = ${AFP_CNID_BACKEND:-dbd}
+cnid scheme = ${AFP_CNID_BACKEND:-sqlite}
 ea = $AFP_EA
 path = $NETATALK_SHARE_DIR
 valid users = $AFP_VALIDUSERS1
@@ -638,7 +638,7 @@ $AFP_RWRO = $AFP_VALIDUSERS1
 convert appledouble = ${AFP_CONVERT_APPLEDOUBLE:-no}
 spotlight = $AFP_SPOTLIGHT_GLOBAL
 [${SHARE_NAME2:-Time Machine}]
-cnid scheme = ${AFP_CNID_BACKEND:-dbd}
+cnid scheme = ${AFP_CNID_BACKEND:-sqlite}
 ea = $AFP_EA
 path = $NETATALK_BACKUP_DIR
 time machine = $TIMEMACHINE

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -525,6 +525,7 @@ Requires datbase administration, giving you full control over how the CNID data 
 >
 > *sqlite*: uses the SQLite embedded database library.
 It is performant and lean, requiring no external database or daemon.
+This is the default backend when compiled in.
 
 cnid server = *host[:port]* **(G)**/**(V)**
 

--- a/libatalk/dsi/dsi_tcp.c
+++ b/libatalk/dsi/dsi_tcp.c
@@ -48,7 +48,7 @@ int deny_severity = log_warning;
 #define min(a,b)  ((a) < (b) ? (a) : (b))
 
 #ifndef DSI_TCPMAXPEND
-#define DSI_TCPMAXPEND      20       /*!< max # of pending connections */
+#define DSI_TCPMAXPEND      128      /*!< max # of pending connections */
 #endif /* DSI_TCPMAXPEND */
 
 #ifndef DSI_TCPTIMEOUT


### PR DESCRIPTION
## CNID: sqlite-default residual cleanup

SQLite has been the default CNID scheme since PR #2265 ("Build and run netatalk without Berkeley DB") made meson select sqlite > mysql > dbd among the compiled backends — and all three compile by default, so `DEFAULT_CNID_SCHEME`, the runtime `cnid scheme` default, is already "sqlite" on any default build (`afpd -v`: "Default CNID backend: sqlite"). What remained was residue that still said dbd:

| residue | fix |
|---|---|
| docker entrypoint fallback: `cnid scheme = ${AFP_CNID_BACKEND:-dbd}` (two sites) | `:-sqlite` — an unset `AFP_CNID_BACKEND` now matches what a stock source build already does |
| ~30 CI test jobs (the ea:sys/ea:ad/UAM/AFP-version/login matrix) set no `AFP_CNID_BACKEND` and were unintentionally testing dbd via the entrypoint fallback | they now inherit sqlite, the shipped default — only jobs that intentionally test a backend name it. The "AFP spec test (cnid:dbd)" job, which also relied on the fallback, now sets `-e AFP_CNID_BACKEND=dbd` explicitly |
| man page never stated which backend is the default | the *sqlite* paragraph now says "This is the default backend when compiled in." |
| NEWS never recorded the default change | entry added |

Intentional backend coverage is unchanged: the cnid:mysql legs (Alpine + Debian) and the cnid:sqlite/perf legs set `AFP_CNID_BACKEND` explicitly, the VM spectest script exports `dbd` explicitly, and the cnid:dbd job is now pinned. Every other job had no business running dbd; this PR resolves that unintended coverage skew — the broad matrix now tests what ships.

## DSI: raise the listen backlog to 128

`DSI_TCPMAXPEND` has been 20 since the CVS-era initial revision, with no config knob. A reconnect storm (default 200 max connections) overflows a backlog of 20: dropped SYNs and ~1s client retransmit delays. 128 matches the common SOMAXCONN floor, and the kernel silently caps the effective backlog at `net.core.somaxconn`, so no new option is warranted. No steady-state effect; the `#ifndef` guard stays for build-time overrides.

## Testing

- `meson test` (Alpine container, CI build flags): 3/3 suites, zero failures.
- AFP spectest ea=sys and ea=ad legs run **without** `AFP_CNID_BACKEND` — i.e. on the new sqlite fallback end-to-end: both exit 0, zero failures.
- Entrypoint verification: a container pinned to `AFP_CNID_BACKEND=dbd` generates `cnid scheme = dbd` and runs the cnid daemon; an env-less container generates `cnid scheme = sqlite`.
- `afpd -v` in the built image reports sqlite as the default backend.

## Outstanding issue

The netatalk master still starts `cnid_metad` whenever the dbd backend is merely *compiled in*, so an env-less (sqlite) container runs an idle cnid daemon that nothing talks to. Startup should be conditional on a volume actually using `cnid scheme = dbd` — tracked in #3268.
