### PR TITLE
netatalk: start cnid_metad only when a volume uses the dbd scheme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@ Netatalk Changelog
 Changes in 4.6.0
 ----------------
 
+* UPD: netatalk: cnid_metad is now started only when a volume uses the
+  dbd CNID scheme, and started or stopped on config reload as volumes
+  change; previously it always ran when the dbd backend was compiled in,
+  GitHub #3269
 * UPD: afpd: the resource-fork data cache is now enabled by default
   (`dircache rfork budget = 32768`, 32 MB). `ea = samba` volumes remain
   excluded (Samba mutates resource forks behind afpd's back). Set

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -75,6 +75,9 @@ static pid_t cnid_metad_pid = NETATALK_SRV_NEEDED;
 static pid_t cnid_metad_pid = NETATALK_SRV_OPTIONAL;
 #endif
 static pid_t dbus_pid = NETATALK_SRV_OPTIONAL;
+/* whether the volume list loaded; without it the cnid_metad
+ * decisions fail conservative (run the daemon) */
+static bool volumes_loaded;
 static uint afpd_restarts, cnid_metad_restarts, dbus_restarts _U_;
 #ifdef WITH_LIBEV
 static struct ev_loop *loop;
@@ -386,7 +389,10 @@ static void sighup_impl(void)
 {
     LOG(log_note, logtype_afpd,
         "Received SIGHUP, sending all processes signal to reload config");
-    load_afp_conf_vols(&obj, LV_ALL);
+
+    if (load_afp_conf_vols(&obj, LV_ALL) == 0) {
+        volumes_loaded = true;
+    }
 
     if (!(obj.options.flags & OPTION_NOZEROCONF)) {
         zeroconf_deregister();
@@ -395,6 +401,23 @@ static void sighup_impl(void)
     }
 
     kill_childs(SIGHUP, &afpd_pid, &cnid_metad_pid, NULL);
+#ifdef CNID_BACKEND_DBD
+
+    if (volumes_loaded) {
+        bool dbd_in_use = conf_cnid_scheme_in_use(&obj, "dbd");
+
+        if (service_running(cnid_metad_pid) && !dbd_in_use) {
+            LOG(log_note, logtype_afpd,
+                "Stopping 'cnid_metad': no volume uses the dbd CNID scheme");
+            kill_childs(SIGTERM, &cnid_metad_pid, NULL);
+        } else if (!service_running(cnid_metad_pid) && dbd_in_use) {
+            LOG(log_note, logtype_afpd,
+                "Starting 'cnid_metad': a volume now uses the dbd CNID scheme");
+            cnid_metad_pid = NETATALK_SRV_NEEDED;
+        }
+    }
+
+#endif
 }
 
 /*! SIGCHLD implementation, returns true if all services have exited during shutdown */
@@ -455,13 +478,17 @@ static void timer_impl(void)
     }
 
     if (cnid_metad_pid == NETATALK_SRV_NEEDED) {
-        cnid_metad_restarts++;
-        LOG(log_note, logtype_afpd, "Restarting 'cnid_metad' (restarts: %u)",
-            cnid_metad_restarts);
+        if (volumes_loaded && !conf_cnid_scheme_in_use(&obj, "dbd")) {
+            cnid_metad_pid = NETATALK_SRV_OPTIONAL;
+        } else {
+            cnid_metad_restarts++;
+            LOG(log_note, logtype_afpd, "Restarting 'cnid_metad' (restarts: %u)",
+                cnid_metad_restarts);
 
-        if ((cnid_metad_pid = run_process(_PATH_CNID_METAD, "-d", "-F",
-                                          obj.options.configfile, NULL)) == -1) {
-            LOG(log_error, logtype_default, "Error starting 'cnid_metad'");
+            if ((cnid_metad_pid = run_process(_PATH_CNID_METAD, "-d", "-F",
+                                              obj.options.configfile, NULL)) == -1) {
+                LOG(log_error, logtype_default, "Error starting 'cnid_metad'");
+            }
         }
     }
 
@@ -761,7 +788,7 @@ int main(int argc, char **argv)
         netatalk_exit(EXITERR_CONF);
     }
 
-    load_afp_conf_vols(&obj, LV_ALL);
+    volumes_loaded = (load_afp_conf_vols(&obj, LV_ALL) == 0);
 #ifdef WITH_LIBEV
     ev_set_syserr_cb(libev_syserr_cb);
 #else
@@ -778,8 +805,10 @@ int main(int argc, char **argv)
 
 #ifdef CNID_BACKEND_DBD
 
-    if ((cnid_metad_pid = run_process(_PATH_CNID_METAD, "-d", "-F",
-                                      obj.options.configfile, NULL)) == NETATALK_SRV_ERROR) {
+    if (volumes_loaded && !conf_cnid_scheme_in_use(&obj, "dbd")) {
+        cnid_metad_pid = NETATALK_SRV_OPTIONAL;
+    } else if ((cnid_metad_pid = run_process(_PATH_CNID_METAD, "-d", "-F",
+                                 obj.options.configfile, NULL)) == NETATALK_SRV_ERROR) {
         LOG(log_error, logtype_afpd, "Error starting 'cnid_metad'");
         netatalk_exit(EXITERR_CONF);
     }

--- a/include/atalk/netatalk_conf.h
+++ b/include/atalk/netatalk_conf.h
@@ -26,6 +26,8 @@ extern int        load_charset(struct vol *vol);
 extern int        load_afp_conf_vols(AFPObj *obj, lv_flags_t flags);
 extern void       unload_volumes(AFPObj *obj);
 extern struct vol *getvolumes(void);
+extern int        conf_cnid_scheme_in_use(const AFPObj *obj,
+        const char *scheme);
 extern struct vol *getvolbyvid(const uint16_t);
 extern struct vol *getvolbypath(AFPObj *obj, const char *path);
 extern struct vol *getvolbyname(const char *name);

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2691,6 +2691,41 @@ struct vol *getvolumes(void)
     return Volumes;
 }
 
+/*!
+ * @brief Whether any configured volume resolves to the given CNID scheme
+ *
+ * Scans the loaded volume list, then the [Homes] section: homes
+ * volumes are instantiated per-user at login, so outside AFP sessions
+ * they never appear in the list. The section's scheme is resolved the
+ * same way creatvol() resolves it (section -> preset -> global ->
+ * compiled default).
+ */
+int conf_cnid_scheme_in_use(const AFPObj *obj, const char *scheme)
+{
+    const char *preset, *default_preset;
+
+    for (const struct vol *vol = Volumes; vol; vol = vol->v_next) {
+        if (vol->v_cnidscheme && strcmp(vol->v_cnidscheme, scheme) == 0) {
+            return 1;
+        }
+    }
+
+    /* basedir regex is the one mandatory [Homes] option: absent means
+     * no homes sharing is configured */
+    if (getoption_str(obj->iniconfig, INISEC_HOMES, "basedir regex",
+                      NULL, NULL) == NULL) {
+        return 0;
+    }
+
+    default_preset = getoption_str(obj->iniconfig, INISEC_GLOBAL,
+                                   "vol preset", NULL, NULL);
+    preset = getoption_str(obj->iniconfig, INISEC_HOMES, "vol preset",
+                           NULL, NULL);
+    return strcmp(vdgoption_str(obj->iniconfig, INISEC_HOMES, "cnid scheme",
+                                preset ? preset : default_preset,
+                                DEFAULT_CNID_SCHEME), scheme) == 0;
+}
+
 struct vol *getvolbyvid(const uint16_t vid)
 {
     struct vol  *vol;


### PR DESCRIPTION
Fixes #3268.

## Problem

The netatalk master started `cnid_metad` whenever the dbd backend was merely *compiled in* (`CNID_BACKEND_DBD`), regardless of whether any volume has `cnid scheme = dbd`. All three backends compile by default and the default scheme is sqlite (in-process), so a stock install ran an idle `cnid_metad`/`cnid_dbd` pair that nothing talks to.

## Design

The master already has the machinery: it loads volumes before starting services and re-loads them on SIGHUP, and its timer re-launches any service whose pid sentinel is `NETATALK_SRV_NEEDED`. The change makes the needed/optional decision from the configuration in one small exported check plus three call sites:

- **`conf_cnid_scheme_in_use()`** (netatalk_conf.c): scans the loaded volume list, then the `[Homes]` section — homes volumes are instantiated per-user at login, so outside AFP sessions they never appear in the master's volume list; the section's scheme is resolved exactly as `creatvol()` resolves it (section → preset → global → compiled default). It lives in netatalk_conf.c because those resolution helpers are static there.
- **Startup**: skip `cnid_metad` when no volume resolves to dbd.
- **Timer restart guard**: the reaper marks a dead `cnid_metad` as `NETATALK_SRV_ERROR`, which equals `NETATALK_SRV_NEEDED` — without a guard the timer would resurrect a daemon a reload just made unnecessary; the guard demotes instead. This one check makes stop transitions converge through the existing machinery with no new state.
- **SIGHUP**: after the volume reload, stop a running daemon no dbd volume needs (SIGTERM → reap → guarded demotion) or mark it needed when one now does (next timer tick starts it). Both transitions are logged.

Robustness: if the master's volume load fails, an empty list is indistinguishable from "no volumes", so a `volumes_loaded` flag makes every decision fail conservative — the daemon runs, exactly as today. Builds without the dbd backend are unchanged: the pid sentinel can never become needed there (the SIGHUP re-evaluation is compile-gated), so the master never attempts to start a binary that isn't installed.

## Reload semantics

Start/stop on SIGHUP applies to **added or removed** volumes. Changing `cnid scheme` on an *existing* volume takes effect at restart only — `creatvol()` does not change options for volumes once loaded, which is netatalk's long-standing reload behaviour for all volume options; this PR matches it rather than changing it.

## Testing

All cases run against live containers built from this branch.

| build | configuration | expected | result |
|---|---|---|---|
| all backends (default) | `cnid scheme = sqlite` volumes | no `cnid_metad` | ✓ 0 processes |
| all backends | `cnid scheme = dbd` volumes | daemon running | ✓ |
| all backends | only share is `[Homes]`, global `cnid scheme = dbd` | daemon running | ✓ — the homes resolution path |
| all backends | SIGHUP: add a new dbd volume | started | ✓ "Starting 'cnid_metad': a volume now uses the dbd CNID scheme", process appears |
| all backends | SIGHUP: remove that volume | stopped, not restarted | ✓ "Stopping 'cnid_metad': …", cnid_metad logs "shutting down on SIGTERM", process gone, no restart — the timer guard held |
| all backends | `kill -9` a needed `cnid_metad` | restarted by the master | ✓ existing behaviour preserved |
| all backends | AFP spectest ea=sys and ea=ad legs | green | ✓ exit 0, zero failures |
| all backends | `meson test` | green | ✓ zero failures |
| **no dbd** (`-Dwith-cnid-backends=sqlite,mysql`) | build + unit suite | green; `cnid_metad` not installed | ✓ |
| no dbd | sqlite volume, live master | master + afpd run, no metad | ✓ |
| no dbd | volume **explicitly** `cnid scheme = dbd` | inert: no metad, no start-error loop | ✓ — the volume fails at client open as on any backend-less build; `cnid_open()` has no backend fallback (verified) |
| **dbd only** (`-Dwith-cnid-backends=dbd`) | stock config, **no scheme set anywhere** | daemon running | ✓ — the compiled default is dbd here, exercising the check's default-resolution end to end |
| dbd only | volume explicitly `sqlite` (unavailable backend) | no metad | ✓ — masks nothing; the volume fails at open, pre-existing |

(The dbd-only build cannot run the unit suite: `with-tests` uses the sqlite backend because the cnid_metad / cnid_dbd daemon combo needs root privileges to run, so dbd was deliberately left out of the afpd tests.)

