### PR TITLE
asp: wait only in poll() so deferred signals are always reachable

### DIFF
--- a/etc/afpd/afp_asp.c
+++ b/etc/afpd/afp_asp.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <poll.h>
 #include <signal.h>
 #include <errno.h>
 #include <sys/time.h>
@@ -33,6 +34,7 @@
 #include "auth.h"
 #include "fork.h"
 #include "dircache.h"
+#include "directory.h"
 
 static AFPObj *child;
 
@@ -40,13 +42,14 @@ static void afp_asp_close(AFPObj *obj)
 {
     ASP asp = obj->handle;
 
-    if (obj->uid != geteuid()) {
-        if (seteuid(obj->uid) < 0) {
-            LOG(log_error, logtype_afpd,
-                "afp_asp_close: can't seteuid back to %i from %i (%s)",
-                obj->uid, geteuid(), strerror(errno));
-        }
-
+    /* euid may not be the login user if an error path exited mid-command
+     * (e.g. after become_root()); volume prexec_close scripts need the login
+     * user, so restore it and carry on. Only a failed restore is fatal —
+     * exiting on success would skip close_all_vol() and the PAM logout. */
+    if (obj->uid != geteuid() && seteuid(obj->uid) < 0) {
+        LOG(log_error, logtype_afpd,
+            "afp_asp_close: can't seteuid back to %i from %i (%s)",
+            obj->uid, geteuid(), strerror(errno));
         exit(EXITERR_SYS);
     }
 
@@ -62,10 +65,37 @@ static void afp_asp_close(AFPObj *obj)
     asp_close(asp);
 }
 
+/*
+ * Signals are recorded and acted on from the request loop, not inside the
+ * handler: the work these used to do in signal context — LOG(), close_all_vol(),
+ * free(), PAM logout, blocking network I/O — deadlocks or corrupts the heap if
+ * it interrupts the main flow mid-allocation or holding the syslog lock.
+ *
+ * That deferral only works because poll() is the loop's one blocking point, so
+ * the self-pipe can always wake it. The request read is entered only once poll()
+ * has reported the socket readable, and consumes a single datagram before
+ * returning, which is why the handlers can keep SA_RESTART as the DSI handlers
+ * do: nothing here waits anywhere the pipe is not watched.
+ */
+/* Consecutive asp_getrequest() read errors tolerated before the session is
+ * given up on */
+#define ASP_MAX_READ_ERRORS 10
+/* Stray packets between log lines. They are remotely driven and harmless, so
+ * they are counted rather than logged one line each. */
+#define ASP_STRAY_LOG_INTERVAL 1000
+
+static volatile sig_atomic_t asp_die_pending = 0;
+static volatile sig_atomic_t asp_timedown_pending = 0;
+#ifdef SERVERTEXT
+static volatile sig_atomic_t asp_getmesg_pending = 0;
+#endif /* SERVERTEXT */
+
 /* ------------------------
  * SIGTERM
 */
-static void afp_asp_die(const int sig)
+static void afp_asp_die_handler(int sig);
+
+static void afp_asp_die_now(const int sig)
 {
     ASP asp = child->handle;
     asp_attention(asp, AFPATTN_SHUTDOWN);
@@ -86,7 +116,7 @@ static void afp_asp_die(const int sig)
 /* -----------------------------
  * SIGUSR1
  */
-static void afp_asp_timedown(int sig _U_)
+static void afp_asp_timedown_now(void)
 {
     struct sigaction	sv;
     struct itimerval	it;
@@ -100,11 +130,11 @@ static void afp_asp_timedown(int sig _U_)
 
     if (setitimer(ITIMER_REAL, &it, NULL) < 0) {
         LOG(log_error, logtype_afpd, "afp_timedown: setitimer: %s", strerror(errno));
-        afp_asp_die(EXITERR_SYS);
+        afp_asp_die_now(EXITERR_SYS);
     }
 
     memset(&sv, 0, sizeof(sv));
-    sv.sa_handler = afp_asp_die;
+    sv.sa_handler = afp_asp_die_handler;
     sigemptyset(&sv.sa_mask);
     sigaddset(&sv.sa_mask, SIGHUP);
     sigaddset(&sv.sa_mask, SIGTERM);
@@ -112,7 +142,7 @@ static void afp_asp_timedown(int sig _U_)
 
     if (sigaction(SIGALRM, &sv, NULL) < 0) {
         LOG(log_error, logtype_afpd, "afp_timedown: sigaction: %s", strerror(errno));
-        afp_asp_die(EXITERR_SYS);
+        afp_asp_die_now(EXITERR_SYS);
     }
 
     /* ignore myself */
@@ -123,7 +153,7 @@ static void afp_asp_timedown(int sig _U_)
     if (sigaction(SIGUSR1, &sv, NULL) < 0) {
         LOG(log_error, logtype_afpd, "afp_timedown: sigaction SIGUSR1: %s",
             strerror(errno));
-        afp_asp_die(EXITERR_SYS);
+        afp_asp_die_now(EXITERR_SYS);
     }
 }
 
@@ -135,16 +165,76 @@ extern volatile sig_atomic_t reload_request;
 static void afp_asp_reload(int sig _U_)
 {
     reload_request = 1;
+    atalk_sigpipe_notify();
 }
 
 /* ---------------------- */
 #ifdef SERVERTEXT
-static void afp_asp_getmesg(int sig _U_)
+static void afp_asp_getmesg_now(void)
 {
     readmessage(child);
     asp_attention(child->handle, AFPATTN_MESG | AFPATTN_TIME(5));
 }
 #endif /* SERVERTEXT */
+
+/* --- handlers: record and wake, nothing more ---
+ *
+ * All of these keep SA_RESTART, as the DSI handlers do. Clearing it would make
+ * every interruptible syscall in the child fail with EINTR: a SIGHUP config
+ * reload delivered while atp_sresp() blocks in netddp_sendto() would surface as
+ * asp_cmdreply() < 0, which the loop treats as a dead client, so a reload would
+ * terminate healthy sessions. The self-pipe is what makes the wake-up reliable,
+ * and it is sufficient because the loop only ever blocks in poll(). */
+static void afp_asp_die_handler(int sig)
+{
+    asp_die_pending = (sig == 0) ? SIGTERM : sig;
+    atalk_sigpipe_notify();
+}
+
+static void afp_asp_timedown(int sig _U_)
+{
+    asp_timedown_pending = 1;
+    atalk_sigpipe_notify();
+}
+
+#ifdef SERVERTEXT
+static void afp_asp_getmesg(int sig _U_)
+{
+    asp_getmesg_pending = 1;
+    atalk_sigpipe_notify();
+}
+#endif /* SERVERTEXT */
+
+/*!
+ * @brief Act on signals recorded while the loop was busy or waiting
+ */
+static void asp_process_deferred_signals(AFPObj *obj)
+{
+    if (asp_die_pending) {
+        int sig = asp_die_pending;
+        asp_die_pending = 0;
+        afp_asp_die_now(sig);            /* exits */
+    }
+
+    if (asp_timedown_pending) {
+        asp_timedown_pending = 0;
+        afp_asp_timedown_now();
+    }
+
+    if (reload_request) {
+        reload_request = 0;
+        load_afp_conf_vols(obj, LV_FORCE);
+    }
+
+#ifdef SERVERTEXT
+
+    if (asp_getmesg_pending) {
+        asp_getmesg_pending = 0;
+        afp_asp_getmesg_now();
+    }
+
+#endif /* SERVERTEXT */
+}
 
 /* ---------------------- */
 void afp_over_asp(AFPObj *obj)
@@ -153,8 +243,10 @@ void afp_over_asp(AFPObj *obj)
     struct sigaction  action;
     int		func,  reply = 0;
     int ccnt = 0;
+    int read_errors = 0;
+    unsigned long stray_packets = 0;
     AFPobj = obj;
-    obj->exit = afp_asp_die;
+    obj->exit = afp_asp_die_now;
     obj->reply = (int (*)()) asp_cmdreply;
     obj->attention = (int (*)(void *, AFPUserBytes)) asp_attention;
     child = obj;
@@ -167,6 +259,13 @@ void afp_over_asp(AFPObj *obj)
     obj->cnx_max = asp->asp_cnx_max;
     obj->ipc_fd  = asp->asp_ipc_fd;
     obj->hint_fd = asp->asp_hint_fd;
+
+    if (atalk_sigpipe_init() != 0) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: signal pipe: %s",
+            strerror(errno));
+        exit(EXITERR_SYS);
+    }
+
     /* install signal handlers
      * With ASP tickle handler is done in the parent process
     */
@@ -183,11 +282,11 @@ void afp_over_asp(AFPObj *obj)
 
     if (sigaction(SIGHUP, &action, NULL) < 0) {
         LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno));
-        afp_asp_die(EXITERR_SYS);
+        afp_asp_die_now(EXITERR_SYS);
     }
 
     /*  install SIGTERM */
-    action.sa_handler = afp_asp_die;
+    action.sa_handler = afp_asp_die_handler;
     sigemptyset(&action.sa_mask);
     sigaddset(&action.sa_mask, SIGHUP);
     sigaddset(&action.sa_mask, SIGUSR1);
@@ -198,7 +297,7 @@ void afp_over_asp(AFPObj *obj)
 
     if (sigaction(SIGTERM, &action, NULL) < 0) {
         LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno));
-        afp_asp_die(EXITERR_SYS);
+        afp_asp_die_now(EXITERR_SYS);
     }
 
 #ifdef SERVERTEXT
@@ -212,7 +311,7 @@ void afp_over_asp(AFPObj *obj)
 
     if (sigaction(SIGUSR2, &action, NULL) < 0) {
         LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno));
-        afp_asp_die(EXITERR_SYS);
+        afp_asp_die_now(EXITERR_SYS);
     }
 
 #endif /* SERVERTEXT */
@@ -228,7 +327,7 @@ void afp_over_asp(AFPObj *obj)
 
     if (sigaction(SIGUSR1, &action, NULL) < 0) {
         LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno));
-        afp_asp_die(EXITERR_SYS);
+        afp_asp_die_now(EXITERR_SYS);
     }
 
     /* Disable rfork caching for ASP sessions — the rfork cache tier-2
@@ -241,7 +340,7 @@ void afp_over_asp(AFPObj *obj)
 
     if (dircache_init(obj->options.dircachesize) != 0) {
         LOG(log_error, logtype_afpd, "afp_over_asp: dircache_init error");
-        afp_asp_die(EXITERR_SYS);
+        afp_asp_die_now(EXITERR_SYS);
     }
 
     LOG(log_info, logtype_afpd, "session from %u.%u:%u on %u.%u:%u",
@@ -251,10 +350,161 @@ void afp_over_asp(AFPObj *obj)
         atp_sockaddr(asp->asp_atp)->sat_addr.s_node,
         atp_sockaddr(asp->asp_atp)->sat_port);
 
-    while ((reply = asp_getrequest(asp))) {
-        if (reload_request) {
-            reload_request = 0;
-            load_afp_conf_vols(child, LV_FORCE);
+    while (1) {
+        /*
+         * The inner loop waits; the outer loop serves. Sections [A0]-[I] are the
+         * DSI loop's, so the two transports can be read against each other.
+         * DSI's [A] (stream data already buffered) and [B] (disconnected or
+         * dying) have no counterpart here: ASP has neither a stream buffer nor a
+         * reconnect state machine. [A1] is ASP's own.
+         */
+        while (1) {
+            /* [A0] Process deferred signals before any blocking I/O */
+            atalk_sigpipe_drain();
+            asp_process_deferred_signals(obj);
+            /* [A1] Release what the hints pruned. DSI does this after each
+             * command; ASP does it here so an idle session still sheds other
+             * clients' churn while it is receiving nothing but hints. */
+            dir_free_invalid_q();
+            /* [C] Setup poll fds — includes self-pipe for signal wake-up */
+            struct pollfd pfds[3];
+            int nfds = 0;
+            int hint_idx = -1;
+            int sigpipe_idx;
+            pfds[nfds].fd = atp_fileno(asp->asp_atp);
+            pfds[nfds].events = POLLIN;
+            nfds++;
+
+            if (obj->hint_fd >= 0) {
+                hint_idx = nfds;
+                pfds[nfds].fd = obj->hint_fd;
+                pfds[nfds].events = POLLIN;
+                nfds++;
+            }
+
+            sigpipe_idx = nfds;
+            pfds[nfds].fd = atalk_sigpipe_readfd();
+            pfds[nfds].events = POLLIN;
+            nfds++;
+            /* [D] BLOCK IN POLL */
+            int pollret = poll(pfds, nfds, -1);
+
+            /* [E] poll error handling */
+            if (pollret < 0) {
+                if (errno == EINTR) {
+                    continue;               /* re-check the flags at [A0] */
+                }
+
+                LOG(log_error, logtype_afpd, "afp_over_asp: poll: %s",
+                    strerror(errno));
+                afp_asp_close(obj);
+                return;
+            }
+
+            /* [E1] Signal pipe — drain and act, as [A0] would. Nothing can
+             * clear a bad one: a POLLHUP/POLLNVAL/POLLERR that no read
+             * consumes makes poll() return immediately for the rest of the
+             * session, and no deferred signal could ever wake the loop. */
+            if (pfds[sigpipe_idx].revents & (POLLNVAL | POLLERR | POLLHUP)) {
+                LOG(log_error, logtype_afpd,
+                    "afp_over_asp: signal pipe fd %d invalid, ending session",
+                    atalk_sigpipe_readfd());
+                afp_asp_close(obj);
+                return;
+            }
+
+            if (pfds[sigpipe_idx].revents & POLLIN) {
+                atalk_sigpipe_drain();
+                asp_process_deferred_signals(obj);
+            }
+
+            /* [F] Hint pipe handling — ahead of [H], so a sibling's
+             * invalidation cannot be overtaken by the command it invalidates.
+             * An invalid fd reports POLLNVAL forever and read() cannot clear
+             * it, so it is closed here rather than in the hint reader. */
+            if (hint_idx >= 0) {
+                if (pfds[hint_idx].revents & POLLNVAL) {
+                    LOG(log_error, logtype_afpd,
+                        "afp_over_asp: hint pipe fd %d invalid (POLLNVAL)",
+                        obj->hint_fd);
+                    close(obj->hint_fd);
+                    obj->hint_fd = -1;
+                } else if (pfds[hint_idx].revents & (POLLIN | POLLHUP | POLLERR)) {
+                    process_cache_hints(obj);
+                }
+            }
+
+            /* [G] ATP socket error handling */
+            if (pfds[0].revents & POLLNVAL) {
+                LOG(log_error, logtype_afpd,
+                    "afp_over_asp: ATP socket fd %d invalid (POLLNVAL)",
+                    atp_fileno(asp->asp_atp));
+                afp_asp_close(obj);
+                return;
+            }
+
+            /* [H] Request ready. DSI ends the session on POLLHUP/POLLERR
+             * because TCP makes them definitive; on a datagram socket they are
+             * not, so the read still runs — it returns the pending error, and
+             * the bounded read-error counter below ends the session if it
+             * persists. Logged so the cause is not invisible. */
+            if (pfds[0].revents & (POLLHUP | POLLERR)) {
+                LOG(log_debug, logtype_afpd,
+                    "afp_over_asp: ATP socket %s reported during wait",
+                    (pfds[0].revents & POLLERR) ? "error" : "hangup");
+            }
+
+            if (pfds[0].revents & (POLLIN | POLLHUP | POLLERR)) {
+                break;
+            }
+
+            /* [I] Only the hint or signal pipe had data — back to poll() */
+        }
+
+        /* Read one datagram, which cannot block: [H] established that the
+         * socket is readable and asp_getrequest() makes a single attempt. A
+         * datagram that yields no request comes back to the wait rather than
+         * parking the loop here with the signal and hint pipes unwatched, and
+         * that is the guarantee the deferred handlers rely on. */
+        reply = asp_getrequest(asp);
+
+        if (reply == ASP_NOREQUEST) {
+            continue;                       /* stray or replayed, not ours */
+        }
+
+        if (!reply) {
+            LOG(log_note, logtype_afpd,
+                "afp_over_asp: session ended without a close request");
+            afp_asp_close(obj);
+            return;
+        }
+
+        /* A read error repeats, so it is bounded rather than retried forever.
+         * The bound counts read errors only: sequence and session-id mismatches
+         * are stray or replayed packets, and they neither raise nor clear it,
+         * because a peer interleaving them with genuine errors would otherwise
+         * hold the counter below the limit indefinitely. Every failure is
+         * reported with its errno — this is a local fault, not remote noise, so
+         * it is not rate-limited and must not reach the stray-packet arm of the
+         * switch below. */
+        if (reply == ASP_ERR_READ) {
+            read_errors++;
+
+            if (read_errors >= ASP_MAX_READ_ERRORS) {
+                LOG(log_error, logtype_afpd,
+                    "afp_over_asp: read error %d of %d, ending session: %s",
+                    read_errors, ASP_MAX_READ_ERRORS, strerror(errno));
+                afp_asp_close(obj);
+                return;
+            }
+
+            LOG(log_note, logtype_afpd, "afp_over_asp: read error %d of %d: %s",
+                read_errors, ASP_MAX_READ_ERRORS, strerror(errno));
+            continue;
+        }
+
+        if (reply >= 0) {
+            read_errors = 0;
         }
 
         switch (reply) {
@@ -288,7 +538,7 @@ void afp_over_asp(AFPObj *obj)
 
             if (asp_cmdreply(asp, reply) < 0) {
                 LOG(log_error, logtype_afpd, "asp_cmdreply: %s", strerror(errno));
-                afp_asp_die(EXITERR_CLNT);
+                afp_asp_die_now(EXITERR_CLNT);
             }
 
             break;
@@ -312,17 +562,23 @@ void afp_over_asp(AFPObj *obj)
 
             if (asp_wrtreply(asp, reply) < 0) {
                 LOG(log_error, logtype_afpd, "asp_wrtreply: %s", strerror(errno));
-                afp_asp_die(EXITERR_CLNT);
+                afp_asp_die_now(EXITERR_CLNT);
             }
 
             break;
 
         default:
+
             /*
                * Bad asp packet.  Probably should have asp filter them,
                * since they are typically things like out-of-order packet.
                */
-            LOG(log_info, logtype_afpd, "main: asp_getrequest: %d", reply);
+            if ((stray_packets++ % ASP_STRAY_LOG_INTERVAL) == 0) {
+                LOG(log_info, logtype_afpd,
+                    "main: asp_getrequest: %d (%lu stray)", reply,
+                    stray_packets);
+            }
+
             break;
         }
 

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -98,63 +98,8 @@ static volatile sig_atomic_t getmesg_pending = 0;
 /* Non-static: also checked by afp_disconnect() in auth.c */
 volatile sig_atomic_t die_pending = 0;
 
-/*!
- * @brief Self-pipe for waking poll() from signal handlers.
- *
- * Signal handlers write a single byte to sigpipe_fd[1].  The read end
- * sigpipe_fd[0] is included in the poll() set so that the main loop
- * wakes up promptly even when SA_RESTART would otherwise cause poll()
- * to be restarted transparently.
- *
- * Although POSIX says poll() is not affected by SA_RESTART, some
- * platforms (Solaris, illumos) have historically restarted it.
- * The self-pipe makes wake-up behaviour portable and deterministic.
- */
-static int sigpipe_fd[2] = {-1, -1};
-
-static void sigpipe_init(void)
-{
-    if (pipe(sigpipe_fd) == -1) {
-        /* Fatal — without the pipe, signals cannot wake poll() reliably */
-        exit(EXITERR_SYS);
-    }
-
-    /* Both ends non-blocking: write so handlers never stall,
-     * read so sigpipe_drain() never blocks */
-    fcntl(sigpipe_fd[0], F_SETFL,
-          fcntl(sigpipe_fd[0], F_GETFL) | O_NONBLOCK);
-    fcntl(sigpipe_fd[1], F_SETFL,
-          fcntl(sigpipe_fd[1], F_GETFL) | O_NONBLOCK);
-    fcntl(sigpipe_fd[0], F_SETFD, FD_CLOEXEC);
-    fcntl(sigpipe_fd[1], F_SETFD, FD_CLOEXEC);
-}
-
-/*!
- * @brief Write a single byte to the self-pipe.
- *
- * Called from signal handlers — async-signal-safe.
- */
-static void sigpipe_notify(void)
-{
-    int saved_errno = errno;
-    char c = 1;
-    (void)write(sigpipe_fd[1], &c, 1);
-    errno = saved_errno;
-}
-
-/*!
- * @brief Drain all pending bytes from the self-pipe.
- *
- * Called from the main loop after poll() returns.
- */
-static void sigpipe_drain(void)
-{
-    char buf[64];
-
-    while (read(sigpipe_fd[0], buf, sizeof(buf)) > 0) {
-        /* drain */
-    }
-}
+/* The self-pipe that wakes poll() from a signal handler lives in
+ * libatalk/util/sigpipe.c and is shared with the ASP transport. */
 
 static void afp_dsi_close(AFPObj *obj)
 {
@@ -265,7 +210,7 @@ static void afp_dsi_die(int sig)
 static void afp_dsi_transfer_handler(int sig _U_)
 {
     transfer_pending = 1;
-    sigpipe_notify();
+    atalk_sigpipe_notify();
 }
 
 /*!
@@ -328,7 +273,7 @@ static void afp_dsi_die_handler(int sig);
 static void afp_dsi_timedown_handler(int sig _U_)
 {
     timedown_pending = 1;
-    sigpipe_notify();
+    atalk_sigpipe_notify();
 }
 
 /*!
@@ -392,7 +337,7 @@ volatile sig_atomic_t reload_request = 0;
 static void afp_dsi_reload(int sig _U_)
 {
     reload_request = 1;
-    sigpipe_notify();
+    atalk_sigpipe_notify();
 }
 
 /*!
@@ -403,14 +348,14 @@ static volatile sig_atomic_t debug_request = 0;
 static void afp_dsi_debug(int sig _U_)
 {
     debug_request = 1;
-    sigpipe_notify();
+    atalk_sigpipe_notify();
 }
 
 /*! SIGUSR2 handler — async-signal-safe */
 static void afp_dsi_getmesg_handler(int sig _U_)
 {
     getmesg_pending = 1;
-    sigpipe_notify();
+    atalk_sigpipe_notify();
 }
 
 /*!
@@ -432,7 +377,7 @@ static void handle_getmesg(AFPObj *obj)
 static void afp_dsi_die_handler(int sig)
 {
     die_pending = sig ? sig : -1;
-    sigpipe_notify();
+    atalk_sigpipe_notify();
 }
 
 /*!
@@ -447,7 +392,7 @@ static void alarm_handler(int sig _U_)
     /* we have to restart the timer because some libraries may use alarm() */
     setitimer(ITIMER_REAL, &dsi->timer, NULL);
     alarm_pending = 1;
-    sigpipe_notify();
+    atalk_sigpipe_notify();
 }
 
 /*!
@@ -768,14 +713,20 @@ void afp_over_dsi(AFPObj *obj)
     int flag = 1;
     setsockopt(dsi->socket, SOL_TCP, TCP_NODELAY, &flag, sizeof(flag));
     ipc_child_state(obj, DSI_RUNNING);
+
     /* Initialise self-pipe for signal-to-mainloop notification */
-    sigpipe_init();
+    if (atalk_sigpipe_init() != 0) {
+        /* Fatal — without the pipe, signals cannot wake poll() reliably */
+        LOG(log_error, logtype_afpd, "afp_over_dsi: signal pipe: %s",
+            strerror(errno));
+        exit(EXITERR_SYS);
+    }
 
     /* get stuck here until the end */
     while (1) {
         while (1) {
             /* [A0] Process deferred signals before any blocking I/O */
-            sigpipe_drain();
+            atalk_sigpipe_drain();
 
             if (process_deferred_signals(obj)) {
                 goto restart_outer;
@@ -812,7 +763,7 @@ void afp_over_dsi(AFPObj *obj)
             }
 
             int sigpipe_idx = nfds;
-            pfds[nfds].fd = sigpipe_fd[0];
+            pfds[nfds].fd = atalk_sigpipe_readfd();
             pfds[nfds].events = POLLIN;
             nfds++;
             /* Grant the idle worker the poll window — only if work is
@@ -835,9 +786,19 @@ void afp_over_dsi(AFPObj *obj)
                 break;
             }
 
-            /* [E1] Signal pipe — drain and loop back to process signals at [A0] */
+            /* [E1] Signal pipe — drain and loop back to process signals at [A0].
+             * Nothing can clear a bad self-pipe, and a POLLHUP/POLLNVAL/POLLERR
+             * that no read consumes makes poll() return immediately for the rest
+             * of the session, so the loop would spin with no way to be woken. */
+            if (pfds[sigpipe_idx].revents & (POLLNVAL | POLLERR | POLLHUP)) {
+                LOG(log_error, logtype_afpd,
+                    "afp_over_dsi: signal pipe fd %d unusable, ending session",
+                    atalk_sigpipe_readfd());
+                break;
+            }
+
             if (pfds[sigpipe_idx].revents & POLLIN) {
-                sigpipe_drain();
+                atalk_sigpipe_drain();
 
                 if (process_deferred_signals(obj)) {
                     goto restart_outer;
@@ -924,7 +885,7 @@ void afp_over_dsi(AFPObj *obj)
             while (dsi->flags & DSI_DISCONNECTED) {
                 /* gets interrupted by SIGALRM or SIGURG */
                 pause();
-                sigpipe_drain();
+                atalk_sigpipe_drain();
 
                 if (process_deferred_signals(obj)) {
                     break;

--- a/include/atalk/asp.h
+++ b/include/atalk/asp.h
@@ -40,6 +40,12 @@
 #define ASP_DATASIZ       (ASP_CMDSIZ*ASP_MAXPACKETS)
 #define ASP_DATAMAXSIZ    ((ASP_CMDSIZ + ASP_HDRSIZ)*ASP_MAXPACKETS)
 
+/* asp_getrequest() results: >0 the command byte, 0 session ended */
+#define ASP_ERR_READ      (-1)  /*!< read failed, errno set */
+#define ASP_ERR_SEQ       (-2)  /*!< sequence number mismatch */
+#define ASP_ERR_SID       (-3)  /*!< session id mismatch */
+#define ASP_NOREQUEST     (-4)  /*!< nothing complete yet, wait again */
+
 typedef struct ASP {
     ATP			asp_atp;
     struct sockaddr_at	asp_sat;

--- a/include/atalk/atp.h
+++ b/include/atalk/atp.h
@@ -83,6 +83,9 @@ struct atphdr {
 
 #define ATP_TRIES_INFINITE	-1	/*!< for atp_sreq, etc */
 
+#define ATP_MAXQUEUE	8	/*!< bound on unmatched incoming packets */
+#define ATP_MAXRESP	8	/*!< response packets per transaction */
+
 struct atpxobuf {
     uint16_t		atpxo_tid;
     struct timeval	atpxo_tv;
@@ -115,7 +118,7 @@ struct atp_handle {
     uint8_t		atph_rbitmap;		/*!< bitmap for request */
     struct atpbuf	*atph_reqpkt;		/*!< last request packet */
     struct timeval	atph_reqtv;		/*!< when we last sent request */
-    struct atpbuf	*atph_resppkt[8];	/*!< response to request */
+    struct atpbuf	*atph_resppkt[ATP_MAXRESP];	/*!< response to request */
 };
 
 typedef struct atp_handle *ATP;
@@ -190,6 +193,8 @@ extern int		atp_sreq(ATP, struct atp_block *, int, uint8_t);
 extern int		atp_rresp(ATP, struct atp_block *);
 extern int		atp_rsel(ATP, struct sockaddr_at *, int);
 extern int		atp_rreq(ATP, struct atp_block *);
+extern int		atp_rreq_try(ATP,
+                          struct atp_block *);	/*!< 1 got, 0 none yet, -1 error */
 extern int		atp_sresp(ATP, struct atp_block *);
 
 #endif  /* NO_DDP */

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -158,6 +158,15 @@ extern int lock_reg(int fd, int cmd, int type, off_t offest, int whence,
     lock_reg((fd), F_SETLK, F_UNLCK, (offset), (whence), (len))
 
 /******************************************************************
+ * sigpipe.c
+ ******************************************************************/
+
+extern int atalk_sigpipe_init(void);
+extern int atalk_sigpipe_readfd(void);
+extern void atalk_sigpipe_notify(void);
+extern void atalk_sigpipe_drain(void);
+
+/******************************************************************
  * socket.c
  ******************************************************************/
 

--- a/libatalk/asp/asp_getreq.c
+++ b/libatalk/asp/asp_getreq.c
@@ -34,31 +34,67 @@
 #include <atalk/atp.h>
 #include <atalk/asp.h>
 
+/*
+ * One attempt only: ASP_NOREQUEST means a datagram was consumed but no request
+ * came of it, and the caller should wait for the socket to be readable again
+ * rather than block here. Callers driving other descriptors in the same loop
+ * depend on that, so the wait stays in one place.
+ *
+ * cmdbuf is char, which is signed on the usual ABIs, so every byte read out of
+ * it for comparison or return needs the unsigned cast: without it a session id
+ * of 0x80 or above never matches asp_sid, and a function byte of 0xFF/0xFE/0xFD
+ * would be returned as one of the negative result codes.
+ */
 int asp_getrequest(ASP asp)
 {
     struct atp_block	atpb;
     uint16_t		seq;
+    int			rc;
     asp->asp_sat.sat_port = ATADDR_ANYPORT;
     atpb.atp_saddr = &asp->asp_sat;
     atpb.atp_rreqdata = asp->cmdbuf;
     atpb.atp_rreqdlen = sizeof(asp->cmdbuf);
+    rc = atp_rreq_try(asp->asp_atp, &atpb);
 
-    if (atp_rreq(asp->asp_atp, &atpb) < 0) {
-        return -1;
+    if (rc < 0) {
+        return ASP_ERR_READ;
     }
 
-    asp->cmdlen = atpb.atp_rreqdlen - 4;
+    if (rc == 0) {
+        return ASP_NOREQUEST;
+    }
+
+    /* cmdlen is size_t, so a request shorter than the ASP header would wrap it
+     * to near SIZE_MAX and be passed to the command handlers as their input
+     * length. Such a packet is malformed; discard it. */
+    if (atpb.atp_rreqdlen < ASP_HDRSIZ) {
+        return ASP_NOREQUEST;
+    }
+
+    asp->cmdlen = (size_t) atpb.atp_rreqdlen - ASP_HDRSIZ;
+
+    /* The header alone is a valid frame for the control functions, but not for
+     * the two that carry an AFP call: the dispatcher reads commands[0] to pick
+     * it, so with no payload it would select the call from whatever the previous
+     * request left in the buffer and run it with an input length of 0. */
+    if (asp->cmdlen < 1
+            && ((unsigned char) asp->cmdbuf[0] == ASPFUNC_CMD
+                || (unsigned char) asp->cmdbuf[0] == ASPFUNC_WRITE)) {
+        return ASP_NOREQUEST;
+    }
+
     asp->read_count += asp->cmdlen;
     memcpy(&seq, asp->cmdbuf + 2, sizeof(seq));
     seq = ntohs(seq);
 
-    if ((asp->cmdbuf[0] != ASPFUNC_CLOSE) && (seq != asp->asp_seq)) {
-        return -2;
+    if (((unsigned char) asp->cmdbuf[0] != ASPFUNC_CLOSE)
+            && (seq != asp->asp_seq)) {
+        return ASP_ERR_SEQ;
     }
 
-    if (asp->cmdbuf[1] != asp->asp_sid) {
-        return -3;
+    if ((unsigned char) asp->cmdbuf[1] != asp->asp_sid) {
+        return ASP_ERR_SID;
     }
 
-    return asp->cmdbuf[0]; /* the command */
+    return (unsigned char) asp->cmdbuf[0]; /* the command */
 }

--- a/libatalk/atp/atp_bufs.c
+++ b/libatalk/atp/atp_bufs.c
@@ -50,6 +50,12 @@
 #define			N_MORE_BUFS		10
 
 static struct atpbuf 	*free_list = NULL;	/*!< free buffers */
+/* Bases of the malloc'd chunks free_list is carved from. free_list holds
+ * interior pointers in hand-back order, so the bases cannot be recovered from
+ * it and have to be recorded to be freed. */
+static char		**chunks = NULL;
+static size_t		nchunks = 0;
+static size_t		chunkcap = 0;
 
 #ifdef EBUG
 static int		numbufs = 0;
@@ -71,6 +77,21 @@ static int more_bufs(void)
         return -1;
     }
 
+    if (nchunks == chunkcap) {
+        size_t newcap = (chunkcap == 0) ? 4 : chunkcap * 2;
+        char **grown = realloc(chunks, newcap * sizeof(*chunks));
+
+        if (grown == NULL) {
+            free(mem);
+            errno = ENOBUFS;
+            return -1;
+        }
+
+        chunks = grown;
+        chunkcap = newcap;
+    }
+
+    chunks[nchunks++] = mem;
     /* now split into separate bufs
     */
     bp = free_list = (struct atpbuf *) mem;
@@ -144,6 +165,23 @@ struct atpbuf *atp_alloc_buf(void)
     return bp;
 }
 
+
+/*
+ * Release every chunk the pool has taken. Only valid once no buffer is still
+ * in use anywhere, since it frees the memory the handed-out buffers live in;
+ * a session process simply exits instead of calling this.
+ */
+void atp_bufs_release(void)
+{
+    for (size_t i = 0; i < nchunks; i++) {
+        free(chunks[i]);
+    }
+
+    free(chunks);
+    chunks = NULL;
+    nchunks = chunkcap = 0;
+    free_list = NULL;
+}
 
 int atp_free_buf(struct atpbuf *bp)
 {

--- a/libatalk/atp/atp_internals.h
+++ b/libatalk/atp/atp_internals.h
@@ -38,6 +38,7 @@
 extern struct atpbuf *atp_alloc_buf(void);
 extern void atp_print_bufuse(ATP, char *);
 extern int atp_free_buf(struct atpbuf *);
+extern void atp_bufs_release(void);
 
 /* in atp_packet.c */
 extern int at_addr_eq(struct sockaddr_at *, struct sockaddr_at *);
@@ -47,6 +48,7 @@ extern void atp_build_resp_packet(struct atpbuf *, uint16_t, uint8_t,
                                   struct atp_block *, uint8_t);
 extern int atp_recv_atp(ATP, struct sockaddr_at *, uint8_t *, uint16_t,
                         char *, int);
+extern void atp_queue_push(ATP, struct atpbuf *);
 #ifdef EBUG
 extern void atp_print_addr(char *, struct sockaddr_at *);
 #endif /* EBUG */

--- a/libatalk/atp/atp_packet.c
+++ b/libatalk/atp/atp_packet.c
@@ -143,6 +143,47 @@ void atp_build_resp_packet(struct atpbuf *pktbuf,
 }
 
 
+/*
+ * Push a packet onto the unmatched-receive queue, evicting the oldest entry
+ * once the queue is full.
+ *
+ * Nothing ages this queue: an entry is removed only by a receive that matches
+ * it, or by atp_close(). A stale response to a timed-out transaction or another
+ * node's traffic can therefore sit here indefinitely, so the queue is bounded
+ * and the oldest entry is evicted, which a datagram protocol is free to do.
+ * Every push goes through here so that both callers agree on which packet is
+ * sacrificed: never the one just received, which is the only one a caller may
+ * still be waiting for.
+ */
+void atp_queue_push(ATP ah, struct atpbuf *buf)
+{
+    struct atpbuf *prev = NULL;
+    int queued = 0;
+
+    /* one pass: count, and remember the entry before the tail */
+    for (struct atpbuf *cq = ah->atph_queue; cq != NULL; cq = cq->atpbuf_next) {
+        queued++;
+
+        if (cq->atpbuf_next != NULL && cq->atpbuf_next->atpbuf_next == NULL) {
+            prev = cq;
+        }
+    }
+
+    /* prev is the entry before the tail, so it is set whenever the queue holds
+     * two or more — which the bound guarantees, ATP_MAXQUEUE being above one. */
+    if (queued >= ATP_MAXQUEUE && prev != NULL) {
+#ifdef EBUG
+        printf("<%d> incoming queue full, dropping oldest\n", getpid());
+#endif /* EBUG */
+        atp_free_buf(prev->atpbuf_next);
+        prev->atpbuf_next = NULL;
+    }
+
+    buf->atpbuf_next = ah->atph_queue;
+    ah->atph_queue = buf;
+}
+
+
 int
 atp_recv_atp(ATP ah,
              struct sockaddr_at *fromaddr,
@@ -190,7 +231,7 @@ atp_recv_atp(ATP ah,
         putchar('\n');
 #endif /* EBUG */
 
-        if (((tid & ahdr.atphd_tid) == ahdr.atphd_tid) &&
+        if (rfunc != 0 && ((tid & ahdr.atphd_tid) == ahdr.atphd_tid) &&
                 ((*func & rfunc) == rfunc)
                 && at_addr_eq(fromaddr, &cq->atpbuf_addr)) {
             break;
@@ -208,7 +249,7 @@ atp_recv_atp(ATP ah,
         /* remove packet from queue and free buffer
         */
         if (pq == NULL) {
-            ah->atph_queue = NULL;
+            ah->atph_queue = cq->atpbuf_next;
         } else {
             pq->atpbuf_next = cq->atpbuf_next;
         }
@@ -242,10 +283,9 @@ atp_recv_atp(ATP ah,
             return -1;
         }
 
-        memcpy(&ahdr, rbuf + 1, sizeof(struct atphdr));
-
         if (recvlen >= ATP_HDRSIZE && *rbuf == DDPTYPE_ATP) {
             /* this is a valid ATP packet -- check for a match */
+            memcpy(&ahdr, rbuf + 1, sizeof(struct atphdr));
             rfunc = ahdr.atphd_ctrlinfo & ATP_FUNCMASK;
             rtid = ahdr.atphd_tid;
 #ifdef EBUG
@@ -256,7 +296,16 @@ atp_recv_atp(ATP ah,
             bprint(rbuf, recvlen);
 #endif /* EBUG */
 
-            if (rfunc == ATP_TREL) {
+            if (rfunc == 0) {
+                /* No function bits set. Such a packet satisfies every
+                 * ((*func & rfunc) == rfunc) test, so it would be handed back
+                 * as the response to whatever transaction asked first, and
+                 * once queued no request could ever claim it. Discard it here
+                 * rather than let it reach the queue. */
+#ifdef EBUG
+                printf("<%d> discarding packet with no function bits\n", getpid());
+#endif /* EBUG */
+            } else if (rfunc == ATP_TREL) {
                 /* remove response from sent list */
                 for (pq = NULL, cq = ah->atph_sent; cq != NULL;
                         pq = cq, cq = cq->atpbuf_next) {
@@ -304,9 +353,9 @@ atp_recv_atp(ATP ah,
 
                 memcpy(&inbuf->atpbuf_addr, &faddr,
                        sizeof(struct sockaddr_at));
-                inbuf->atpbuf_next = ah->atph_queue;
                 inbuf->atpbuf_dlen = (size_t) recvlen;
                 memcpy(inbuf->atpbuf_info.atpbuf_data, rbuf, recvlen);
+                atp_queue_push(ah, inbuf);
             }
         }
 

--- a/libatalk/atp/atp_rreq.c
+++ b/libatalk/atp/atp_rreq.c
@@ -43,12 +43,16 @@
 #endif /* EBUG */
 
 
-/*!
- * @brief wait for a transaction service request
- * @param ah open atp handle
- * @param atpb parameter block
+/*
+ * atp_rreq() waits for a request, consuming as many datagrams as it takes.
+ * atp_rreq_try() makes exactly one attempt, so a caller that has already
+ * established the socket is readable never blocks in it, and stays in charge of
+ * its own wait. That matters for a caller driving other descriptors in the same
+ * loop: a readable socket does not promise a request, because the datagram may
+ * belong to another transaction or another node, and the waiting caller would
+ * otherwise be parked here with those descriptors unwatched.
  */
-int atp_rreq(ATP ah, struct atp_block *atpb)
+int atp_rreq_try(ATP ah, struct atp_block *atpb)
 {
     struct atpbuf	*req_buf;	/* for receiving request packet */
     struct atphdr	req_hdr;	/* request header overlay */
@@ -60,16 +64,17 @@ int atp_rreq(ATP ah, struct atp_block *atpb)
 #ifdef EBUG
     atp_print_bufuse(ah, "atp_rreq");
 #endif /* EBUG */
+    rc = atp_rsel(ah, atpb->atp_saddr, ATP_TREQ);
 
-    while ((rc = atp_rsel(ah, atpb->atp_saddr, ATP_TREQ)) == 0) {
-        ;
+    if (rc == 0) {
+        return 0;		/* consumed, but not a new request */
     }
 
     if (rc != ATP_TREQ) {
 #ifdef EBUG
         printf("<%d> atp_rreq: atp_rsel returns err %d\n", getpid(), rc);
 #endif /* EBUG */
-        return rc;
+        return -1;
     }
 
     /* allocate a buffer for receiving request
@@ -111,5 +116,21 @@ int atp_rreq(ATP ah, struct atp_block *atpb)
            recvlen - ATP_HDRSIZE);
     atpb->atp_bitmap = req_hdr.atphd_bitmap;
     atp_free_buf(req_buf);
-    return 0;
+    return 1;
+}
+
+/*!
+ * @brief wait for a transaction service request
+ * @param ah open atp handle
+ * @param atpb parameter block
+ */
+int atp_rreq(ATP ah, struct atp_block *atpb)
+{
+    int rc;
+
+    while ((rc = atp_rreq_try(ah, atpb)) == 0) {
+        ;
+    }
+
+    return (rc == 1) ? 0 : rc;
 }

--- a/libatalk/atp/atp_rsel.c
+++ b/libatalk/atp/atp_rsel.c
@@ -70,6 +70,24 @@ resend_request(ATP ah)
     return 0;
 }
 
+/*
+ * A response arrived that does not complete the transaction. Report "keep
+ * waiting" only while retries remain: every caller loops while this returns 0,
+ * and once resend_request() has spent the last retry `requesting` goes false,
+ * which drops the select() timeout and leaves the next receive blocking with
+ * nothing to break it. An exhausted transaction must therefore fail rather than
+ * ask the caller to wait again.
+ */
+static int atp_resp_incomplete(ATP ah)
+{
+    if (ah->atph_reqtries > 0 || ah->atph_reqtries == ATP_TRIES_INFINITE) {
+        return 0;
+    }
+
+    errno = ETIMEDOUT;
+    return -1;
+}
+
 /*!
  * @brief Receive ATP packets
  * @param ah open atp handle
@@ -264,8 +282,7 @@ timeout :
             /* new request -- queue it and return */
             memcpy(&abuf->atpbuf_addr, &saddr, sizeof(struct sockaddr_at));
             memcpy(faddr, &saddr, sizeof(struct sockaddr_at));
-            abuf->atpbuf_next = ah->atph_queue;
-            ah->atph_queue = abuf;
+            atp_queue_push(ah, abuf);
             return ATP_TREQ;
         } else {
             atp_free_buf(abuf);
@@ -274,10 +291,26 @@ timeout :
     }
 
     /*
-     * we got a response: update bitmap
+     * we got a response: update bitmap. A response with no request outstanding
+     * has nothing to match against, and reading atph_reqpkt would dereference
+     * NULL.
      */
+    if (ah->atph_reqpkt == NULL) {
+        atp_free_buf(abuf);
+        return atp_resp_incomplete(ah);
+    }
+
     memcpy(&req_hdr, ah->atph_reqpkt->atpbuf_info.atpbuf_data + 1,
            sizeof(struct atphdr));
+
+    /* atphd_bitmap is a sequence number straight off the wire. Out of range it
+     * would index atph_resppkt[] out of bounds, and the shift below is
+     * undefined past the width of int — on the usual targets the count is
+     * masked, so 32, 64, ... alias onto bits the bitmap test accepts. */
+    if (resp_hdr.atphd_bitmap >= ATP_MAXRESP) {
+        atp_free_buf(abuf);
+        return atp_resp_incomplete(ah);
+    }
 
     if (requesting && ah->atph_rbitmap & (1 << resp_hdr.atphd_bitmap)
             && req_hdr.atphd_tid == resp_hdr.atphd_tid) {
@@ -316,7 +349,10 @@ timeout :
                               (struct sockaddr *) &ah->atph_reqpkt->atpbuf_addr,
                               sizeof(struct sockaddr_at)) !=
                     ah->atph_reqpkt->atpbuf_dlen) {
-                atp_free_buf(abuf);
+                /* abuf is owned by atph_resppkt[] from here on: the response
+                 * was accepted and only the resend failed. Freeing it would
+                 * leave a dangling slot for atp_sreq/atp_rresp/atp_close to
+                 * push onto the buffer free list a second time. */
                 return -1;
             }
         }
@@ -363,13 +399,7 @@ timeout :
     }
 
     if (ah->atph_rbitmap != 0) {
-        if (ah->atph_reqtries > 0
-                || ah->atph_reqtries == ATP_TRIES_INFINITE) {
-            return 0;
-        } else {
-            errno = ETIMEDOUT;
-            return -1;
-        }
+        return atp_resp_incomplete(ah);
     }
 
     memcpy(faddr, &saddr, sizeof(struct sockaddr_at));

--- a/libatalk/dsi/dsi_stream.c
+++ b/libatalk/dsi/dsi_stream.c
@@ -731,6 +731,18 @@ int dsi_stream_receive(DSI *dsi)
         return 0;
     }
 
+    /* Every check above is an upper bound. A command frame also needs a lower
+     * one: the dispatcher reads commands[0] to pick the AFP call, so a
+     * zero-length payload would select it from whatever the previous request
+     * left in the buffer and then run it with an input length of 0. */
+    if ((dsi->header.dsi_command == DSIFUNC_CMD
+            || dsi->header.dsi_command == DSIFUNC_WRITE)
+            && dsi_len < 1) {
+        LOG(log_error, logtype_dsi,
+            "dsi_stream_receive: command frame carries no AFP function byte");
+        return 0;
+    }
+
     dsi->cmdlen = dsi_len;
 
     /* Receiving DSIWrite data is done in AFP function, not here */

--- a/libatalk/util/meson.build
+++ b/libatalk/util/meson.build
@@ -15,6 +15,7 @@ util_sources = [
     'server_child.c',
     'server_ipc.c',
     'server_lock.c',
+    'sigpipe.c',
     'socket.c',
     'strdicasecmp.c',
     'unix.c',

--- a/libatalk/util/sigpipe.c
+++ b/libatalk/util/sigpipe.c
@@ -1,0 +1,92 @@
+/*
+  Copyright (c) 2026 Andy Lemin (andylemin)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+/*
+ * Self-pipe for waking a poll() loop from a signal handler.
+ *
+ * A handler records what happened in a volatile sig_atomic_t and calls
+ * atalk_sigpipe_notify(); the loop keeps the read end in its poll() set, so the
+ * wake-up does not depend on whether the platform restarts poll() for a handler
+ * installed with SA_RESTART. POSIX says poll() is not affected by SA_RESTART,
+ * but some platforms have historically restarted it.
+ *
+ * This only works for a loop whose only blocking point is poll(). A loop that
+ * blocks in a read the pipe is not part of will not be woken.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <atalk/util.h>
+
+static int sigpipe_fd[2] = { -1, -1 };
+
+int atalk_sigpipe_init(void)
+{
+    if (sigpipe_fd[0] >= 0) {
+        return 0;                       /* already set up for this process */
+    }
+
+    if (pipe(sigpipe_fd) == -1) {
+        sigpipe_fd[0] = sigpipe_fd[1] = -1;
+        return -1;
+    }
+
+    /* Write end non-blocking so a handler never stalls, read end so the drain
+     * never blocks. A full pipe means a wake-up is already pending, which is
+     * all the loop needs to know. Leaving a half-configured pipe in place would
+     * be worse than none: a blocking write end stalls inside a handler, and a
+     * blocking read end makes the drain wait for a signal that never comes. */
+    for (int i = 0; i < 2; i++) {
+        if (setnonblock(sigpipe_fd[i], 1) != 0
+                || fcntl(sigpipe_fd[i], F_SETFD, FD_CLOEXEC) == -1) {
+            int saved_errno = errno;
+            close(sigpipe_fd[0]);
+            close(sigpipe_fd[1]);
+            sigpipe_fd[0] = sigpipe_fd[1] = -1;
+            errno = saved_errno;
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+int atalk_sigpipe_readfd(void)
+{
+    return sigpipe_fd[0];
+}
+
+/* async-signal-safe: write() only, errno preserved */
+void atalk_sigpipe_notify(void)
+{
+    int saved_errno = errno;
+    char c = 1;
+    (void) write(sigpipe_fd[1], &c, 1);
+    errno = saved_errno;
+}
+
+void atalk_sigpipe_drain(void)
+{
+    char buf[64];
+
+    while (read(sigpipe_fd[0], buf, sizeof(buf)) > 0) {
+        /* drain */
+    }
+}

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -9,6 +9,14 @@ test_internal_deps = [] + afpd_common_internal_deps
 test_link_args = [] + afpd_common_link_args
 test_includes = [] + afpd_common_includes
 
+# ATP queue tests reach the library-internal push helper
+afpd_test_extra_sources = []
+
+if enable_appletalk
+    test_includes += include_directories('../../libatalk/atp')
+    afpd_test_extra_sources += files('subtests_atp.c')
+endif
+
 if build_afpd_tests
 
     # For dtrace probes we need to invoke dtrace on all input files, before
@@ -98,6 +106,7 @@ if build_afpd_tests
         'subtests_conf.c',
         'subtests_lock.c',
         'subtests_pfd.c',
+        afpd_test_extra_sources,
         include_directories: test_includes,
         objects: afpdtest_objects,
         link_whole: afpdtest_link_whole,

--- a/test/afpd/subtests_atp.c
+++ b/test/afpd/subtests_atp.c
@@ -1,0 +1,191 @@
+/*
+  Copyright (c) 2026 Andy Lemin (andylemin)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+/*
+ * ATP unmatched-receive queue tests.
+ *
+ * The queue holds packets no request has claimed. It is bounded, so a full
+ * queue has to sacrifice something, and which packet it sacrifices decides
+ * whether a session survives: the packet just received is the only one a
+ * caller may still be waiting for, so it must never be the victim. Dropping
+ * it instead of an older entry wedges the session permanently, because the
+ * entries already there are the ones nothing can claim.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#ifndef NO_DDP
+
+#include <string.h>
+
+#include <netatalk/at.h>
+#include <atalk/atp.h>
+
+#include "atp_internals.h"
+#include "subtests_atp.h"
+
+/*
+ * Buffers come from the library pool, so the tests exercise the same ownership
+ * the transport does — atp_queue_push() releases what it evicts through
+ * atp_free_buf(), which returns it to that pool rather than freeing it. Each
+ * test calls atp_bufs_release() when it is done so the pool's chunks are freed
+ * and nothing of this file's is left on the free list for a later test to be
+ * handed.
+ */
+static struct atpbuf *atp_test_alloc(char tag)
+{
+    struct atpbuf *buf = atp_alloc_buf();
+
+    if (buf == NULL) {
+        return NULL;
+    }
+
+    memset(buf, 0, sizeof(*buf));
+    buf->atpbuf_dlen = 1;
+    buf->atpbuf_info.atpbuf_data[0] = tag;      /* recognise it after the push */
+    return buf;
+}
+
+static int atp_test_queue_len(struct atp_handle *ah)
+{
+    int n = 0;
+
+    for (struct atpbuf *q = ah->atph_queue; q != NULL; q = q->atpbuf_next) {
+        n++;
+    }
+
+    return n;
+}
+
+static void atp_test_queue_free(struct atp_handle *ah)
+{
+    while (ah->atph_queue != NULL) {
+        struct atpbuf *next = ah->atph_queue->atpbuf_next;
+        atp_free_buf(ah->atph_queue);
+        ah->atph_queue = next;
+    }
+
+    ah->atph_queue = NULL;
+    atp_bufs_release();
+}
+
+/*
+ * Fill the queue to the bound, then push one more. The queue must stay at the
+ * bound, and the entry that goes is the oldest — the tail, since pushes are at
+ * the head.
+ */
+int utest_atp_queue_push_evicts_oldest(void)
+{
+    struct atp_handle ah;
+    struct atpbuf *buf;
+    struct atpbuf *tail;
+    int rc = 0;
+    memset(&ah, 0, sizeof(ah));
+
+    /* 'a' is pushed first, so it is the oldest and should be the one evicted */
+    for (int i = 0; i < ATP_MAXQUEUE; i++) {
+        if ((buf = atp_test_alloc((char)('a' + i))) == NULL) {
+            rc = 1;
+            goto done;
+        }
+
+        atp_queue_push(&ah, buf);
+    }
+
+    if (atp_test_queue_len(&ah) != ATP_MAXQUEUE) {
+        rc = 2;
+        goto done;
+    }
+
+    /* the oldest is the tail */
+    for (tail = ah.atph_queue; tail->atpbuf_next != NULL;
+            tail = tail->atpbuf_next) {
+        /* walk */
+    }
+
+    if (tail->atpbuf_info.atpbuf_data[0] != 'a') {
+        rc = 3;
+        goto done;
+    }
+
+    if ((buf = atp_test_alloc('Z')) == NULL) {
+        rc = 4;
+        goto done;
+    }
+
+    atp_queue_push(&ah, buf);
+
+    if (atp_test_queue_len(&ah) != ATP_MAXQUEUE) {
+        rc = 5;                 /* bound not held */
+        goto done;
+    }
+
+    for (struct atpbuf *q = ah.atph_queue; q != NULL; q = q->atpbuf_next) {
+        if (q->atpbuf_info.atpbuf_data[0] == 'a') {
+            rc = 6;             /* oldest was not the victim */
+            goto done;
+        }
+    }
+
+done:
+    atp_test_queue_free(&ah);
+    return rc;
+}
+
+/*
+ * The packet just pushed must be present and reachable afterwards. A full
+ * queue that discards the incoming packet instead loses every subsequent
+ * request, which no retransmission can recover from because the queue never
+ * drains on its own.
+ */
+int utest_atp_queue_push_keeps_newest(void)
+{
+    struct atp_handle ah;
+    struct atpbuf *buf;
+    int rc = 0;
+    memset(&ah, 0, sizeof(ah));
+
+    /* deliberately overfill: every push must still surface its own packet */
+    for (int i = 0; i < ATP_MAXQUEUE * 3; i++) {
+        if ((buf = atp_test_alloc('Z')) == NULL) {
+            rc = 1;
+            goto done;
+        }
+
+        atp_queue_push(&ah, buf);
+
+        if (ah.atph_queue != buf) {
+            rc = 2;             /* newest not at the head */
+            goto done;
+        }
+
+        if (ah.atph_queue->atpbuf_info.atpbuf_data[0] != 'Z') {
+            rc = 3;
+            goto done;
+        }
+
+        if (atp_test_queue_len(&ah) > ATP_MAXQUEUE) {
+            rc = 4;             /* bound exceeded */
+            goto done;
+        }
+    }
+
+done:
+    atp_test_queue_free(&ah);
+    return rc;
+}
+
+#endif /* NO_DDP */

--- a/test/afpd/subtests_atp.h
+++ b/test/afpd/subtests_atp.h
@@ -1,0 +1,7 @@
+#ifndef NETATALK_TEST_SUBTESTS_ATP_H
+#define NETATALK_TEST_SUBTESTS_ATP_H
+
+int utest_atp_queue_push_evicts_oldest(void);
+int utest_atp_queue_push_keeps_newest(void);
+
+#endif /* NETATALK_TEST_SUBTESTS_ATP_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -46,6 +46,9 @@
 #include "subtests_conf.h"
 #include "subtests_lock.h"
 #include "subtests_pfd.h"
+#ifndef NO_DDP
+#include "subtests_atp.h"
+#endif /* NO_DDP */
 #include "test.h"
 #include "test_capabilities.h"
 #include "volume.h"
@@ -334,6 +337,19 @@ static int utest_dsi_receive_rejects_overquantum_cmd(void)
     return ret == 0 ? 0 : -1;
 }
 
+/* A command frame with no payload at all: the dispatcher reads commands[0] to
+ * pick the AFP call, so it would take it from whatever the previous request
+ * left behind. Every other length check here is an upper bound. */
+static int utest_dsi_receive_rejects_zero_length_cmd(void)
+{
+    DSI dsi;
+    uint8_t payload[1] = { AFP_LOGOUT };
+    int ret;
+    ret = dsi_test_receive(DSIFUNC_CMD, 0, 0, payload, 0, 4096, &dsi);
+    dsi_test_cleanup(&dsi);
+    return ret == 0 ? 0 : -1;
+}
+
 static int utest_dsi_receive_valid_cmd(void)
 {
     uint8_t payload[2] = {AFP_LOGIN, 0};
@@ -462,6 +478,14 @@ int main(int argc, char *argv[])
              "DSI receive rejects payload larger than server quantum");
     TEST_int(utest_dsi_receive_rejects_write_offset_past_payload(), 0,
              "DSI receive rejects DSIWrite offset beyond payload");
+    TEST_int(utest_dsi_receive_rejects_zero_length_cmd(), 0,
+             "DSI receive rejects a command frame with no AFP function byte");
+#ifndef NO_DDP
+    TEST_int(utest_atp_queue_push_evicts_oldest(), 0,
+             "ATP queue: full queue evicts the oldest, not the arrival");
+    TEST_int(utest_atp_queue_push_keeps_newest(), 0,
+             "ATP queue: the packet just received is never the victim");
+#endif /* NO_DDP */
     /* Config-resolution tests: self-contained fixtures with their own
      * AFPObj + temp configs.  They MUST run before the harness's own
      * config/volume init below, which leaves process state live for the


### PR DESCRIPTION
The ASP transport never received the loop work the DSI transport has had since February. Its request loop was still `while ((reply = asp_getrequest(asp)))` — a bare blocking read, no `poll()`, signal work done inside the handlers, and a sibling dircache hint pipe that the child was handed but never read.

This PR brings ASP to the same footing as DSI: `poll()` as the single blocking point with a self-pipe wake, async-signal-safe handlers, and IPC cache hints actually consumed. It also repairs an unbounded ATP receive queue, a packet class that matched every request, two `cmdbuf` sign-extension faults, a `size_t` underflow reaching the command handlers, an out-of-bounds store driven by one wire byte, and a pooled-buffer double free.

It adds **the first unit tests the AppleTalk transport has ever had.** Two of the seams it touches are shared, so a pair of minor fixes fall to the DSI loop as well — see below.

## What this brings ASP that DSI already had

| DSI work | ASP before | ASP now |
|---|---|---|
| **#2733** — cross-process dircache sync via the IPC hint pipe, and the blocking `poll(-1)` loop that watches it | pipe created and passed to the child (`asp_getsess()`), then **never read** — `process_cache_hints()` was called only from `afp_dsi.c` | hints consumed every wake-up, applied *before* the command they invalidate |
| **#2860** — async-signal-safe handlers, self-pipe wake, deferred-signal flags, `[A0]`–`[I]` poll loop | handlers did `LOG()`, `close_all_vol()`, `free()`, PAM logout and blocking network I/O in signal context | handlers record and wake; all work runs in the loop |

**IPC cache hints are the headline.** `asp_getsess()` builds the hint pipe, registers the write end with the parent and stores the read end in `asp->asp_hint_fd`; `073379df` then wired it to `obj->hint_fd` in the child. But nothing in the ASP path ever drained it — on `main`, `process_cache_hints()` has exactly two call sites, both in `afp_dsi.c`. So an ASP session's dircache was never invalidated by a sibling's activity: it served stale entries for the life of the session, while the parent filled the pipe and then discarded hints once it was full. ASP now fully participates in cross-process cache coherency.

What ASP deliberately does **not** gain: **#2808**'s idle worker. ASP has no `iw_*` integration (DSI has fifteen call sites) because the rfork cache tier it maintains is a TCP-path optimisation of no benefit over AppleTalk, so `dircache_init()` skips that allocation for ASP sessions. `[A1]` below is ASP's own substitute for the invalid-entry release DSI does under `iw_is_active()`.

Latency and stability follow from the same change rather than being separate work: the loop now waits in `poll()` instead of a blocking read, so hints and signals are serviced at the moment they arrive rather than whenever the next client request happens to turn up — which, for an idle client, was never.

## Root cause

ASP is harder to drive from `poll()` than DSI, and the reason is the protocol, not the code quality. DSI reads a stream: once `poll()` reports readable, `dsi_stream_receive()` has data and cannot block — its own comment says exactly that. ATP is a datagram protocol, and a readable socket does **not** promise a request: the datagram may be a response to another transaction, a release for a timed-out one, or traffic from a different node. `atp_rreq()` therefore looped, consuming datagrams until one matched:

```c
while ((rc = atp_rsel(ah, atpb->atp_saddr, ATP_TREQ)) == 0) {
    ;
}
```

Each `atp_rsel()` performs one blocking `recvfrom()`. So the loop's resting place was inside that read. Anything that wants to reach an idle ASP child — a signal, a cache hint — has nowhere to arrive, because the child is not watching any descriptor. That is the whole of it, and both the stale-dircache behaviour and the signal-context handlers are consequences: with no `poll()` to return to, there was no safe place to defer handler work *to*, and no point at which the hint pipe could be read.

`SA_RESTART` is retained on every handler, as DSI retains it. Clearing it would make each interruptible syscall in the child fail with `EINTR`: a SIGHUP reload arriving while `atp_sresp()` blocks in `netddp_sendto()` surfaces as `asp_cmdreply() < 0`, which the loop reads as a dead client, so a reload would end healthy sessions. The self-pipe is what makes the wake-up reliable, and it suffices precisely because nothing now waits outside `poll()`.

*Revision note, since this branch was previously pushed:* an earlier revision of this PR deferred the handler work but tried to bridge the blocking read with `shutdown(asp_atp_fd, SHUT_RDWR)` from the die handler. That cannot work — the ATP socket is `socket(AF_APPLETALK, SOCK_DGRAM, 0)` (`libatalk/netddp/netddp_open.c`) and dgram `shutdown()` is unsupported there, with the return value discarded — and where it does take effect it is worse, because `atp_recv_atp()` treats only `recvlen < 0` as an error, so a permanently-`0`-returning `recvfrom()` spins. That approach, and the `asp_atp_fd` it needed, are gone; the read itself no longer blocks.

## How this code got here (2000 → 2011 → 2024)

Not anyone's mistake. This is the 2000 original, and it missed the hardening DSI received because for most of the intervening time it was not in the tree at all.

- **`31843674` — rufustfirefly, 2000-07-25 (initial revision).** Every defect below is present here: `while ((reply = asp_getrequest(asp)))` as the entire request loop, `atp_rreq()`'s consume-until-match loop, `asp->cmdlen = atpb.atp_rreqdlen - 4`, `asp->cmdbuf[1] != asp->asp_sid`, and `atph_resppkt[resp_hdr.atphd_bitmap]` indexed by a raw wire byte. All were reasonable then: the `cmdbuf` fault needs a session id above 127, hence 128 concurrent sessions; the queue needs a peer willing to send unmatchable datagrams.
- **`be96d276` — Frank Lahm, 2011-02-24 ("Remove all Appletalk stuff").** AppleTalk leaves the tree. From here DSI is hardened alone.
- **`983e15c9` — Daniel Markstedt, 2024-07-24 ("Reintroduce AppleTalk modules in libatalk").** The 2000 code returns essentially unchanged, into a tree whose DSI loop had moved on.
- **`cc0c751e` / `a2fa3170` (#2733, 2026-02)**, **`3c424057` (#2808, 2026-03)**, **`2ea63298` (#2860, 2026-04).** The dircache hint pipe, the idle worker and the async-signal-safe self-pipe loop all land in `afp_dsi.c`. ASP, back for under two years, gets the hint *plumbing* via `073379df` but no consumer.

Attribution note: `git blame` credits the `cmdlen`, `cmdbuf` and `atph_resppkt` lines to `983e15c9` and to `200f3999` (the 2025 astyle reformat), because both rewrote every line in the file. Neither introduced anything — the logic is verbatim 2000, confirmed against the `31843674` blob.

### Coverage matrix — what could reach an ASP session

Each event the loop must answer. "Idle" means a connected client not currently issuing a command, i.e. parked in `recvfrom()` — the common case.

Legend: ✓ = handled promptly and safely · ⚠ = handled, but from signal context, where `LOG()` can deadlock on the syslog lock and `free()`/`close_all_vol()` can corrupt the heap if they interrupt mid-allocation · ~ = delayed until the next client request, unbounded for an idle client · ✗ = never.

| event | on `main` | now |
|---|---|---|
| SIGTERM / SIGALRM (die) | ⚠ `asp_attention()` does blocking network I/O, `afp_asp_close()` runs `close_all_vol()` + PAM logout + `free()` | ✓ |
| SIGUSR1 (timedown: 5-min warning, 300s timer) | ⚠ `asp_attention()`, `setitimer()`, `sigaction()` from a handler | ✓ |
| SIGUSR2 (server message, `SERVERTEXT`) | ⚠ `readmessage()` + `asp_attention()` from a handler | ✓ |
| SIGHUP (config reload) | ~ flag checked only after a request completes | ✓ in the wake-up that delivered it |
| **sibling dircache hint** | **✗ pipe never read** | ✓ applied *before* the command it invalidates |
| client request | ✓ | ✓ |
| unmatchable datagrams accumulating | ✗ queue grows without bound, freed only by `atp_close()` | ✓ bounded, oldest evicted |
| packet with no ATP function bits | ✗ matches *every* request and is returned as its response | ✓ discarded at validation |
| unreadable lock on `atphd_bitmap` | ✗ out-of-bounds store | ✓ range-checked |

## Fix

`atp_rreq_try()` makes exactly one attempt and reports "nothing yet" (`0`) separately from failure (`-1`). `atp_rreq()` keeps its existing blocking contract by looping it, so its six callers outside ASP — `bin/pap`, `etc/papd` (two sites), `contrib/timelord`, `contrib/a2boot`, `contrib/macipgw` and `asp_getsess()` — are untouched. `asp_getrequest()` uses the single-attempt form and returns `ASP_NOREQUEST` when the datagram was not a request for this session.

The loop enters the read only once `poll()` has reported the socket readable, and `poll()` always waits without a timeout. Every `ASP_NOREQUEST` has consumed exactly one datagram, so the socket is no longer readable and the next `poll()` blocks — there is no spin.

Structurally it is now DSI's loop: an inner wait and an outer serve, carrying the same `[A0]`–`[I]` section labels so the two transports read side by side. DSI's `[A]` (stream data already buffered) and `[B]` (disconnected or dying) have no ASP counterpart — no stream buffer, no reconnect state machine — and the code says so, to save the next reader hunting. `[A1]` is ASP's own: releasing what the hints pruned, which DSI does after each command gated on `iw_is_active()`, but ASP does in the wait so an idle session still sheds other clients' churn while receiving nothing but hints.

```mermaid
flowchart TD
    A0["<b>[A0]</b> drain self-pipe · act on deferred signals<br/><i>die · timedown · reload · server message</i>"]
    A1["<b>[A1]</b> release hint-pruned dircache entries"]
    C["<b>[C]</b> build pollfd set<br/><i>ATP socket · hint pipe · self-pipe</i>"]
    D{{"<b>[D]</b> BLOCK IN POLL — timeout −1<br/><i>the only place this loop waits</i>"}}
    E{"<b>[E]</b> poll error?"}
    E1{"<b>[E1]</b> self-pipe<br/>healthy?"}
    F["<b>[F]</b> apply cache hints<br/><i>ahead of dispatch</i>"]
    G{"<b>[G]</b> ATP fd<br/>valid?"}
    H{"<b>[H]</b> socket<br/>readable?"}
    I["<b>[I]</b> hints or signals only"]
    R["<b>asp_getrequest</b><br/>one datagram · cannot block"]
    S["dispatch AFP command"]
    X(["end session"])

    A0 --> A1 --> C --> D --> E
    E -->|"EINTR"| A0
    E -->|"fatal"| X
    E -->|"ok"| E1
    E1 -->|"POLLNVAL / POLLERR"| X
    E1 -->|"POLLIN — drain + act"| F
    E1 -->|"quiet"| F
    F --> G
    G -->|"POLLNVAL"| X
    G -->|"ok"| H
    H -->|"no"| I --> A0
    H -->|"yes"| R
    R -->|"ASP_NOREQUEST<br/>stray or replayed"| A0
    R -->|"command"| S --> A0

    classDef blockNode fill:#1f6feb,stroke:#1158c7,color:#ffffff
    classDef endNode fill:#a40e26,stroke:#82071e,color:#ffffff
    classDef serveNode fill:#1a7f37,stroke:#116329,color:#ffffff
    class D blockNode
    class X endNode
    class R,S serveNode
```

### How each element maps to a defect

Baseline is `main`.

| defect on `main` | consequence | fix |
|---|---|---|
| Loop waits in `recvfrom()`, never in `poll()` | no descriptor is watched, so nothing can reach an idle child; no safe point to defer handler work to | `atp_rreq_try()`; read only after `[H]` |
| Signal work done in handler context | `LOG()` deadlocks on the syslog lock, `free()`/`close_all_vol()` corrupt the heap mid-allocation | handlers record and wake; work runs at `[A0]`/`[E1]` |
| Hint pipe handed to the child but never read | ASP dircache never invalidated by siblings; stale entries served for the session's life | `[F]`, ahead of `[H]` |
| ATP receive queue unbounded | a peer can grow it without limit; entries freed only by `atp_close()` | one `atp_queue_push()`, bounded, evicting the oldest in a single pass — never the arriving packet, which is the only one a caller may still be waiting for |
| Packet with no ATP function bits is queued and matched | satisfies every `((*func & rfunc) == rfunc)` test, so it is returned as the response to whichever transaction asks first | discarded at validation |
| `atphd_bitmap` unbounded | indexes `atph_resppkt[8]` out of bounds; the shift is undefined past `int`, and on the usual targets the count is masked, so 32, 64, … alias onto bits the bitmap test accepts | range-checked against `ATP_MAXRESP` |
| `atp_free_buf()` on a Send-Transaction-Status resend failure | the `atph_resppkt[]` slot keeps the pointer, so the buffer reaches the pool free list twice and has two owners | not freed; the slot owns it |
| `asp->cmdlen = atp_rreqdlen - 4`, `cmdlen` a `size_t` | a 5–8 byte request yields `~SIZE_MAX` as the `ibuflen` handed to the command handlers | rejected below `ASP_HDRSIZ` |
| `cmdbuf[1] != asp_sid`, `char` vs `uint8_t` | a session id of 0x80+ never matches, so that session answers nothing and never closes; reachable at the default `max connections = 200` | `unsigned char` on every `cmdbuf` read |
| `cmdbuf[0]` returned as `char` | function bytes 0xFF/0xFE/0xFD alias the negative result codes | same |
| `afp_asp_close()` exits whenever euid ≠ login user | `exit()` sat outside the failed-`seteuid` branch, so a successful restore still skipped `close_all_vol()` and the PAM logout | only a failed restore is fatal |
| Stray sequence/session-id mismatches logged per packet | unbounded remote log flood | counted, logged periodically |

## Minor DSI loop fixes

Three of the defects live in seams both transports share, so they are fixed on both sides rather than only on the one this PR is named after. All three are small and none changes the DSI loop's structure.

| fix | DSI before | why it matters |
|---|---|---|
| **Zero-length command frame rejected** | every length check in `dsi_stream_receive()` was an upper bound, and both dispatch sites read `commands[0]` with no `cmdlen >= 1` guard | a payload-free frame let the dispatcher pick the AFP call from whatever the previous request left in the buffer, then run it with an input length of 0 |
| **`POLLHUP` on the self-pipe ends the session** | `[E1]` tested only `POLLIN`, so it missed `POLLHUP`, `POLLNVAL` and `POLLERR` | nothing consumes those, so `poll()` returns immediately for the rest of the session and the loop spins with no way to be woken |
| **Self-pipe migrated to the shared helper** | `afp_dsi.c` had its own copy whose four `fcntl()` calls were unchecked | a failed `F_SETFL` left the pipe blocking, and `sigpipe_drain()` runs unconditionally at the top of every iteration — that session would have hung on its first pass |

The migration also deletes ~45 lines of duplicated machinery, which is what the "still two copies" follow-up in the previous revision of this description was about. There is now one implementation, hardened: a half-configured pipe is closed rather than left in place, and a second init is a no-op.

## Behaviour changes

- **ASP sessions now honour cross-process cache invalidation.** Previously an ASP session's dircache went stale as soon as a sibling modified the volume.
- An idle ASP session services signals and hints when they arrive, not when the next request happens to. Signal work no longer runs in handler context.
- A SIGHUP reload is acted on in the wake-up that delivered it, because all deferred work funnels through one `asp_process_deferred_signals()` called at both `[A0]` and `[E1]`, as DSI does.
- The ATP receive queue is bounded. A datagram protocol may drop; which packet it drops decides whether the session survives, so the arriving request is never the victim.
- A malformed ATP datagram (no function bits) is dropped rather than queued and mis-matched.
- `atp_rreq()`'s contract is unchanged; `atp_rreq_try()` is additive.
- `process_cache_hints()` runs on `revents`, so stray traffic does not cost a read and a parse each.
- The self-pipe primitive moves to `libatalk/util/sigpipe.c`, using the existing `setnonblock()` helper and checking what it calls. `afp_dsi.c` still has its own copy (see follow-ups).

## Testing

Container build, `-Dwith-appletalk=true -Dwith-tests=true`, `-Wall -Wextra`: clean, 198/198 targets.

Warnings are a **delta** against `main` measured per file, not an absolute count: `libatalk/atp/atp_rsel.c` carries two pre-existing `-Wsign-compare` warnings on the `netddp_sendto` return comparisons. `main` built with the same flags emits the identical two, at the same source expressions. Delta zero; no other changed file warns. For anyone reproducing this: `with-appletalk` defaults to **false**, so a default build compiles none of these files and reports no warnings for them.

### Unit tests — the first the AppleTalk transport has ever had

`test/afpd/subtests_atp.c` is **the first unit test coverage for ASP/ATP in the project's history.** On `main`, searching `test/` for `atp_`, `asp_` or `appletalk` matches **zero files** — the transport had none, while DSI has nine distinct unit tests in the same harness. That gap is a large part of why the 2000-era defects above survived reintroduction unnoticed, and it is why this PR starts closing it rather than only fixing the code.

`afpdtest`: 81 ok, 9 skip, 0 failures.

Both new cases are regression tests in the strict sense — reverting `atp_queue_push()` to discarding the arriving packet turns them red, which was verified rather than assumed:

- full queue evicts the oldest, not the arrival
- the packet just received is never the victim, across a deliberate overfill
- a DSI command frame carrying no AFP function byte is rejected — verified red with the guard removed

The ATP buffer pool is now releasable, which is what lets these tests use the
real allocator. It carved each `malloc` into ten buffers and recorded nothing, so
the chunk bases were unrecoverable and the pool was unfreeable by construction —
valgrind reported the base as *possibly lost*, which is in its default error set,
and CI runs `meson test --wrapper='valgrind --leak-check=full --error-exitcode=1'`.
`atp_bufs_release()` frees the chunks, so the tests exercise the same ownership
the transport does and leave nothing of their own on the pool's free list.

### Spectests

Green, but as regression assurance only: spectest runs over TCP/DSI and does not exercise ASP at all, so it covers none of this branch's own behaviour. Stated rather than implied.

## Not in this PR (follow-ups)

- **Three repairs have no unit test** — the `cmdlen` bound, the `cmdbuf` signedness and the `atphd_bitmap` range check. Each needs a live ASP session or a handle mid-transaction, which the afpd unit harness cannot set up. They are verified by reading.
- **The loop invariant has no automated guard.** Nothing in the harness can assert the process is parked in `poll()` rather than in a read, so a future change can silently reintroduce the blocking read that makes deferred signals and hints unreachable. This is the PR's central property and its least protected one.
- **ASP hint handling is untested end to end.** Proving a sibling's invalidation reaches an ASP session needs two sessions on one volume over AppleTalk, which spectest does not do.
- **`contrib/macipgw` fills the same `atph_queue` through its own unbounded pusher** and then calls `atp_rsel()` on that handle. It is unaffected by the eviction policy, but it should go through `atp_queue_push()` rather than keeping a second implementation of the same queue.
- **`afpdtest` is not run by `meson test`** in the Alpine configuration, and `test/afpd/test.sh` only generates `test.conf`, so the binary must be run separately; the image needs `util-linux` for `uuidgen`. The unit results above were obtained that way.
