### PR TITLE
cnid: classify contended vs corrupt vs broken sqlite backends end to end; stop contention and disk-full ending AFP sessions

### DIFF
--- a/distrib/docker/entrypoint_netatalk.sh
+++ b/distrib/docker/entrypoint_netatalk.sh
@@ -114,8 +114,9 @@ else
     set -e
 
     echo "==== TESTS (${TESTSUITE}) COMPLETED (exit code: $TEST_EXIT_CODE) ===="
-    # Display Netatalk's server logs if SERVER_LOGS environment variable is set
-    if [ -n "$SERVER_LOGS" ]; then
+    # Display Netatalk's server logs if SERVER_LOGS is set, and always on a
+    # failed run: a dying afpd child takes its diagnosis with it otherwise
+    if [ -n "$SERVER_LOGS" ] || [ "$TEST_EXIT_CODE" -ne 0 ]; then
         if [ -f /var/log/afpd.log ]; then
             echo "/var/log/afpd.log log lines: $(wc -l /var/log/afpd.log | awk '{print $1}')"
             echo "==== AFPD LOG CONTENT ===="

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -657,7 +657,17 @@ static struct dir *dirlookup_internal(const struct vol *vol, cnid_t did,
      * Outputs: upath = basename only ("mydir") + cnid modified to parent DID
      * So we need to build the rest of the fullpath */
     if (upath == NULL) {
-        afp_errno = AFPERR_NOOBJ;
+        /* AFPERR_NOOBJ is permanent; a backend that could not answer has not
+         * said the directory is gone */
+        if (CNID_ERRNO_IS_BACKEND_FAILURE()) {
+            LOG(log_warning, logtype_afpd,
+                DIRLOOKUP_LOG_FMT ": CNID backend error, errno=0x%x",
+                ntohl(did), CNID_ERRNO());
+            afp_errno = AFPERR_MISC;
+        } else {
+            afp_errno = AFPERR_NOOBJ;
+        }
+
         err = 1;
         goto exit;
     }
@@ -1225,29 +1235,32 @@ int dir_modify(const struct vol *vol, struct dir *dir,
             AFP_CNID_DONE();
 
             if (new_cnid == CNID_INVALID) {
+                const char *why = CNID_ERRNO_IS_BACKEND_FAILURE()
+                                  ? "CNID backend could not answer" : "no CNID for new inode";
+
                 if (dir == curdir) {
                     /* Do not remove curdir — callers rely on it being valid.
-                     * AD cache already invalidated (AD_RLEN_UNKNOWN above) */
+                     * AD cache already invalidated (AD_RLEN_UNKNOWN above).
+                     * The DID re-index below runs only for a valid CNID, as
+                     * CNID_INVALID is DID 0. */
                     LOG(log_error, logtype_afpd,
-                        "dir_modify: inode change on curdir! — no CNID for "
-                        "new inode, keeping stale entry (did:%u, ino:%llu->%llu)",
-                        ntohl(dir->d_did),
+                        "dir_modify: inode change on curdir! — %s, "
+                        "keeping stale entry (did:%u, ino:%llu->%llu)",
+                        why, ntohl(dir->d_did),
                         (unsigned long long)dir->dcache_ino,
                         (unsigned long long)args->st->st_ino);
                 } else {
                     /* No CNID. Remove stale entry. */
                     LOG(log_debug, logtype_afpd,
-                        "dir_modify: inode change — no CNID for new inode, "
+                        "dir_modify: inode change — %s, "
                         "removing stale entry did:%u (ino:%llu->%llu)",
-                        ntohl(dir->d_did),
+                        why, ntohl(dir->d_did),
                         (unsigned long long)dir->dcache_ino,
                         (unsigned long long)args->st->st_ino);
                     dir_remove(vol, dir, 0);
                     return 0;
                 }
-            }
-
-            if (new_cnid != dir->d_did) {
+            } else if (new_cnid != dir->d_did) {
                 LOG(log_debug, logtype_afpd,
                     "dir_modify: inode change — CNID refreshed "
                     "did:%u->%u (ino:%llu->%llu)",
@@ -2072,6 +2085,8 @@ int movecwd(const struct vol *vol, struct dir *dir)
         LOG(log_error, logtype_afpd, "movecwd: NULL parameter (vol:%p, dir:%p)",
             (void*)vol, (void*)dir);
         afp_errno = AFPERR_PARAM;
+        /* Callers read errno right after this returns */
+        errno = EINVAL;
         return -1;
     }
 
@@ -2090,6 +2105,12 @@ int movecwd(const struct vol *vol, struct dir *dir)
         ntohl(dir->d_did), dir->d_fullpath ? cfrombstr(dir->d_fullpath) : "(null)");
 
     if ((ret = ochdir_vol(cfrombstr(dir->d_fullpath), vol)) != 0) {
+        /* The CNID lookups and chdirs in the self-heal below overwrite errno,
+         * while the reply must reflect why this chdir failed */
+        int chdir_errno = errno;
+        /* Set when the self-heal's lookup failed because the CNID backend
+         * could not answer, rather than because the directory is gone */
+        int backend_failure = 0;
         /* Failed to change directory */
         LOG(log_debug, logtype_afpd, "movecwd(\"%s\"): %s",
             dir->d_fullpath ? cfrombstr(dir->d_fullpath) : "(null)", strerror(errno));
@@ -2121,12 +2142,17 @@ int movecwd(const struct vol *vol, struct dir *dir)
                     return 0;
                 }
 
+                chdir_errno = errno;
                 LOG(log_info, logtype_afpd,
                     "movecwd: CNID retry chdir failed: %s", strerror(errno));
             } else {
+                /* dirlookup_strict sets AFPERR_MISC when the backend could not
+                 * answer; the errno switch below must not overrule it */
+                backend_failure = (afp_errno == AFPERR_MISC);
                 LOG(log_debug, logtype_afpd,
-                    "movecwd: dirlookup_strict returned NULL for did:%u (does not exist)",
-                    ntohl(saved_did));
+                    "movecwd: dirlookup_strict returned NULL for did:%u (%s)",
+                    ntohl(saved_did),
+                    backend_failure ? "CNID backend could not answer" : "does not exist");
             }
 
             /* Special movecwd requirement: sync process CWD with curdir pointer.
@@ -2149,19 +2175,25 @@ int movecwd(const struct vol *vol, struct dir *dir)
             }
 
             curdir = vol->v_root;
+            errno = chdir_errno;
             return -1;
         }
 
-        switch (errno) {
-        case EACCES:
-        case EPERM:
-            afp_errno = AFPERR_ACCESS;
-            break;
+        if (!backend_failure) {
+            switch (chdir_errno) {
+            case EACCES:
+            case EPERM:
+                afp_errno = AFPERR_ACCESS;
+                break;
 
-        default:
-            afp_errno = AFPERR_NOOBJ;
+            default:
+                afp_errno = AFPERR_NOOBJ;
+            }
         }
 
+        /* Callers switch on errno after this returns and have no arm for the
+         * CNID_ERR_* values the self-heal above may have left there */
+        errno = chdir_errno;
         return -1;
     }
 

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -455,6 +455,14 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
                         LOG(log_error, logtype_afpd, "enumerate: error updating CNID of \"%s\"",
                             fullpathname(convname));
                     }
+                } else if (CNID_ERRNO_IS_BACKEND_FAILURE()) {
+                    /* ad_convert has already renamed the file, so the CNID row
+                     * names a path that is gone and the next lookup mints a
+                     * fresh CNID for it */
+                    LOG(log_error, logtype_afpd,
+                        "enumerate: CNID backend error (errno=0x%x), the CNID of "
+                        "converted \"%s\" still names the pre-conversion file",
+                        CNID_ERRNO(), fullpathname(convname));
                 }
             }
         }

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -373,7 +373,26 @@ uint32_t get_id(struct vol *vol,
         if (dbcnid == CNID_INVALID) {
             switch (errno) {
             case CNID_ERR_CLOSE: /* the db is closed */
-                break;
+                /* Callers reply with afp_errno after a CNID_INVALID result */
+                LOG(log_error, logtype_afpd,
+                    "get_id: CNID database is not open for \"%s\"", upath);
+                afp_errno = AFPERR_MISC;
+                goto exit;
+
+            case CNID_ERR_BUSY:
+                /* Contention, not a broken backend: retryable, unlike the
+                 * CNID_ERR_DB arm below */
+                LOG(log_warning, logtype_afpd,
+                    "get_id: CNID backend busy for \"%s\"", upath);
+                afp_errno = AFPERR_MISC;
+                goto exit;
+
+            case CNID_ERR_CORRUPT:
+                LOG(log_error, logtype_afpd,
+                    "get_id: CNID backend returned unusable data for \"%s\"; "
+                    "the CNID database for this volume should be rebuilt", upath);
+                afp_errno = AFPERR_MISC;
+                goto exit;
 
             case CNID_ERR_DB:
                 LOG(log_error, logtype_afpd,
@@ -551,6 +570,15 @@ int getmetadata(const AFPObj *obj,
                         AFP_CNID_START("cnid_get");
                         id = cnid_get(vol->v_cdb, dir->d_did, upath, len);
                         AFP_CNID_DONE();
+
+                        /* The AFPERR_NOOBJ below is permanent; a backend that
+                         * could not answer has not said the object is gone */
+                        if (id == CNID_INVALID && CNID_ERRNO_IS_BACKEND_FAILURE()) {
+                            LOG(log_warning, logtype_afpd,
+                                "getmetadata(\"%s\"): CNID backend error, errno=0x%x",
+                                upath, CNID_ERRNO());
+                            return AFPERR_MISC;
+                        }
                     }
 
                     if (id == CNID_INVALID || ntohl(id) < CNID_START) {
@@ -559,7 +587,9 @@ int getmetadata(const AFPObj *obj,
                 } else {
                     id = get_id(vol, adp, st, dir->d_did, upath, len);
 
-                    if (id < CNID_START) {
+                    /* get_id returns a CNID in network byte order, as does the
+                     * ad_getid()/cnid_get() branch above */
+                    if (ntohl(id) < CNID_START) {
                         LOG(log_error, logtype_afpd,
                             "getmetadata: get_id failed for \"%s\", invalid id %u, afp_errno=%d (%s)",
                             upath, id, afp_errno, AfpErr2name(afp_errno));
@@ -2648,11 +2678,26 @@ retry:
     AFP_CNID_DONE();
 
     if (upath == NULL) {
+        /* The AFPERR_NOID below is permanent; a backend that could not answer
+         * has not said the id is unknown */
+        if (CNID_ERRNO_IS_BACKEND_FAILURE()) {
+            LOG(log_warning, logtype_afpd,
+                "afp_resolveid(%u): CNID backend error, errno=0x%x", ntohl(cnid),
+                CNID_ERRNO());
+            return AFPERR_MISC;
+        }
+
         /* was AFPERR_BADID, but help older Macs */
         return AFPERR_NOID;
     }
 
     if (NULL == (dir = dirlookup(vol, id))) {
+        /* dirlookup sets AFPERR_MISC when the backend could not answer; the
+         * AFPERR_NOID below is permanent */
+        if (afp_errno == AFPERR_MISC) {
+            return AFPERR_MISC;
+        }
+
         /* idem AFPERR_PARAM */
         return AFPERR_NOID;
     }
@@ -2769,6 +2814,14 @@ int afp_deleteid(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
     AFP_CNID_DONE();
 
     if (upath == NULL) {
+        /* A backend that could not answer has not said the id is unknown */
+        if (CNID_ERRNO_IS_BACKEND_FAILURE()) {
+            LOG(log_warning, logtype_afpd,
+                "afp_deleteid(%u): CNID backend error, errno=0x%x", ntohl(fileid),
+                CNID_ERRNO());
+            return AFPERR_MISC;
+        }
+
         return AFPERR_NOID;
     }
 
@@ -2776,6 +2829,12 @@ int afp_deleteid(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
         if (afp_errno == AFPERR_NOOBJ) {
             err = AFPERR_NOOBJ;
             goto delete;
+        }
+
+        /* dirlookup sets AFPERR_MISC when the backend could not answer; the
+         * AFPERR_PARAM below is permanent */
+        if (afp_errno == AFPERR_MISC) {
+            return AFPERR_MISC;
         }
 
         return AFPERR_PARAM;
@@ -2809,6 +2868,14 @@ delete:
 
     if (cnid_delete(vol->v_cdb, fileid)) {
         AFP_CNID_DONE();
+
+        /* The CNID_ERR_* values have no arm in the switch below */
+        if (CNID_ERRNO_IS_BACKEND_FAILURE()) {
+            LOG(log_warning, logtype_afpd,
+                "afp_deleteid(%u): CNID backend error, errno=0x%x", ntohl(fileid),
+                CNID_ERRNO());
+            return AFPERR_MISC;
+        }
 
         switch (errno) {
         case EROFS:
@@ -2991,6 +3058,16 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
     sid = cnid_lookup(vol->v_cdb, &srcst, sdir->d_did, supath, slen);
     AFP_CNID_DONE();
 
+    /* A backend that could not answer is not "no CNID recorded": the id swap
+     * below is the point of the call */
+    if (sid == CNID_INVALID && CNID_ERRNO_IS_BACKEND_FAILURE()) {
+        LOG(log_warning, logtype_afpd,
+            "afp_exchangefiles(\"%s\"): CNID backend error, errno=0x%x",
+            supath ? supath : "(null)", CNID_ERRNO());
+        err = AFPERR_MISC;
+        goto err_exchangefile;
+    }
+
     /* destination file - use strict validation for parent directory */
     if (NULL == (dir = dirlookup_strict(vol, did))) {
         err = afp_errno;
@@ -3075,6 +3152,17 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
     AFP_CNID_START("cnid_lookup");
     did = cnid_lookup(vol->v_cdb, &destst, curdir->d_did, upath, dlen);
     AFP_CNID_DONE();
+
+    /* As for the source above: a backend that could not answer is not
+     * "no CNID recorded" */
+    if (did == CNID_INVALID && CNID_ERRNO_IS_BACKEND_FAILURE()) {
+        LOG(log_warning, logtype_afpd,
+            "afp_exchangefiles(\"%s\"): CNID backend error, errno=0x%x",
+            upath, CNID_ERRNO());
+        err = AFPERR_MISC;
+        goto err_exchangefile;
+    }
+
     /* construct a temp name.
      * NOTE: the temp file will be in the dest file's directory. it
      * will also be inaccessible from AFP. */
@@ -3131,6 +3219,16 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
             (sid && ((crossdev && ostat(p, &destst, vol_syml_opt(vol)) < 0) ||
                      cnid_update(vol->v_cdb, sid, &destst, sdir->d_did, supath, slen) < 0))
        ) {
+        /* The CNID_ERR_* values have no arm in the switch below, and both rows
+         * are already deleted at this point */
+        if (CNID_ERRNO_IS_BACKEND_FAILURE()) {
+            LOG(log_warning, logtype_afpd,
+                "afp_exchangefiles: CNID backend error updating ids, errno=0x%x",
+                CNID_ERRNO());
+            err = AFPERR_MISC;
+            goto err_temp_to_dest;
+        }
+
         switch (errno) {
         case EPERM:
         case EACCES:

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -332,6 +332,18 @@ static int moveandrename(const AFPObj *obj,
         AFP_CNID_START("cnid_get");
         id = cnid_get(vol->v_cdb, sdir->d_did, oldunixname, oldunixname_len);
         AFP_CNID_DONE();
+
+        /* A backend that could not answer is not "no CNID recorded": the
+         * cnid_update() after the rename below repoints this id at the new
+         * name */
+        if (id == CNID_INVALID && CNID_ERRNO_IS_BACKEND_FAILURE()) {
+            LOG(log_warning, logtype_afpd,
+                "moveandrename(\"%s\"): CNID backend error, errno=0x%x",
+                oldunixname, CNID_ERRNO());
+            free(oldunixname);
+            return AFPERR_MISC;
+        }
+
         path.st_valid = 0;
         path.u_name = oldunixname;
         opened = of_findnameat(sdir_fd, &path);

--- a/include/atalk/cnid.h
+++ b/include/atalk/cnid.h
@@ -27,6 +27,7 @@
 #ifndef _ATALK_CNID__H
 #define _ATALK_CNID__H 1
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -48,9 +49,26 @@
 
 #define CNID_ERR_PARAM 0x80000001
 #define CNID_ERR_PATH  0x80000002
-#define CNID_ERR_DB    0x80000003
+#define CNID_ERR_DB    0x80000003   /*!< the backend itself is gone */
 #define CNID_ERR_CLOSE 0x80000004   /*!< the db was not open */
 #define CNID_ERR_MAX   0x80000005
+#define CNID_ERR_BUSY  0x80000007   /*!< contended or transient, retryable */
+#define CNID_ERR_CORRUPT 0x80000008 /*!< unusable data returned for a CNID */
+#define CNID_ERR_NOTFOUND 0x80000009 /*!< no row for the query */
+
+/* CNID_ERR_* exceed INT_MAX; compare against errno through this unsigned view */
+#define CNID_ERRNO() ((unsigned int) errno)
+
+/*!
+ * @brief Whether errno says the backend could not answer at all
+ *
+ * The object's existence is unknown, so the reply is the retryable AFPERR_MISC:
+ * AFPERR_NOOBJ and AFPERR_NOID are permanent and a client does not retry them.
+ */
+#define CNID_ERRNO_IS_BACKEND_FAILURE()         \
+    (CNID_ERRNO() == CNID_ERR_BUSY              \
+     || CNID_ERRNO() == CNID_ERR_CORRUPT        \
+     || CNID_ERRNO() == CNID_ERR_DB)
 
 /* cnid_find() requires a result buffer large enough to hold at least one
  * full DBD-backend batch (CNID_FIND_MIN_RESULTS = 100 CNIDs in network

--- a/include/atalk/cnid_sqlite_private.h
+++ b/include/atalk/cnid_sqlite_private.h
@@ -21,6 +21,9 @@ typedef struct CNID_sqlite_private {
     sqlite3_stmt *cnid_getstamp_stmt;
     sqlite3_stmt *cnid_find_stmt;
     sqlite3_stmt *cnid_find_scoped_stmt;
+    sqlite3_stmt *cnid_update_stmt;
+    sqlite3_stmt *cnid_del_didname_stmt;
+    sqlite3_stmt *cnid_del_devino_stmt;
 } CNID_sqlite_private;
 
 #endif

--- a/libatalk/cnid/cnid.c
+++ b/libatalk/cnid/cnid.c
@@ -18,6 +18,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <arpa/inet.h>
 #include <errno.h>
 #include <signal.h>
 #include <stdlib.h>
@@ -209,14 +210,22 @@ static void unblock_signal(uint32_t flags)
 /*!
   protect against bogus value from the DB.
   adddir really doesn't like 2
+
+  Every CNID_INVALID returned from this file carries its own errno: callers read
+  the CNID_ERR_* values to choose between a permanent reply and a retryable one,
+  and CNID_ERR_DB ends the session. No syscall overwrites those values and the
+  logger preserves errno, so one persists until deliberately replaced.
 */
 static cnid_t valide(cnid_t id)
 {
     if (id == CNID_INVALID) {
+        /* the backend classified this one */
         return id;
     }
 
-    if (id < CNID_START) {
+    /* id is in network byte order; comparing it raw would reject 16 valid
+     * CNIDs on little-endian hosts and wave the reserved ids 1-16 through */
+    if (ntohl(id) < CNID_START) {
         static int err = 0;
 
         if (!err) {
@@ -224,6 +233,7 @@ static cnid_t valide(cnid_t id)
             LOG(log_error, logtype_afpd, "Error: Invalid cnid, corrupted DB?");
         }
 
+        errno = CNID_ERR_CORRUPT;
         return CNID_INVALID;
     }
 
@@ -254,9 +264,13 @@ cnid_t cnid_add(struct _cnid_db *cdb, const struct stat *st, const cnid_t did,
     cnid_t ret;
 
     if (len == 0) {
+        errno = CNID_ERR_PARAM;
         return CNID_INVALID;
     }
 
+    /* Cleared for every backend and caller here, so errno reads as this
+     * operation's verdict. Not every backend classifies every failure. */
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
     ret = valide(cdb->cnid_add(cdb, st, did, name, len, hint));
     unblock_signal(cdb->cnid_db_flags);
@@ -267,6 +281,7 @@ cnid_t cnid_add(struct _cnid_db *cdb, const struct stat *st, const cnid_t did,
 int cnid_delete(struct _cnid_db *cdb, cnid_t id)
 {
     int ret;
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
     ret = cdb->cnid_delete(cdb, id);
     unblock_signal(cdb->cnid_db_flags);
@@ -279,6 +294,7 @@ cnid_t cnid_get(struct _cnid_db *cdb, const cnid_t did, char *name,
                 const size_t len)
 {
     cnid_t ret;
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
     ret = valide(cdb->cnid_get(cdb, did, name, len));
     unblock_signal(cdb->cnid_db_flags);
@@ -304,6 +320,7 @@ int cnid_getstamp(struct _cnid_db *cdb,  void *buffer, const size_t len)
         return 0;
     }
 
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
     ret = cdb->cnid_getstamp(cdb, buffer, len);
     unblock_signal(cdb->cnid_db_flags);
@@ -316,6 +333,7 @@ cnid_t cnid_lookup(struct _cnid_db *cdb, const struct stat *st,
                    char *name, const size_t len)
 {
     cnid_t ret;
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
     ret = valide(cdb->cnid_lookup(cdb, st, did, name, len));
     unblock_signal(cdb->cnid_db_flags);
@@ -408,6 +426,7 @@ int cnid_find_scoped(struct _cnid_db *cdb, const char *name,
         return -1;
     }
 
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
     ret = cdb->cnid_find(cdb, name, namelen, scope_did,
                          buffer, buflen, more_available);
@@ -419,12 +438,17 @@ int cnid_find_scoped(struct _cnid_db *cdb, const char *name,
 char *cnid_resolve(struct _cnid_db *cdb, cnid_t *id, void *buffer, size_t len)
 {
     char *ret;
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
     ret = cdb->cnid_resolve(cdb, id, buffer, len);
     unblock_signal(cdb->cnid_db_flags);
 
     if (ret && !strcmp(ret, "..")) {
         LOG(log_error, logtype_afpd, "cnid_resolve: name is '..', corrupted db? ");
+        /* Match the backend failure contract: without these the caller reads
+         * a stale errno and *id still holds the parent DID the backend wrote */
+        *id = CNID_INVALID;
+        errno = CNID_ERR_CORRUPT;
         ret = NULL;
     }
 
@@ -436,6 +460,7 @@ int cnid_update(struct _cnid_db *cdb, const cnid_t id, const struct stat *st,
                 const cnid_t did, char *name, const size_t len)
 {
     int ret;
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
     ret = cdb->cnid_update(cdb, id, st, did, name, len);
     unblock_signal(cdb->cnid_db_flags);
@@ -448,6 +473,7 @@ cnid_t cnid_rebuild_add(struct _cnid_db *cdb, const struct stat *st,
                         char *name, const size_t len, cnid_t hint)
 {
     cnid_t ret;
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
     ret = cdb->cnid_rebuild_add(cdb, st, did, name, len, hint);
     unblock_signal(cdb->cnid_db_flags);
@@ -458,6 +484,7 @@ cnid_t cnid_rebuild_add(struct _cnid_db *cdb, const struct stat *st,
 int cnid_wipe(struct _cnid_db *cdb)
 {
     int ret = 0;
+    errno = 0;
     block_signal(cdb->cnid_db_flags);
 
     if (cdb->cnid_wipe) {

--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -19,6 +19,7 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <arpa/inet.h>
+#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
@@ -50,23 +51,59 @@
 #include <atalk/util.h>
 #include <atalk/volume.h>
 
-static int init_prepared_stmt_lookup(CNID_sqlite_private * db)
+/* Total time SQLite waits for a contended lock before returning SQLITE_BUSY.
+ * The busy handler polls internally and returns as soon as the lock frees. */
+#define CNID_SQLITE_BUSY_TIMEOUT    3000
+
+/* Bound on the lookup-then-insert cycle, which does not converge when a row
+ * satisfies the insert's unique keys but no lookup index reaches it */
+#define CNID_SQLITE_ADD_ATTEMPTS    16
+
+/* Attempts at the table-emptiness probe during open. Each step already waits
+ * out CNID_SQLITE_BUSY_TIMEOUT, so this only covers sustained contention. */
+#define CNID_SQLITE_EMPTY_PROBE_TRIES   3
+
+/* Ceiling for a CNID hint. A hint binds as an explicit rowid, which raises the
+ * AUTOINCREMENT high-water mark, so the headroom below the 32-bit ceiling
+ * keeps a hint out of corrupt AppleDouble/EA metadata from reaching it. */
+#define CNID_SQLITE_MAX_HINT    (UINT32_MAX - 65536)
+
+static void cnid_sqlite_set_errno(int sqlite_return);
+
+/*!
+ * @brief Prepare one per-volume statement, replacing any previous handle
+ *
+ * @param[in,out] db      backend private data
+ * @param[out] stmt       statement handle to finalize and re-prepare
+ * @param[in] tag         statement name, for the debug log only
+ * @param[in] sql_fmt     SQL with one %s for the volume's table name, or none
+ */
+static int init_prepared_stmt_one(CNID_sqlite_private *db,
+                                  sqlite3_stmt **stmt,
+                                  const char *tag, const char *sql_fmt)
 {
     EC_INIT;
     char *sql = NULL;
 
-    if (db->cnid_lookup_stmt) {
-        EC_ZERO(sqlite3_finalize(db->cnid_lookup_stmt));
+    if (*stmt) {
+        sqlite3_finalize(*stmt);
+        *stmt = NULL;
     }
 
-    EC_NEG1(asprintf
-            (&sql,
-             "SELECT Id,Did,Name,DevNo,InodeNo FROM \"%s\" "
-             "WHERE (Name = ? AND Did = ?) OR (DevNo = ? AND InodeNo = ?)",
-             db->cnid_sqlite_voluuid_str));
-    LOG(log_maxdebug, logtype_cnid, "init_prepared_stmt_lookup: SQL: %s", sql);
-    EC_ZERO_LOG(sqlite3_prepare_v2
-                (db->cnid_sqlite_con, sql, strlen(sql), &db->cnid_lookup_stmt, NULL));
+    EC_NEG1(asprintf(&sql, sql_fmt, db->cnid_sqlite_voluuid_str));
+    LOG(log_maxdebug, logtype_cnid, "init_prepared_stmt_%s: SQL: %s", tag, sql);
+    int prepare_return = sqlite3_prepare_v2(db->cnid_sqlite_con, sql,
+                                            (int) strlen(sql), stmt, NULL);
+
+    /* Preparing loads the schema, so a corrupt or read-only database
+     * surfaces here, not at step time; classify it like any other failure */
+    if (prepare_return != SQLITE_OK) {
+        LOG(log_error, logtype_cnid, "init_prepared_stmt_%s: prepare failed: %s",
+            tag, sqlite3_errmsg(db->cnid_sqlite_con));
+        cnid_sqlite_set_errno(prepare_return);
+        EC_FAIL;
+    }
+
 EC_CLEANUP:
 
     if (sql) {
@@ -76,208 +113,61 @@ EC_CLEANUP:
     EC_EXIT;
 }
 
-static int init_prepared_stmt_add(CNID_sqlite_private * db)
-{
-    EC_INIT;
-    char *sql = NULL;
-
-    if (db->cnid_add_stmt) {
-        EC_ZERO(sqlite3_finalize(db->cnid_add_stmt));
-    }
-
-    EC_NEG1(asprintf(&sql,
-                     "INSERT INTO \"%s\" (Name, Did, DevNo, InodeNo) VALUES(?, ?, ?, ?)",
-                     db->cnid_sqlite_voluuid_str));
-    LOG(log_maxdebug, logtype_cnid, "init_prepared_stmt_add: SQL: %s", sql);
-    EC_ZERO_LOG(sqlite3_prepare_v2
-                (db->cnid_sqlite_con, sql, strlen(sql), &db->cnid_add_stmt, NULL));
-EC_CLEANUP:
-
-    if (sql) {
-        free(sql);
-    }
-
-    EC_EXIT;
-}
-
-static int init_prepared_stmt_put(CNID_sqlite_private * db)
-{
-    EC_INIT;
-    char *sql = NULL;
-
-    if (db->cnid_put_stmt) {
-        EC_ZERO(sqlite3_finalize(db->cnid_put_stmt));
-    }
-
-    EC_NEG1(asprintf(&sql,
-                     "INSERT INTO \"%s\" (Id, Name, Did, DevNo, InodeNo) VALUES(?, ?, ?, ?, ?)",
-                     db->cnid_sqlite_voluuid_str));
-    LOG(log_maxdebug, logtype_cnid, "init_prepared_stmt_put: SQL: %s", sql);
-    EC_ZERO_LOG(sqlite3_prepare_v2
-                (db->cnid_sqlite_con, sql, strlen(sql), &db->cnid_put_stmt, NULL));
-EC_CLEANUP:
-
-    if (sql) {
-        free(sql);
-    }
-
-    EC_EXIT;
-}
-
-static int init_prepared_stmt_get(CNID_sqlite_private *db)
-{
-    EC_INIT;
-    char *sql = NULL;
-
-    if (db->cnid_get_stmt) {
-        sqlite3_finalize(db->cnid_get_stmt);
-    }
-
-    EC_NEG1(asprintf(&sql, "SELECT Id FROM \"%s\" WHERE Name = ? AND Did = ?",
-                     db->cnid_sqlite_voluuid_str));
-    LOG(log_maxdebug, logtype_cnid, "init_prepared_stmt_get: SQL: %s", sql);
-    EC_ZERO_LOG(sqlite3_prepare_v2(db->cnid_sqlite_con, sql, strlen(sql),
-                                   &db->cnid_get_stmt, NULL));
-EC_CLEANUP:
-
-    if (sql) {
-        free(sql);
-    }
-
-    EC_EXIT;
-}
-
-static int init_prepared_stmt_resolve(CNID_sqlite_private *db)
-{
-    EC_INIT;
-    char *sql = NULL;
-
-    if (db->cnid_resolve_stmt) {
-        sqlite3_finalize(db->cnid_resolve_stmt);
-    }
-
-    EC_NEG1(asprintf(&sql, "SELECT Did, Name FROM \"%s\" WHERE Id = ?",
-                     db->cnid_sqlite_voluuid_str));
-    LOG(log_maxdebug, logtype_cnid, "init_prepared_stmt_resolve: SQL: %s", sql);
-    EC_ZERO_LOG(sqlite3_prepare_v2(db->cnid_sqlite_con, sql, strlen(sql),
-                                   &db->cnid_resolve_stmt, NULL));
-EC_CLEANUP:
-
-    if (sql) {
-        free(sql);
-    }
-
-    EC_EXIT;
-}
-
-static int init_prepared_stmt_delete(CNID_sqlite_private *db)
-{
-    EC_INIT;
-    char *sql = NULL;
-
-    if (db->cnid_delete_stmt) {
-        sqlite3_finalize(db->cnid_delete_stmt);
-    }
-
-    EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\" WHERE Id = ?",
-                     db->cnid_sqlite_voluuid_str));
-    LOG(log_maxdebug, logtype_cnid, "init_prepared_stmt_delete: SQL: %s", sql);
-    EC_ZERO_LOG(sqlite3_prepare_v2(db->cnid_sqlite_con, sql, strlen(sql),
-                                   &db->cnid_delete_stmt, NULL));
-EC_CLEANUP:
-
-    if (sql) {
-        free(sql);
-    }
-
-    EC_EXIT;
-}
-
-static int init_prepared_stmt_find(CNID_sqlite_private *db)
-{
-    EC_INIT;
-    char *sql = NULL;
-
-    if (db->cnid_find_stmt) {
-        sqlite3_finalize(db->cnid_find_stmt);
-    }
-
-    EC_NEG1(asprintf(&sql,
-                     "SELECT Id FROM \"%s\" WHERE Name LIKE ? ORDER BY Id LIMIT ?",
-                     db->cnid_sqlite_voluuid_str));
-    LOG(log_maxdebug, logtype_cnid, "init_prepared_stmt_find: SQL: %s", sql);
-    EC_ZERO_LOG(sqlite3_prepare_v2(db->cnid_sqlite_con, sql, strlen(sql),
-                                   &db->cnid_find_stmt, NULL));
-    free(sql);
-    sql = NULL;
-
-    if (db->cnid_find_scoped_stmt) {
-        sqlite3_finalize(db->cnid_find_scoped_stmt);
-    }
-
-    /*
-     * Subtree-scoped variant: the recursive CTE enumerates the scope
-     * directory's transitive contents via the (Did, Name) unique
-     * index, and the CROSS JOIN pins the scope set as the outer loop
-     * so cost is proportional to the subtree, not the volume.
-     * Recursive CTEs are a hard requirement (SQLite >= 3.8.3).
-     */
-    EC_NEG1(asprintf(&sql,
-                     "WITH RECURSIVE scope(Id) AS ("
-                     "  VALUES(?)"
-                     "  UNION"
-                     "  SELECT t.Id FROM \"%s\" t JOIN scope s ON t.Did = s.Id"
-                     ") "
-                     "SELECT t.Id FROM scope s CROSS JOIN \"%s\" t "
-                     "ON t.Did = s.Id "
-                     "WHERE t.Name LIKE ? ORDER BY t.Id LIMIT ?",
-                     db->cnid_sqlite_voluuid_str,
-                     db->cnid_sqlite_voluuid_str));
-    LOG(log_maxdebug, logtype_cnid,
-        "init_prepared_stmt_find: scoped SQL: %s", sql);
-    EC_ZERO_LOG(sqlite3_prepare_v2(db->cnid_sqlite_con, sql, strlen(sql),
-                                   &db->cnid_find_scoped_stmt, NULL));
-EC_CLEANUP:
-
-    if (sql) {
-        free(sql);
-    }
-
-    EC_EXIT;
-}
-
-static int init_prepared_stmt_getstamp(CNID_sqlite_private *db)
-{
-    EC_INIT;
-    char *sql = "SELECT Stamp FROM volumes WHERE VolPath = ?";
-
-    if (db->cnid_getstamp_stmt) {
-        sqlite3_finalize(db->cnid_getstamp_stmt);
-    }
-
-    LOG(log_maxdebug, logtype_cnid, "init_prepared_stmt_getstamp: SQL: %s", sql);
-    EC_ZERO_LOG(sqlite3_prepare_v2(db->cnid_sqlite_con, sql, strlen(sql),
-                                   &db->cnid_getstamp_stmt, NULL));
-EC_CLEANUP:
-    EC_EXIT;
-}
-
+/*!
+ * @brief (Re-)prepare every per-volume statement, at open and after a wipe
+ *
+ * A failure leaves the handles past that point NULL; cnid_sqlite_stmt_ready()
+ * rejects those.
+ */
 static int init_prepared_stmt(CNID_sqlite_private * db)
 {
     EC_INIT;
-    EC_ZERO(init_prepared_stmt_lookup(db));
-    EC_ZERO(init_prepared_stmt_add(db));
-    EC_ZERO(init_prepared_stmt_put(db));
-    EC_ZERO(init_prepared_stmt_get(db));
-    EC_ZERO(init_prepared_stmt_resolve(db));
-    EC_ZERO(init_prepared_stmt_delete(db));
-    EC_ZERO(init_prepared_stmt_getstamp(db));
-    EC_ZERO(init_prepared_stmt_find(db));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_lookup_stmt, "lookup",
+                                   "SELECT Id,Did,Name,DevNo,InodeNo FROM \"%s\" "
+                                   "WHERE (Name = ? AND Did = ?) OR (DevNo = ? AND InodeNo = ?)"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_add_stmt, "add",
+                                   "INSERT INTO \"%s\" (Name, Did, DevNo, InodeNo) VALUES(?, ?, ?, ?)"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_put_stmt, "put",
+                                   "INSERT INTO \"%s\" (Id, Name, Did, DevNo, InodeNo) VALUES(?, ?, ?, ?, ?)"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_get_stmt, "get",
+                                   "SELECT Id FROM \"%s\" WHERE Name = ? AND Did = ?"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_resolve_stmt, "resolve",
+                                   "SELECT Did, Name FROM \"%s\" WHERE Id = ?"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_delete_stmt, "delete",
+                                   "DELETE FROM \"%s\" WHERE Id = ?"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_getstamp_stmt, "getstamp",
+                                   "SELECT Stamp FROM volumes WHERE VolPath = ?"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_find_stmt, "find",
+                                   "SELECT Id FROM \"%s\" WHERE Name LIKE ? ORDER BY Id LIMIT ?"));
+    /* Subtree-scoped variant: the recursive CTE enumerates the scope
+     * directory's transitive contents via the (Did, Name) unique index, and
+     * the CROSS JOIN pins the scope set as the outer loop so cost is
+     * proportional to the subtree, not the volume. Recursive CTEs are a hard
+     * requirement (SQLite >= 3.8.3). The table name appears twice, hence the
+     * positional %1$s. */
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_find_scoped_stmt, "find_scoped",
+                                   "WITH RECURSIVE scope(Id) AS ("
+                                   "  VALUES(?)"
+                                   "  UNION"
+                                   "  SELECT t.Id FROM \"%1$s\" t JOIN scope s ON t.Did = s.Id"
+                                   ") "
+                                   "SELECT t.Id FROM scope s CROSS JOIN \"%1$s\" t "
+                                   "ON t.Did = s.Id "
+                                   "WHERE t.Name LIKE ? ORDER BY t.Id LIMIT ?"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_update_stmt, "update",
+                                   "UPDATE \"%s\" SET Name = ?, Did = ?, DevNo = ?, InodeNo = ? WHERE Id = ?"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_del_didname_stmt, "del_didname",
+                                   "DELETE FROM \"%s\" WHERE Did = ? AND Name = ?"));
+    EC_ZERO(init_prepared_stmt_one(db, &db->cnid_del_devino_stmt, "del_devino",
+                                   "DELETE FROM \"%s\" WHERE DevNo = ? AND InodeNo = ?"));
     EC_EXIT;
 EC_CLEANUP:
     EC_EXIT;
 }
 
+/*!
+ * @brief Finalize every prepared statement and clear the handles
+ */
 static void close_prepared_stmt(CNID_sqlite_private * db)
 {
     sqlite3_finalize(db->cnid_lookup_stmt);
@@ -289,6 +179,9 @@ static void close_prepared_stmt(CNID_sqlite_private * db)
     sqlite3_finalize(db->cnid_getstamp_stmt);
     sqlite3_finalize(db->cnid_find_stmt);
     sqlite3_finalize(db->cnid_find_scoped_stmt);
+    sqlite3_finalize(db->cnid_update_stmt);
+    sqlite3_finalize(db->cnid_del_didname_stmt);
+    sqlite3_finalize(db->cnid_del_devino_stmt);
     db->cnid_lookup_stmt = NULL;
     db->cnid_add_stmt = NULL;
     db->cnid_put_stmt = NULL;
@@ -298,48 +191,309 @@ static void close_prepared_stmt(CNID_sqlite_private * db)
     db->cnid_getstamp_stmt = NULL;
     db->cnid_find_stmt = NULL;
     db->cnid_find_scoped_stmt = NULL;
+    db->cnid_update_stmt = NULL;
+    db->cnid_del_didname_stmt = NULL;
+    db->cnid_del_devino_stmt = NULL;
 }
 
+/*!
+ * @brief Whether a CNID hint from AppleDouble/EA metadata is safe to bind
+ *
+ * Rejects the reserved range below CNID_START and anything above
+ * CNID_SQLITE_MAX_HINT, which as an explicit rowid would raise the
+ * AUTOINCREMENT high-water mark towards the depletion reset.
+ */
+static bool cnid_sqlite_hint_usable(cnid_t hint)
+{
+    uint32_t id = ntohl(hint);
+    return id >= CNID_START && id <= CNID_SQLITE_MAX_HINT;
+}
+
+/*!
+ * @brief Whether a rowid read from the database still fits a CNID
+ *
+ * The Id column is a 64-bit sqlite integer while a CNID is 32 bits. Narrowing
+ * one that does not fit would produce the id of an unrelated live row, which
+ * the caller would then hand to a client, or delete.
+ */
+static bool cnid_sqlite_rowid_ok(uint64_t rowid)
+{
+    return rowid != 0 && rowid <= (uint64_t) UINT32_MAX;
+}
+
+/*!
+ * @brief Whether a volume UUID is safe to interpolate as a table name
+ *
+ * A table name cannot be a bound parameter, so it is built into the SQL text.
+ * uuid_strip_dashes() yields exactly 32 hex digits; the UUIDs read back out of
+ * the volumes table are only as trustworthy as the world-writable database
+ * file, so anything else is refused rather than quoted and hoped for.
+ */
+static bool cnid_sqlite_uuid_usable(const char *uuid)
+{
+    size_t i;
+
+    if (uuid == NULL) {
+        return false;
+    }
+
+    for (i = 0; uuid[i] != '\0'; i++) {
+        if (!isxdigit((unsigned char) uuid[i])) {
+            return false;
+        }
+    }
+
+    return i == 32;
+}
+
+/*!
+ * @brief Map a sqlite3 result code onto the CNID error contract in errno
+ *
+ * CNID_ERR_BUSY covers what clears on its own: contention, disk full, I/O
+ * error, out of memory, and SQLITE_PROTOCOL, which is WAL's bounded locking
+ * handshake giving up. SQLITE_LOCKED is not in that set — it reports a
+ * same-connection or shared-cache conflict the busy handler never waits on, so
+ * the state survives a retry.
+ *
+ * CNID_ERR_DB, which get_id() in etc/afpd/file.c answers by ending the session,
+ * means the backend itself is unreachable — for the dbd backend, cnid_metad
+ * being gone. A local database file has no such state: the connection outlives
+ * whatever one statement returns, so an unrecognised code fails the single
+ * operation as CNID_ERR_CORRUPT.
+ */
+static void cnid_sqlite_set_errno(int sqlite_return)
+{
+    /* The READONLY family mixes a permanently read-only database with recovery
+     * states that clear on their own, so it is read before the 0xff mask */
+    switch (sqlite_return) {
+    case SQLITE_READONLY_RECOVERY:
+    case SQLITE_READONLY_ROLLBACK:
+    case SQLITE_READONLY_DBMOVED:
+        errno = CNID_ERR_BUSY;
+        return;
+
+    case SQLITE_READONLY:
+        /* afp_deleteid() in etc/afpd/file.c maps EROFS to AFPERR_VLOCK */
+        errno = EROFS;
+        return;
+
+    default:
+        /* Not a READONLY code: classified by primary result below */
+        break;
+    }
+
+    switch (sqlite_return & 0xff) {
+    case SQLITE_BUSY:
+    case SQLITE_PROTOCOL:
+    case SQLITE_FULL:
+    case SQLITE_IOERR:
+    case SQLITE_NOMEM:
+        errno = CNID_ERR_BUSY;
+        break;
+
+    default:
+        errno = CNID_ERR_CORRUPT;
+        break;
+    }
+}
+
+/*!
+ * @brief Run one SQL statement, classifying a failure into errno
+ *
+ * @returns 0 on success, -1 with errno set by cnid_sqlite_set_errno()
+ */
 static int cnid_sqlite_execute(sqlite3 *con, const char *sql)
 {
     int rv;
     LOG(log_maxdebug, logtype_cnid, "SQL: %s", sql);
     rv = sqlite3_exec(con, sql, NULL, NULL, NULL);
 
-    if (rv) {
-        LOG(log_info, logtype_cnid,
+    if (rv != SQLITE_OK) {
+        LOG(log_error, logtype_cnid,
             "sqlite query \"%s\", error: %s", sql, sqlite3_errmsg(con));
-        errno = CNID_ERR_DB;
+        cnid_sqlite_set_errno(rv);
+        return -1;
     }
 
-    return rv;
+    return 0;
+}
+
+/*!
+ * @brief Delete one row identified by a UUID, through a bound parameter
+ *
+ * The UUID is data here, not an identifier, so it never enters the SQL text:
+ * the stale entries this removes are read back out of the world-writable
+ * database file, where a value chosen to break out of a quoted string would
+ * otherwise run as SQL under the become_root() the cleanup holds.
+ *
+ * @returns 0 on success, -1 with errno set by cnid_sqlite_set_errno()
+ */
+static int cnid_sqlite_delete_by_uuid(sqlite3 *con, const char *sql,
+                                      const char *uuid)
+{
+    sqlite3_stmt *stmt = NULL;
+    int rv;
+    LOG(log_maxdebug, logtype_cnid, "SQL: %s", sql);
+
+    if ((rv = sqlite3_prepare_v2(con, sql, -1, &stmt, NULL)) != SQLITE_OK) {
+        LOG(log_error, logtype_cnid, "sqlite prepare \"%s\", error: %s", sql,
+            sqlite3_errmsg(con));
+        cnid_sqlite_set_errno(rv);
+        return -1;
+    }
+
+    if ((rv = sqlite3_bind_text(stmt, 1, uuid, -1, SQLITE_STATIC)) == SQLITE_OK) {
+        rv = sqlite3_step(stmt);
+    }
+
+    sqlite3_finalize(stmt);
+
+    if (rv != SQLITE_DONE) {
+        LOG(log_error, logtype_cnid, "sqlite query \"%s\", error: %s", sql,
+            sqlite3_errmsg(con));
+        cnid_sqlite_set_errno(rv);
+        return -1;
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Remove a stale volume's row from the volumes table
+ */
+static int cnid_sqlite_delete_volumes_row(sqlite3 *con, const char *uuid)
+{
+    return cnid_sqlite_delete_by_uuid(con,
+                                      "DELETE FROM volumes WHERE VolUUID = ?", uuid);
+}
+
+/*!
+ * @brief Remove a stale volume's AUTOINCREMENT high-water mark
+ */
+static int cnid_sqlite_delete_sequence_row(sqlite3 *con, const char *uuid)
+{
+    return cnid_sqlite_delete_by_uuid(con,
+                                      "DELETE FROM sqlite_sequence WHERE name = ?", uuid);
+}
+
+/*!
+ * @brief Reset a prepared statement without disturbing the classification
+ *
+ * sqlite3_reset() enters the VFS and can leave errno set by a speculative
+ * syscall. It runs in every cleanup path after errno has been classified, and
+ * that classification is the caller's only signal for what failed.
+ */
+static void cnid_sqlite_stmt_reset(sqlite3_stmt *stmt)
+{
+    int saved_errno = errno;
+    sqlite3_reset(stmt);
+    errno = saved_errno;
+}
+
+/*!
+ * @brief Whether a prepared statement is available to bind and step
+ *
+ * The handles are NULL when cnid_sqlite_wipe()'s re-preparation stopped partway.
+ * sqlite3_bind_*() tolerates a NULL statement; sqlite3_step() on one is
+ * undefined, so every entry point checks the handles it uses.
+ */
+static bool cnid_sqlite_stmt_ready(sqlite3_stmt *stmt, const char *caller)
+{
+    if (stmt == NULL) {
+        LOG(log_error, logtype_cnid,
+            "%s: prepared statement is unavailable; the CNID database for this "
+            "volume has to be reopened", caller);
+        errno = CNID_ERR_CLOSE;
+        return false;
+    }
+
+    return true;
+}
+
+/*!
+ * @brief Open a transaction and mark it owned by the calling function
+ *
+ * An exec'd COMMIT can fail and error-jump to cleanup, leaving the connection
+ * inside a transaction. Ownership is tracked so a cleanup handler can only
+ * abandon a transaction its own function started, never a caller's.
+ */
+static int cnid_sqlite_begin(sqlite3 *con, int *owned)
+{
+    if (cnid_sqlite_execute(con, "BEGIN") < 0) {
+        return -1;
+    }
+
+    *owned = 1;
+    return 0;
+}
+
+/*!
+ * @brief Commit the owned transaction, releasing ownership only on success
+ */
+static int cnid_sqlite_commit(sqlite3 *con, int *owned)
+{
+    /* Ownership must survive a failed COMMIT: SQLITE_BUSY leaves the
+     * transaction open, and the cleanup rollback is the only thing that can
+     * close it. Releasing ownership first would strand the write lock for the
+     * life of the connection. */
+    if (cnid_sqlite_execute(con, "COMMIT") < 0) {
+        return -1;
+    }
+
+    *owned = 0;
+    return 0;
+}
+
+/*!
+ * @brief Abandon an owned transaction without disturbing the classification
+ *
+ * Runs from cleanup paths after errno has been classified; the ROLLBACK
+ * enters the VFS and could leave errno set by a speculative syscall.
+ */
+static void cnid_sqlite_rollback(sqlite3 *con, int *owned)
+{
+    if (!*owned) {
+        return;
+    }
+
+    *owned = 0;
+
+    if (con && !sqlite3_get_autocommit(con)) {
+        int saved_errno = errno;
+        sqlite3_exec(con, "ROLLBACK", NULL, NULL, NULL);
+        errno = saved_errno;
+    }
 }
 
 int cnid_sqlite_delete(struct _cnid_db *cdb, const cnid_t id)
 {
     EC_INIT;
-    CNID_sqlite_private *db = cdb->cnid_db_private;
-    LOG(log_maxdebug, logtype_cnid,
-        "cnid_sqlite_delete(id: %" PRIu32 "): BEGIN", ntohl(id));
+    CNID_sqlite_private *db = NULL;
+    int sqlite_return;
 
-    if (!cdb || !db || !id) {
+    if (!cdb || !(db = cdb->cnid_db_private) || !id) {
         LOG(log_error, logtype_cnid, "cnid_sqlite_delete: Parameter error");
         errno = CNID_ERR_PARAM;
         EC_FAIL;
     }
 
-    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "BEGIN"));
+    LOG(log_maxdebug, logtype_cnid,
+        "cnid_sqlite_delete(id: %" PRIu32 "): BEGIN", ntohl(id));
+
+    if (!cnid_sqlite_stmt_ready(db->cnid_delete_stmt, "cnid_sqlite_delete")) {
+        EC_FAIL;
+    }
+
     sqlite3_reset(db->cnid_delete_stmt);
     sqlite3_clear_bindings(db->cnid_delete_stmt);
     sqlite3_bind_int64(db->cnid_delete_stmt, 1, ntohl(id));
+    sqlite_return = sqlite3_step(db->cnid_delete_stmt);
 
-    if (sqlite3_step(db->cnid_delete_stmt) == SQLITE_DONE) {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "COMMIT"));
-    } else {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+    if (sqlite_return != SQLITE_DONE) {
         LOG(log_error, logtype_cnid,
             "cnid_sqlite_delete: sqlite query error: %s",
             sqlite3_errmsg(db->cnid_sqlite_con));
+        cnid_sqlite_set_errno(sqlite_return);
         EC_FAIL;
     }
 
@@ -347,8 +501,8 @@ EC_CLEANUP:
     LOG(log_maxdebug, logtype_cnid,
         "cnid_sqlite_delete(id: %" PRIu32 "): END", ntohl(id));
 
-    if (cdb && db) {
-        sqlite3_reset(db->cnid_delete_stmt);
+    if (db) {
+        cnid_sqlite_stmt_reset(db->cnid_delete_stmt);
     }
 
     EC_EXIT;
@@ -356,13 +510,15 @@ EC_CLEANUP:
 
 void cnid_sqlite_close(struct _cnid_db *cdb)
 {
-    CNID_sqlite_private *db = cdb->cnid_db_private;
+    CNID_sqlite_private *db;
 
     if (!cdb) {
         LOG(log_error, logtype_cnid,
             "cnid_close called with NULL argument !");
         return;
     }
+
+    db = cdb->cnid_db_private;
 
     if (db != NULL) {
         LOG(log_debug, logtype_cnid,
@@ -372,8 +528,15 @@ void cnid_sqlite_close(struct _cnid_db *cdb)
         close_prepared_stmt(db);
 
         if (db->cnid_sqlite_con) {
+            /* Fold the WAL back into the database so the next session starts
+             * with a small one. TRUNCATE invokes the busy handler, which with
+             * readers in other sessions waits the whole budget and truncates
+             * nothing, so the timeout is dropped first. A skipped checkpoint is
+             * retried at the next close. */
+            sqlite3_busy_timeout(db->cnid_sqlite_con, 0);
+            sqlite3_wal_checkpoint_v2(db->cnid_sqlite_con, NULL,
+                                      SQLITE_CHECKPOINT_TRUNCATE, NULL, NULL);
             sqlite3_close(db->cnid_sqlite_con);
-            sqlite3_shutdown();
         }
 
         free(db);
@@ -389,22 +552,13 @@ int cnid_sqlite_update(struct _cnid_db *cdb,
                        cnid_t did, const char *name, size_t len)
 {
     EC_INIT;
-    CNID_sqlite_private *db = cdb->cnid_db_private;
-    cnid_t update_id = CNID_INVALID;
+    CNID_sqlite_private *db = NULL;
     uint64_t dev = 0;
     uint64_t ino;
-    char stmt_param_name[MAXPATHLEN];
-    size_t stmt_param_name_len;
-    uint64_t stmt_param_id;
-    uint64_t stmt_param_did;
-    uint64_t stmt_param_dev;
-    uint64_t stmt_param_ino;
-    char *sql = NULL;
-    LOG(log_maxdebug, logtype_cnid,
-        "cnid_sqlite_update(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\"): BEGIN",
-        ntohl(id), ntohl(did), name);
+    int sqlite_return;
+    int owned = 0;
 
-    if (!cdb || !db || !id || !st || !name) {
+    if (!cdb || !(db = cdb->cnid_db_private) || !id || !st || !name) {
         if (!cdb) {
             LOG(log_error, logtype_cnid,
                 "cnid_update: Parameter error: cdb is NULL");
@@ -416,12 +570,25 @@ int cnid_sqlite_update(struct _cnid_db *cdb,
         } else if (!st) {
             LOG(log_error, logtype_cnid,
                 "cnid_update: Parameter error: st is NULL");
-        } else if (!name) {
+        } else {
             LOG(log_error, logtype_cnid,
                 "cnid_update: Parameter error: name is NULL");
         }
 
         errno = CNID_ERR_PARAM;
+        EC_FAIL;
+    }
+
+    LOG(log_maxdebug, logtype_cnid,
+        "cnid_sqlite_update(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\"): BEGIN",
+        ntohl(id), ntohl(did), name);
+
+    if (!cnid_sqlite_stmt_ready(db->cnid_update_stmt, "cnid_sqlite_update")
+            || !cnid_sqlite_stmt_ready(db->cnid_put_stmt, "cnid_sqlite_update")
+            || !cnid_sqlite_stmt_ready(db->cnid_del_didname_stmt,
+                                       "cnid_sqlite_update")
+            || !cnid_sqlite_stmt_ready(db->cnid_del_devino_stmt,
+                                       "cnid_sqlite_update")) {
         EC_FAIL;
     }
 
@@ -438,61 +605,103 @@ int cnid_sqlite_update(struct _cnid_db *cdb,
 
     ino = st->st_ino;
 
-    do {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "BEGIN"));
-        EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\" WHERE Id=%" PRIu32,
-                         db->cnid_sqlite_voluuid_str, ntohl(id)));
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, sql));
-        free(sql);
-        sql = NULL;
-        EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\" WHERE Did = %" PRIu32
-                         " AND Name = \"%s\"",
-                         db->cnid_sqlite_voluuid_str, ntohl(did), name));
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, sql));
-        free(sql);
-        sql = NULL;
-        EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\" WHERE DevNo = %" PRIu64
-                         " AND InodeNo = %"
-                         PRIu64, db->cnid_sqlite_voluuid_str, dev, ino));
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, sql));
-        free(sql);
-        sql = NULL;
-        stmt_param_id = ntohl(id);
-        strlcpy(stmt_param_name, name, sizeof(stmt_param_name));
-        stmt_param_name_len = len;
-        stmt_param_did = ntohl(did);
-        stmt_param_dev = dev;
-        stmt_param_ino = ino;
-        sqlite3_reset(db->cnid_put_stmt);
-        sqlite3_clear_bindings(db->cnid_put_stmt);
-        sqlite3_bind_int64(db->cnid_put_stmt, 1, stmt_param_id);
-        sqlite3_bind_text(db->cnid_put_stmt, 2, stmt_param_name,
-                          (int)stmt_param_name_len,
-                          SQLITE_STATIC);
-        sqlite3_bind_int64(db->cnid_put_stmt, 3, stmt_param_did);
-        sqlite3_bind_int64(db->cnid_put_stmt, 4, stmt_param_dev);
-        sqlite3_bind_int64(db->cnid_put_stmt, 5, stmt_param_ino);
+    for (int attempt = 0; attempt < 2; attempt++) {
+        if (attempt > 0) {
+            /* Clearing the colliding rows and re-applying the update has to
+             * be atomic: a failure in between would leave another file
+             * without its CNID row */
+            EC_NEG1(cnid_sqlite_begin(db->cnid_sqlite_con, &owned));
+            sqlite3_reset(db->cnid_del_didname_stmt);
+            sqlite3_clear_bindings(db->cnid_del_didname_stmt);
+            sqlite3_bind_int64(db->cnid_del_didname_stmt, 1, ntohl(did));
+            sqlite3_bind_text(db->cnid_del_didname_stmt, 2, name, (int)len,
+                              SQLITE_STATIC);
+            sqlite_return = sqlite3_step(db->cnid_del_didname_stmt);
 
-        if (sqlite3_step(db->cnid_put_stmt) == SQLITE_DONE) {
-            EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "COMMIT"));
-        } else {
-            EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
-            LOG(log_error, logtype_cnid,
-                "cnid_sqlite_add: sqlite query error: %s",
-                sqlite3_errmsg(db->cnid_sqlite_con));
-            EC_FAIL;
+            if (sqlite_return != SQLITE_DONE) {
+                LOG(log_error, logtype_cnid,
+                    "cnid_sqlite_update: clearing (Did, Name) failed: %s",
+                    sqlite3_errmsg(db->cnid_sqlite_con));
+                sqlite3_reset(db->cnid_del_didname_stmt);
+                cnid_sqlite_set_errno(sqlite_return);
+                EC_FAIL;
+            }
+
+            sqlite3_reset(db->cnid_del_didname_stmt);
+            sqlite3_reset(db->cnid_del_devino_stmt);
+            sqlite3_clear_bindings(db->cnid_del_devino_stmt);
+            sqlite3_bind_int64(db->cnid_del_devino_stmt, 1, dev);
+            sqlite3_bind_int64(db->cnid_del_devino_stmt, 2, ino);
+            sqlite_return = sqlite3_step(db->cnid_del_devino_stmt);
+
+            if (sqlite_return != SQLITE_DONE) {
+                LOG(log_error, logtype_cnid,
+                    "cnid_sqlite_update: clearing (DevNo, InodeNo) failed: %s",
+                    sqlite3_errmsg(db->cnid_sqlite_con));
+                sqlite3_reset(db->cnid_del_devino_stmt);
+                cnid_sqlite_set_errno(sqlite_return);
+                EC_FAIL;
+            }
+
+            sqlite3_reset(db->cnid_del_devino_stmt);
         }
 
-        update_id = (cnid_t) sqlite3_last_insert_rowid(db->cnid_sqlite_con);
-    } while (update_id != ntohl(id));
+        sqlite3_reset(db->cnid_update_stmt);
+        sqlite3_clear_bindings(db->cnid_update_stmt);
+        sqlite3_bind_text(db->cnid_update_stmt, 1, name, (int)len,
+                          SQLITE_STATIC);
+        sqlite3_bind_int64(db->cnid_update_stmt, 2, ntohl(did));
+        sqlite3_bind_int64(db->cnid_update_stmt, 3, dev);
+        sqlite3_bind_int64(db->cnid_update_stmt, 4, ino);
+        sqlite3_bind_int64(db->cnid_update_stmt, 5, ntohl(id));
+        sqlite_return = sqlite3_step(db->cnid_update_stmt);
+        sqlite3_reset(db->cnid_update_stmt);
+
+        if (sqlite_return == SQLITE_DONE) {
+            if (sqlite3_changes(db->cnid_sqlite_con) != 0) {
+                break;
+            }
+
+            /* The UPDATE matched nothing, so no row holds this Id: reinsert */
+            sqlite3_reset(db->cnid_put_stmt);
+            sqlite3_clear_bindings(db->cnid_put_stmt);
+            sqlite3_bind_int64(db->cnid_put_stmt, 1, ntohl(id));
+            sqlite3_bind_text(db->cnid_put_stmt, 2, name, (int)len,
+                              SQLITE_STATIC);
+            sqlite3_bind_int64(db->cnid_put_stmt, 3, ntohl(did));
+            sqlite3_bind_int64(db->cnid_put_stmt, 4, dev);
+            sqlite3_bind_int64(db->cnid_put_stmt, 5, ino);
+            sqlite_return = sqlite3_step(db->cnid_put_stmt);
+            sqlite3_reset(db->cnid_put_stmt);
+
+            if (sqlite_return == SQLITE_DONE) {
+                break;
+            }
+        }
+
+        /* Only a unique-key collision is worth a second attempt, and only
+         * once: the next pass clears the colliding rows first */
+        if ((sqlite_return & 0xff) != SQLITE_CONSTRAINT || attempt > 0) {
+            LOG(log_error, logtype_cnid,
+                "cnid_sqlite_update: sqlite query error: %s",
+                sqlite3_errmsg(db->cnid_sqlite_con));
+            cnid_sqlite_set_errno(sqlite_return);
+            EC_FAIL;
+        }
+    }
+
+    if (owned) {
+        EC_NEG1(cnid_sqlite_commit(db->cnid_sqlite_con, &owned));
+    }
 
 EC_CLEANUP:
-    LOG(log_maxdebug, logtype_cnid,
-        "cnid_sqlite_update(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\"): END",
-        ntohl(id), ntohl(did), name);
 
-    if (cdb && db) {
-        sqlite3_reset(db->cnid_put_stmt);
+    if (db) {
+        LOG(log_maxdebug, logtype_cnid,
+            "cnid_sqlite_update(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\"): END",
+            ntohl(id), ntohl(did), name);
+        cnid_sqlite_stmt_reset(db->cnid_put_stmt);
+        cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
     }
 
     EC_EXIT;
@@ -502,25 +711,34 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
                           cnid_t did, const char *name, size_t len)
 {
     EC_INIT;
-    CNID_sqlite_private *db = cdb->cnid_db_private;
+    CNID_sqlite_private *db = NULL;
     cnid_t id = CNID_INVALID;
     uint64_t dev = 0;
-    uint64_t ino = st->st_ino;
-    cnid_t hint = db->cnid_sqlite_hint;
+    uint64_t ino;
+    cnid_t hint = CNID_INVALID;
     const unsigned char *retname;
     cnid_t retid;
     uint64_t retdid;
     int sqlite_return;
-    char stmt_param_name[MAXPATHLEN];
-    size_t stmt_param_name_len;
-    uint64_t stmt_param_did;
-    uint64_t stmt_param_dev;
-    uint64_t stmt_param_ino;
     char lookup_result_name[MAXPATHLEN];
     uint64_t lookup_result_id;
     uint64_t lookup_result_did;
     uint64_t lookup_result_dev;
     uint64_t lookup_result_ino;
+
+    if (!cdb || !st || !name || !(db = cdb->cnid_db_private)) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_lookup: Parameter error");
+        errno = CNID_ERR_PARAM;
+        EC_FAIL;
+    }
+
+    if (!cnid_sqlite_stmt_ready(db->cnid_lookup_stmt, "cnid_sqlite_lookup")) {
+        EC_FAIL;
+    }
+
+    ino = st->st_ino;
+    hint = db->cnid_sqlite_hint;
 
     if (!(cdb->cnid_db_flags & CNID_FLAG_NODEV)) {
         dev = st->st_dev;
@@ -529,13 +747,6 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
     LOG(log_maxdebug, logtype_cnid,
         "cnid_sqlite_lookup(did: %" PRIu32 ", name: \"%s\", hint: %" PRIu32 "): BEGIN",
         ntohl(did), name, ntohl(hint));
-
-    if (!cdb || !db || !st || !name) {
-        LOG(log_error, logtype_cnid,
-            "cnid_sqlite_lookup: Parameter error");
-        errno = CNID_ERR_PARAM;
-        EC_FAIL;
-    }
 
     if (len > MAXPATHLEN) {
         LOG(log_error, logtype_cnid,
@@ -547,22 +758,16 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
     if (ntohl(did) < 2) {
         LOG(log_warning, logtype_cnid,
             "cnid_sqlite_lookup: not looking up illegal did: %" PRIu32, ntohl(did));
-        errno = CNID_INVALID;
+        errno = CNID_ERR_PARAM;
         EC_FAIL;
     }
 
-    strlcpy(stmt_param_name, name, sizeof(stmt_param_name));
-    stmt_param_name_len = len;
-    stmt_param_did = ntohl(did);
-    stmt_param_dev = dev;
-    stmt_param_ino = ino;
     sqlite3_reset(db->cnid_lookup_stmt);
     sqlite3_clear_bindings(db->cnid_lookup_stmt);
-    sqlite3_bind_text(db->cnid_lookup_stmt, 1, stmt_param_name,
-                      (int)stmt_param_name_len, SQLITE_STATIC);
-    sqlite3_bind_int64(db->cnid_lookup_stmt, 2, stmt_param_did);
-    sqlite3_bind_int64(db->cnid_lookup_stmt, 3, stmt_param_dev);
-    sqlite3_bind_int64(db->cnid_lookup_stmt, 4, stmt_param_ino);
+    sqlite3_bind_text(db->cnid_lookup_stmt, 1, name, (int)len, SQLITE_STATIC);
+    sqlite3_bind_int64(db->cnid_lookup_stmt, 2, ntohl(did));
+    sqlite3_bind_int64(db->cnid_lookup_stmt, 3, dev);
+    sqlite3_bind_int64(db->cnid_lookup_stmt, 4, ino);
     sqlite_return = sqlite3_step(db->cnid_lookup_stmt);
 
     if (sqlite_return == SQLITE_DONE) {
@@ -570,13 +775,13 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
         LOG(log_debug, logtype_cnid,
             "cnid_sqlite_lookup: name: '%s', did: %u is not in the CNID database",
             name, ntohl(did));
-        errno = CNID_DBD_RES_NOTFOUND;
+        errno = CNID_ERR_NOTFOUND;
         EC_FAIL;
     } else if (sqlite_return != SQLITE_ROW) {
         LOG(log_error, logtype_cnid,
             "cnid_sqlite_lookup: sqlite query error (1): %s - %i",
             sqlite3_errmsg(db->cnid_sqlite_con), sqlite_return);
-        errno = CNID_ERR_DB;
+        cnid_sqlite_set_errno(sqlite_return);
         EC_FAIL;
     }
 
@@ -598,22 +803,21 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
         ", ino=%" PRIu64,
         lookup_result_id, lookup_result_did, lookup_result_name,
         lookup_result_dev, lookup_result_ino);
-    /* Check for additional rows */
+    /* Check for additional rows; collect them first, delete once the
+     * statement is reset. Deleting mid-SELECT mutates the table under the
+     * active cursor, whose remaining row order is then unspecified. The two
+     * UNIQUE indexes bound the query to one row per disjunct, so the buffer
+     * only has to hold the surplus one; a larger count is logged and cleaned
+     * up over successive lookups. */
     int row_count = 1;
-    int delete_error = 0;
+    int delete_errno = 0;
+    uint64_t extra_ids[2];
+    int extra_count = 0;
 
     while ((sqlite_return = sqlite3_step(db->cnid_lookup_stmt)) == SQLITE_ROW) {
-        uint64_t extra_id = sqlite3_column_int64(db->cnid_lookup_stmt, 0);
-        LOG(log_debug, logtype_cnid,
-            "cnid_sqlite_lookup: multiple matches for did: %u, name: '%s', deleting extra id: %"
-            PRIu64,
-            ntohl(did), name, extra_id);
-
-        if (cnid_sqlite_delete(cdb, htonl((cnid_t)extra_id))) {
-            LOG(log_error, logtype_cnid,
-                "cnid_sqlite_lookup: sqlite query error (delete extra): %s",
-                sqlite3_errmsg(db->cnid_sqlite_con));
-            delete_error = 1;
+        if (extra_count < (int)(sizeof(extra_ids) / sizeof(extra_ids[0]))) {
+            extra_ids[extra_count++] =
+                sqlite3_column_int64(db->cnid_lookup_stmt, 0);
         }
 
         row_count++;
@@ -623,31 +827,64 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
         LOG(log_error, logtype_cnid,
             "cnid_sqlite_lookup: sqlite query error (step): %s",
             sqlite3_errmsg(db->cnid_sqlite_con));
-        errno = CNID_ERR_DB;
+        cnid_sqlite_set_errno(sqlite_return);
         EC_FAIL;
     }
 
+    sqlite3_reset(db->cnid_lookup_stmt);
+
+    for (int i = 0; i < extra_count; i++) {
+        /* An out-of-range rowid is unreachable through this statement, whose
+         * bound id is 32-bit: it is reported and left in place */
+        if (!cnid_sqlite_rowid_ok(extra_ids[i])) {
+            LOG(log_error, logtype_cnid,
+                "cnid_sqlite_lookup: out of range duplicate id %" PRIu64
+                " for did: %u, name: '%s', not deleted",
+                extra_ids[i], ntohl(did), name);
+            delete_errno = CNID_ERR_CORRUPT;
+            continue;
+        }
+
+        LOG(log_debug, logtype_cnid,
+            "cnid_sqlite_lookup: multiple matches for did: %u, name: '%s', deleting extra id: %"
+            PRIu64,
+            ntohl(did), name, extra_ids[i]);
+
+        if (cnid_sqlite_delete(cdb, htonl((cnid_t)extra_ids[i]))) {
+            LOG(log_error, logtype_cnid,
+                "cnid_sqlite_lookup: sqlite query error (delete extra): %s",
+                sqlite3_errmsg(db->cnid_sqlite_con));
+            delete_errno = errno;
+        }
+    }
+
+    /* row_count, not extra_count: extra_ids saturates at its size */
     if (row_count > 1) {
         LOG(log_debug, logtype_cnid,
             "cnid_sqlite_lookup: deleted %d duplicate rows for did: %u, name: '%s'",
             row_count - 1, ntohl(did), name);
 
-        if (delete_error) {
-            errno = CNID_ERR_DB;
+        if (delete_errno != 0) {
+            /* Latched at the failure: a later successful delete enters the VFS,
+             * which can overwrite errno */
+            errno = delete_errno;
             EC_FAIL;
         }
 
-        errno = CNID_DBD_RES_NOTFOUND;
+        errno = CNID_ERR_NOTFOUND;
         EC_FAIL;
     }
 
-    if (lookup_result_id == 0) {
+    /* Did is range-checked with Id: a truncated Did can equal the queried did,
+     * passing the comparison below on a row cnid_sqlite_resolve() calls corrupt */
+    if (!cnid_sqlite_rowid_ok(lookup_result_id)
+            || !cnid_sqlite_rowid_ok(lookup_result_did)) {
         LOG(log_error, logtype_cnid,
-            "cnid_sqlite_lookup: Invalid/corrupt row: id=0, did=%" PRIu64
+            "cnid_sqlite_lookup: Invalid/corrupt row: id=%" PRIu64 ", did=%" PRIu64
             ", name='%s', dev=%" PRIu64 ", ino=%" PRIu64,
-            lookup_result_did, lookup_result_name,
+            lookup_result_id, lookup_result_did, lookup_result_name,
             lookup_result_dev, lookup_result_ino);
-        errno = CNID_INVALID;
+        errno = CNID_ERR_CORRUPT;
         EC_FAIL;
     }
 
@@ -662,14 +899,14 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
 
         if (hint != retid) {
             if (cnid_sqlite_delete(cdb, retid) != 0) {
+                /* errno holds the delete's classification and is passed through */
                 LOG(log_error, logtype_cnid,
                     "cnid_sqlite_lookup: sqlite query error (hint delete): %s",
                     sqlite3_errmsg(db->cnid_sqlite_con));
-                errno = CNID_ERR_DB;
                 EC_FAIL;
             }
 
-            errno = CNID_DBD_RES_NOTFOUND;
+            errno = CNID_ERR_NOTFOUND;
             EC_FAIL;
         }
 
@@ -680,7 +917,6 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
             LOG(log_error, logtype_cnid,
                 "cnid_sqlite_lookup: sqlite query error (update): %s",
                 sqlite3_errmsg(db->cnid_sqlite_con));
-            errno = CNID_ERR_DB;
             EC_FAIL;
         }
 
@@ -694,11 +930,10 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
             LOG(log_error, logtype_cnid,
                 "cnid_sqlite_lookup: sqlite query error (delete): %s",
                 sqlite3_errmsg(db->cnid_sqlite_con));
-            errno = CNID_ERR_DB;
             EC_FAIL;
         }
 
-        errno = CNID_DBD_RES_NOTFOUND;
+        errno = CNID_ERR_NOTFOUND;
         EC_FAIL;
     } else {
         /* everything is good */
@@ -706,12 +941,12 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
     }
 
 EC_CLEANUP:
-    LOG(log_maxdebug, logtype_cnid,
-        "cnid_sqlite_lookup(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\"): END",
-        ntohl(id), ntohl(did), name);
 
-    if (cdb && db) {
-        sqlite3_reset(db->cnid_lookup_stmt);
+    if (db) {
+        LOG(log_maxdebug, logtype_cnid,
+            "cnid_sqlite_lookup(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\"): END",
+            ntohl(id), ntohl(did), name);
+        cnid_sqlite_stmt_reset(db->cnid_lookup_stmt);
     }
 
     if (ret != 0) {
@@ -727,30 +962,33 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
                        const char *name, size_t len, cnid_t hint)
 {
     EC_INIT;
-    CNID_sqlite_private *db = cdb->cnid_db_private;
+    CNID_sqlite_private *db = NULL;
     cnid_t id = CNID_INVALID;
     uint64_t lastid;
     uint64_t dev = 0;
     uint64_t ino;
     int sqlite_return;
-    int retries;
-    int was_depleted = 0;
-    struct timespec ts = {0, 10000000};
-    char stmt_param_name[MAXPATHLEN];
-    size_t stmt_param_name_len;
+    int owned = 0;
+    int attempts = 0;
     uint64_t stmt_param_id;
     uint64_t stmt_param_did;
     uint64_t stmt_param_dev;
     uint64_t stmt_param_ino;
     char *sql = NULL;
+
+    if (!cdb || !(db = cdb->cnid_db_private) || !st || !name) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_add: Parameter error");
+        errno = CNID_ERR_PARAM;
+        EC_FAIL;
+    }
+
     LOG(log_maxdebug, logtype_cnid,
         "cnid_sqlite_add(did: %" PRIu32 ", name: \"%s\", hint: %" PRIu32 "): BEGIN",
         ntohl(did), name, ntohl(hint));
 
-    if (!cdb || !db || !st || !name) {
-        LOG(log_error, logtype_cnid,
-            "cnid_sqlite_add: Parameter error");
-        errno = CNID_ERR_PARAM;
+    if (!cnid_sqlite_stmt_ready(db->cnid_add_stmt, "cnid_sqlite_add")
+            || !cnid_sqlite_stmt_ready(db->cnid_put_stmt, "cnid_sqlite_add")) {
         EC_FAIL;
     }
 
@@ -766,6 +1004,14 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
     }
 
     ino = st->st_ino;
+
+    if (hint != CNID_INVALID && !cnid_sqlite_hint_usable(hint)) {
+        LOG(log_warning, logtype_cnid,
+            "cnid_sqlite_add: ignoring out-of-range CNID hint %" PRIu32
+            " for name: \"%s\"", ntohl(hint), name);
+        hint = CNID_INVALID;
+    }
+
     db->cnid_sqlite_hint = hint;
 
     do {
@@ -774,22 +1020,24 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
             "cnid_sqlite_add: lookup returned id=%" PRIu32 ", errno=%d", ntohl(id), errno);
 
         if (id == CNID_INVALID) {
-            if (errno == CNID_ERR_DB) {
-                LOG(log_error, logtype_cnid, "cnid_sqlite_add: Invalid CNID returned!");
+            /* Only a "not in the database" answer is resolvable by inserting.
+             * Any other classification passes to the caller unchanged. */
+            if (errno != CNID_ERR_NOTFOUND) {
+                LOG(log_error, logtype_cnid,
+                    "cnid_sqlite_add: lookup failed for did: %" PRIu32
+                    ", name: \"%s\", errno=%d", ntohl(did), name, errno);
                 EC_FAIL;
             }
 
-            strlcpy(stmt_param_name, name, sizeof(stmt_param_name));
-            stmt_param_name_len = len;
             stmt_param_did = ntohl(did);
             stmt_param_dev = dev;
             stmt_param_ino = ino;
             LOG(log_debug, logtype_cnid,
                 "cnid_sqlite_add: binding name='%s', did=%" PRIu64 ", dev=%" PRIu64 ", ino=%"
                 PRIu64,
-                stmt_param_name, stmt_param_did, stmt_param_dev, stmt_param_ino);
+                name, stmt_param_did, stmt_param_dev, stmt_param_ino);
 
-            if (stmt_param_name[0] == '\0' ||
+            if (name[0] == '\0' ||
                     stmt_param_did == 0 ||
                     stmt_param_ino == 0) {
                 LOG(log_error, logtype_cnid,
@@ -798,7 +1046,7 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
                 EC_FAIL;
             }
 
-            EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "BEGIN"));
+            EC_NEG1(cnid_sqlite_begin(db->cnid_sqlite_con, &owned));
 
             /*
              * If the CNID set has previously overflowed
@@ -809,62 +1057,45 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
                     || (db->cnid_sqlite_flags & CNID_SQLITE_FLAG_DEPLETED)) {
                 LOG(log_debug, logtype_cnid,
                     "cnid_sqlite_add: not using CNID hint, CNID set is depleted or hint not set");
-                was_depleted = 1;
                 sqlite3_reset(db->cnid_add_stmt);
                 sqlite3_clear_bindings(db->cnid_add_stmt);
-                sqlite3_bind_text(db->cnid_add_stmt, 1, stmt_param_name,
-                                  (int)stmt_param_name_len,
+                sqlite3_bind_text(db->cnid_add_stmt, 1, name, (int)len,
                                   SQLITE_STATIC);
                 sqlite3_bind_int64(db->cnid_add_stmt, 2, stmt_param_did);
                 sqlite3_bind_int64(db->cnid_add_stmt, 3, stmt_param_dev);
                 sqlite3_bind_int64(db->cnid_add_stmt, 4, stmt_param_ino);
-                retries = 0;
+                sqlite_return = sqlite3_step(db->cnid_add_stmt);
 
-                do {
-                    sqlite_return = sqlite3_step(db->cnid_add_stmt);
-
-                    if (sqlite_return == SQLITE_BUSY || sqlite_return == SQLITE_LOCKED) {
-                        LOG(log_debug, logtype_cnid,
-                            "cnid_sqlite_add: SQLITE_BUSY or SQLITE_LOCKED, retrying cnid_add_stmt (%d)",
-                            retries);
-                        nanosleep(&ts, NULL);
-                        retries++;
-                    }
-                } while ((sqlite_return == SQLITE_BUSY || sqlite_return == SQLITE_LOCKED)
-                         && retries < 10);
+                if ((sqlite_return & 0xff) == SQLITE_BUSY) {
+                    LOG(log_warning, logtype_cnid,
+                        "cnid_sqlite_add: database still locked after %d ms",
+                        CNID_SQLITE_BUSY_TIMEOUT);
+                }
             } else {
                 stmt_param_id = ntohl(db->cnid_sqlite_hint);
                 sqlite3_reset(db->cnid_put_stmt);
                 sqlite3_clear_bindings(db->cnid_put_stmt);
                 sqlite3_bind_int64(db->cnid_put_stmt, 1, stmt_param_id);
-                sqlite3_bind_text(db->cnid_put_stmt, 2, stmt_param_name,
-                                  (int)stmt_param_name_len,
+                sqlite3_bind_text(db->cnid_put_stmt, 2, name, (int)len,
                                   SQLITE_STATIC);
                 sqlite3_bind_int64(db->cnid_put_stmt, 3, stmt_param_did);
                 sqlite3_bind_int64(db->cnid_put_stmt, 4, stmt_param_dev);
                 sqlite3_bind_int64(db->cnid_put_stmt, 5, stmt_param_ino);
-                retries = 0;
+                sqlite_return = sqlite3_step(db->cnid_put_stmt);
 
-                do {
-                    sqlite_return = sqlite3_step(db->cnid_put_stmt);
-
-                    if (sqlite_return == SQLITE_BUSY || sqlite_return == SQLITE_LOCKED) {
-                        LOG(log_debug, logtype_cnid,
-                            "cnid_sqlite_add: SQLITE_BUSY or SQLITE_LOCKED, retrying cnid_put_stmt (%d)",
-                            retries);
-                        nanosleep(&ts, NULL);
-                        retries++;
-                    }
-                } while ((sqlite_return == SQLITE_BUSY || sqlite_return == SQLITE_LOCKED)
-                         && retries < 10);
+                if ((sqlite_return & 0xff) == SQLITE_BUSY) {
+                    LOG(log_warning, logtype_cnid,
+                        "cnid_sqlite_add: database still locked after %d ms",
+                        CNID_SQLITE_BUSY_TIMEOUT);
+                }
             }
 
             if (sqlite_return == SQLITE_DONE) {
-                EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "COMMIT"));
+                EC_NEG1(cnid_sqlite_commit(db->cnid_sqlite_con, &owned));
             } else {
-                EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+                cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
 
-                if (sqlite_return == SQLITE_CONSTRAINT) {
+                if ((sqlite_return & 0xff) == SQLITE_CONSTRAINT) {
                     LOG(log_debug, logtype_cnid,
                         "cnid_sqlite_add: Unique constraint violation for combinations of: (name=%s, did=%"
                         PRIu32 ") or (dev=%" PRIu64 ", ino=%" PRIu64 ")", name, ntohl(did),
@@ -875,6 +1106,7 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
                     LOG(log_error, logtype_cnid,
                         "cnid_sqlite_add: sqlite query error: %s",
                         sqlite3_errmsg(db->cnid_sqlite_con));
+                    cnid_sqlite_set_errno(sqlite_return);
                     EC_FAIL;
                 }
             }
@@ -883,14 +1115,16 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
 
             if ((uint32_t) lastid > UINT32_MAX) {
                 /* CNID set is depleted, restart from scratch */
-                LOG(log_info, logtype_cnid,
-                    "cnid_sqlite_add: CNID set is depleted, resetting ID sequence");
-                EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "BEGIN"));
-                EC_NEG1(asprintf(&sql, "UPDATE volumes SET Depleted = 1 WHERE VolUUID = \"%s\"",
+                LOG(log_warning, logtype_cnid,
+                    "cnid_sqlite_add: CNID set is depleted, emptying the CNID "
+                    "table for volume '%s'; entries are rebuilt on access",
+                    cdb->cnid_db_vol->v_localname);
+                EC_NEG1(cnid_sqlite_begin(db->cnid_sqlite_con, &owned));
+                EC_NEG1(asprintf(&sql, "UPDATE volumes SET Depleted = 1 WHERE VolUUID = '%s'",
                                  db->cnid_sqlite_voluuid_str));
 
                 if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-                    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+                    cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
                     EC_FAIL;
                 }
 
@@ -899,7 +1133,7 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
                 EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\"", db->cnid_sqlite_voluuid_str));
 
                 if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-                    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+                    cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
                     EC_FAIL;
                 }
 
@@ -910,7 +1144,7 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
                                  db->cnid_sqlite_voluuid_str));
 
                 if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-                    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+                    cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
                     EC_FAIL;
                 }
 
@@ -923,14 +1157,15 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
                                  db->cnid_sqlite_voluuid_str));
 
                 if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-                    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+                    cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
                     EC_FAIL;
                 }
 
                 free(sql);
                 sql = NULL;
-                EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "COMMIT"));
+                EC_NEG1(cnid_sqlite_commit(db->cnid_sqlite_con, &owned));
                 db->cnid_sqlite_flags |= CNID_SQLITE_FLAG_DEPLETED;
+                continue;
             }
 
             /* Finally assign our result */
@@ -939,24 +1174,34 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
             if (id == 0) {
                 LOG(log_error, logtype_cnid,
                     "cnid_sqlite_add: Invalid CNID 0 returned after insert!");
-                errno = CNID_INVALID;
+                errno = CNID_ERR_CORRUPT;
                 EC_FAIL;
             }
         }
-    } while (id == CNID_INVALID);
+    } while (id == CNID_INVALID && ++attempts < CNID_SQLITE_ADD_ATTEMPTS);
+
+    if (id == CNID_INVALID) {
+        /* Every attempt ended in a unique-key collision that the following
+         * lookup then failed to find: a row owns (Did, Name) or
+         * (DevNo, InodeNo) but is not reachable through either index. */
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_add: giving up after %d attempts for did: %" PRIu32
+            ", name: \"%s\": colliding row is not reachable by lookup",
+            attempts, ntohl(did), name);
+        errno = CNID_ERR_CORRUPT;
+        EC_FAIL;
+    }
 
 EC_CLEANUP:
-    LOG(log_maxdebug, logtype_cnid,
-        "cnid_sqlite_add(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\", hint: %"
-        PRIu32 "): END",
-        ntohl(id), ntohl(did), name, ntohl(hint));
 
-    if (cdb && db) {
-        if (was_depleted) {
-            sqlite3_reset(db->cnid_add_stmt);
-        } else {
-            sqlite3_reset(db->cnid_put_stmt);
-        }
+    if (db) {
+        LOG(log_maxdebug, logtype_cnid,
+            "cnid_sqlite_add(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\", hint: %"
+            PRIu32 "): END",
+            ntohl(id), ntohl(did), name, ntohl(hint));
+        cnid_sqlite_stmt_reset(db->cnid_add_stmt);
+        cnid_sqlite_stmt_reset(db->cnid_put_stmt);
+        cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
     }
 
     if (sql) {
@@ -970,17 +1215,22 @@ cnid_t cnid_sqlite_get(struct _cnid_db *cdb, cnid_t did, const char *name,
                        size_t len)
 {
     EC_INIT;
-    CNID_sqlite_private *db = cdb->cnid_db_private;
+    CNID_sqlite_private *db = NULL;
     cnid_t id = CNID_INVALID;
     int sqlite_return;
+
+    if (!cdb || !(db = cdb->cnid_db_private) || !name) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_get: Parameter error");
+        errno = CNID_ERR_PARAM;
+        EC_FAIL;
+    }
+
     LOG(log_maxdebug, logtype_cnid,
         "cnid_sqlite_get(did: %" PRIu32 ", name: \"%s\"): BEGIN",
         ntohl(did), name);
 
-    if (!cdb || !db || !name) {
-        LOG(log_error, logtype_cnid,
-            "cnid_sqlite_get: Parameter error");
-        errno = CNID_ERR_PARAM;
+    if (!cnid_sqlite_stmt_ready(db->cnid_get_stmt, "cnid_sqlite_get")) {
         EC_FAIL;
     }
 
@@ -993,31 +1243,57 @@ cnid_t cnid_sqlite_get(struct _cnid_db *cdb, cnid_t did, const char *name,
 
     sqlite3_reset(db->cnid_get_stmt);
     sqlite3_clear_bindings(db->cnid_get_stmt);
-    EC_ZERO_LOG(sqlite3_bind_text(db->cnid_get_stmt, 1, name, len,
-                                  SQLITE_STATIC));
-    EC_ZERO_LOG(sqlite3_bind_int64(db->cnid_get_stmt, 2, ntohl(did)));
+    sqlite_return = sqlite3_bind_text(db->cnid_get_stmt, 1, name, (int) len,
+                                      SQLITE_STATIC);
+
+    if (sqlite_return == SQLITE_OK) {
+        sqlite_return = sqlite3_bind_int64(db->cnid_get_stmt, 2, ntohl(did));
+    }
+
+    if (sqlite_return != SQLITE_OK) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_get: bind failed: %s",
+            sqlite3_errmsg(db->cnid_sqlite_con));
+        cnid_sqlite_set_errno(sqlite_return);
+        EC_FAIL;
+    }
+
     sqlite_return = sqlite3_step(db->cnid_get_stmt);
 
     if (sqlite_return == SQLITE_DONE) {
         LOG(log_debug, logtype_cnid,
             "cnid_sqlite_get: name: '%s', did: %u is not in the CNID database",
             name, ntohl(did));
+        errno = CNID_ERR_NOTFOUND;
     } else if (sqlite_return != SQLITE_ROW) {
+        /* Classified so the caller can tell a missing entry from a contended
+         * database */
         LOG(log_error, logtype_cnid,
             "cnid_sqlite_get: sqlite query error: %s",
             sqlite3_errmsg(db->cnid_sqlite_con));
+        cnid_sqlite_set_errno(sqlite_return);
         EC_FAIL;
     } else {
-        id = htonl((uint32_t)sqlite3_column_int64(db->cnid_get_stmt, 0));
+        uint64_t retid = sqlite3_column_int64(db->cnid_get_stmt, 0);
+
+        if (!cnid_sqlite_rowid_ok(retid)) {
+            LOG(log_error, logtype_cnid,
+                "cnid_sqlite_get: out of range id %" PRIu64
+                " for did: %u, name: '%s'", retid, ntohl(did), name);
+            errno = CNID_ERR_CORRUPT;
+            EC_FAIL;
+        }
+
+        id = htonl((uint32_t) retid);
     }
 
 EC_CLEANUP:
-    LOG(log_maxdebug, logtype_cnid,
-        "cnid_sqlite_get(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\"): END",
-        ntohl(id), ntohl(did), name);
 
-    if (cdb && db) {
-        sqlite3_reset(db->cnid_get_stmt);
+    if (db) {
+        LOG(log_maxdebug, logtype_cnid,
+            "cnid_sqlite_get(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\"): END",
+            ntohl(id), ntohl(did), name);
+        cnid_sqlite_stmt_reset(db->cnid_get_stmt);
     }
 
     return id;
@@ -1027,32 +1303,80 @@ char *cnid_sqlite_resolve(struct _cnid_db *cdb, cnid_t * id, void *buffer,
                           size_t len)
 {
     EC_INIT;
-    CNID_sqlite_private *db = cdb->cnid_db_private;
+    CNID_sqlite_private *db = NULL;
+
+    /* id is both an input and an output: the failure paths below write it */
+    if (!cdb || !(db = cdb->cnid_db_private) || !id || !buffer || len == 0) {
+        LOG(log_error, logtype_cnid, "cnid_sqlite_resolve: Parameter error");
+        errno = CNID_ERR_PARAM;
+
+        if (id) {
+            *id = CNID_INVALID;
+        }
+
+        EC_FAIL;
+    }
+
     LOG(log_maxdebug, logtype_cnid, "cnid_sqlite_resolve(id: %" PRIu32 "): BEGIN",
         ntohl(*id));
 
-    if (!cdb || !db) {
-        LOG(log_error, logtype_cnid, "cnid_sqlite_resolve: Parameter error");
-        errno = CNID_ERR_PARAM;
+    if (!cnid_sqlite_stmt_ready(db->cnid_resolve_stmt, "cnid_sqlite_resolve")) {
         *id = CNID_INVALID;
         EC_FAIL;
     }
 
     sqlite3_reset(db->cnid_resolve_stmt);
     sqlite3_clear_bindings(db->cnid_resolve_stmt);
-    sqlite3_bind_int64(db->cnid_resolve_stmt, 1, ntohl(*id));
-    EC_ZERO_LOG(sqlite3_bind_int64(db->cnid_resolve_stmt, 1, ntohl(*id)));
+    int resolve_return = sqlite3_bind_int64(db->cnid_resolve_stmt, 1,
+                                            ntohl(*id));
 
-    if (sqlite3_step(db->cnid_resolve_stmt) != SQLITE_ROW) {
+    if (resolve_return != SQLITE_OK) {
         LOG(log_error, logtype_cnid,
-            "cnid_sqlite_resolve: No result found for id: %" PRIu32, ntohl(*id));
+            "cnid_sqlite_resolve: bind failed for id: %" PRIu32 ": %s",
+            ntohl(*id), sqlite3_errmsg(db->cnid_sqlite_con));
+        cnid_sqlite_set_errno(resolve_return);
+        EC_FAIL;
+    }
+
+    resolve_return = sqlite3_step(db->cnid_resolve_stmt);
+
+    if (resolve_return != SQLITE_ROW) {
+        /* Only SQLITE_DONE is a missing id. afp_resolveid() in etc/afpd/file.c
+         * answers that with the permanent AFPERR_NOID. */
+        if (resolve_return == SQLITE_DONE) {
+            LOG(log_debug, logtype_cnid,
+                "cnid_sqlite_resolve: No result found for id: %" PRIu32, ntohl(*id));
+            errno = CNID_ERR_NOTFOUND;
+        } else {
+            LOG(log_error, logtype_cnid,
+                "cnid_sqlite_resolve: sqlite query error for id: %" PRIu32 ": %s",
+                ntohl(*id), sqlite3_errmsg(db->cnid_sqlite_con));
+            cnid_sqlite_set_errno(resolve_return);
+        }
+
         *id = CNID_INVALID;
         EC_FAIL;
     }
 
-    *id = htonl((uint32_t)sqlite3_column_int64(db->cnid_resolve_stmt, 0));
-    strlcpy(buffer, (const char *)sqlite3_column_text(db->cnid_resolve_stmt, 1),
-            len);
+    uint64_t resolve_result_did = sqlite3_column_int64(db->cnid_resolve_stmt, 0);
+    const unsigned char *resolve_result_name =
+        sqlite3_column_text(db->cnid_resolve_stmt, 1);
+
+    /* Name can be NULL on a corrupt page or under memory pressure, and
+     * strlcpy on it would fault afpd inside dirlookup */
+    if (!cnid_sqlite_rowid_ok(resolve_result_did)
+            || resolve_result_name == NULL) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_resolve: invalid/corrupt row for id: %" PRIu32
+            ": did=%" PRIu64 ", name=%s",
+            ntohl(*id), resolve_result_did,
+            resolve_result_name ? (const char *) resolve_result_name : "(null)");
+        errno = CNID_ERR_CORRUPT;
+        EC_FAIL;
+    }
+
+    *id = htonl((uint32_t) resolve_result_did);
+    strlcpy(buffer, (const char *) resolve_result_name, len);
     ((char *)buffer)[len - 1] = '\0';
     LOG(log_debug, logtype_cnid,
         "cnid_sqlite_resolve: resolved did: %u, name: \"%s\"",
@@ -1060,12 +1384,15 @@ char *cnid_sqlite_resolve(struct _cnid_db *cdb, cnid_t * id, void *buffer,
 EC_CLEANUP:
     LOG(log_maxdebug, logtype_cnid, "cnid_sqlite_resolve(): END");
 
-    if (cdb && db) {
-        sqlite3_reset(db->cnid_resolve_stmt);
+    if (db) {
+        cnid_sqlite_stmt_reset(db->cnid_resolve_stmt);
     }
 
     if (ret != 0) {
-        *id = CNID_INVALID;
+        if (id) {
+            *id = CNID_INVALID;
+        }
+
         return NULL;
     }
 
@@ -1079,31 +1406,70 @@ int cnid_sqlite_getstamp(struct _cnid_db *cdb, void *buffer,
                          const size_t len)
 {
     EC_INIT;
-    CNID_sqlite_private *db = cdb->cnid_db_private;
+    CNID_sqlite_private *db = NULL;
     LOG(log_maxdebug, logtype_cnid, "cnid_sqlite_getstamp(): BEGIN");
 
-    if (!cdb || !db) {
+    /* CNID_INVALID is 0, which this int-returning function's callers read as
+     * success, so parameter failures have to return -1 like every other path */
+    if (!cdb || !(db = cdb->cnid_db_private)) {
         LOG(log_error, logtype_cnid, "cnid_sqlite_getstamp: Parameter error");
         errno = CNID_ERR_PARAM;
-        return CNID_INVALID;
+        return -1;
     }
 
     if (!buffer) {
         LOG(log_error, logtype_cnid, "cnid_sqlite_getstamp: bad buffer");
-        return CNID_INVALID;
+        errno = CNID_ERR_PARAM;
+        return -1;
+    }
+
+    if (!cnid_sqlite_stmt_ready(db->cnid_getstamp_stmt, "cnid_sqlite_getstamp")) {
+        return -1;
     }
 
     sqlite3_reset(db->cnid_getstamp_stmt);
     sqlite3_clear_bindings(db->cnid_getstamp_stmt);
-    EC_ZERO_LOG(sqlite3_bind_text(db->cnid_getstamp_stmt, 1,
-                                  cdb->cnid_db_vol->v_path, strlen(cdb->cnid_db_vol->v_path),
-                                  SQLITE_STATIC));
+    int stamp_return = sqlite3_bind_text(db->cnid_getstamp_stmt, 1,
+                                         cdb->cnid_db_vol->v_path,
+                                         (int) strlen(cdb->cnid_db_vol->v_path),
+                                         SQLITE_STATIC);
 
-    if ((sqlite3_step(db->cnid_getstamp_stmt) != SQLITE_ROW)
-            || (sqlite3_column_text(db->cnid_getstamp_stmt, 0) == NULL)) {
+    if (stamp_return != SQLITE_OK) {
         LOG(log_error, logtype_cnid,
-            "cnid_sqlite_getstamp: Can't get DB stamp for volume \"%s\"",
+            "cnid_sqlite_getstamp: bind failed for volume \"%s\": %s",
+            cdb->cnid_db_vol->v_path, sqlite3_errmsg(db->cnid_sqlite_con));
+        cnid_sqlite_set_errno(stamp_return);
+        EC_FAIL;
+    }
+
+    stamp_return = sqlite3_step(db->cnid_getstamp_stmt);
+
+    /* A missing volumes row is missing data, not a failing backend:
+     * classifying SQLITE_DONE would end the session over a row that a
+     * rebuild recreates */
+    if (stamp_return == SQLITE_DONE) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_getstamp: no DB stamp for volume \"%s\"",
             cdb->cnid_db_vol->v_path);
+        errno = CNID_ERR_CORRUPT;
+        EC_FAIL;
+    }
+
+    if (stamp_return != SQLITE_ROW) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_getstamp: Can't get DB stamp for volume \"%s\": %s",
+            cdb->cnid_db_vol->v_path, sqlite3_errmsg(db->cnid_sqlite_con));
+        cnid_sqlite_set_errno(stamp_return);
+        EC_FAIL;
+    }
+
+    /* A row with no Stamp is unusable data, not a failing backend: classifying
+     * SQLITE_ROW would fall through to the session-fatal CNID_ERR_DB */
+    if (sqlite3_column_text(db->cnid_getstamp_stmt, 0) == NULL) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_getstamp: NULL DB stamp for volume \"%s\"",
+            cdb->cnid_db_vol->v_path);
+        errno = CNID_ERR_CORRUPT;
         EC_FAIL;
     }
 
@@ -1115,8 +1481,8 @@ int cnid_sqlite_getstamp(struct _cnid_db *cdb, void *buffer,
 EC_CLEANUP:
     LOG(log_maxdebug, logtype_cnid, "cnid_sqlite_getstamp(): END");
 
-    if (cdb && db) {
-        sqlite3_reset(db->cnid_getstamp_stmt);
+    if (db) {
+        cnid_sqlite_stmt_reset(db->cnid_getstamp_stmt);
     }
 
     EC_EXIT;
@@ -1134,18 +1500,35 @@ EC_CLEANUP:
  * asprintf("%%%s%%", name), which already requires a NUL-terminated
  * @p name. The parameter is kept to satisfy the cnid_db function-pointer
  * signature shared with the dbd / mysql backends.
+ *
+ * @p scope_did selects the statement: CNID_INVALID searches the whole
+ * volume, anything else only the subtree rooted at that directory.
  */
 int cnid_sqlite_find(struct _cnid_db *cdb, const char *name, size_t namelen _U_,
                      cnid_t scope_did,
                      void *buffer, size_t buflen, bool *more_available)
 {
     EC_INIT;
-    CNID_sqlite_private *db = cdb->cnid_db_private;
+    CNID_sqlite_private *db = NULL;
+    sqlite3_stmt *stmt = NULL;
     int count = 0;
     char *namelike = NULL;
     cnid_t *cnids = (cnid_t *)buffer;
     unsigned long max_results = buflen / sizeof(cnid_t);
     LOG(log_maxdebug, logtype_cnid, "cnid_sqlite_find(\"%s\"): BEGIN", name);
+
+    if (!cdb || !(db = cdb->cnid_db_private)) {
+        LOG(log_error, logtype_cnid, "cnid_sqlite_find: Parameter error");
+        errno = CNID_ERR_PARAM;
+        EC_FAIL;
+    }
+
+    stmt = scope_did != CNID_INVALID ? db->cnid_find_scoped_stmt
+           : db->cnid_find_stmt;
+
+    if (!cnid_sqlite_stmt_ready(stmt, "cnid_sqlite_find")) {
+        EC_FAIL;
+    }
 
     /* Parameters pre-validated by the libatalk/cnid/cnid.c wrapper:
      *   cdb, name non-NULL; namelen in [1, MAXPATHLEN-sizeof(uint32_t)];
@@ -1158,45 +1541,70 @@ int cnid_sqlite_find(struct _cnid_db *cdb, const char *name, size_t namelen _U_,
         *more_available = false;
     }
 
-    /* NULL matters: EC_NEG1 below can jump to cleanup, which resets
-     * the statement only when one was selected. */
-    sqlite3_stmt *stmt = NULL;
     /* Construct the LIKE pattern, escaping any special characters */
     EC_NEG1(asprintf(&namelike, "%%%s%%", name));
+    sqlite3_reset(stmt);
+    sqlite3_clear_bindings(stmt);
+    int find_return;
 
     if (scope_did != CNID_INVALID) {
-        /* Bind the scope DID in host order: the table stores host-order
-         * integers; the API traffics in network order. */
-        stmt = db->cnid_find_scoped_stmt;
-        sqlite3_reset(stmt);
-        sqlite3_clear_bindings(stmt);
-        EC_ZERO_LOG(sqlite3_bind_int64(stmt, 1,
-                                       (sqlite3_int64)ntohl(scope_did)));
-        EC_ZERO_LOG(sqlite3_bind_text(stmt, 2, namelike, strlen(namelike),
-                                      SQLITE_STATIC));
-        /* LIMIT max_results + 1: peek for an extra row to detect "more
-         * results exist" without a second query. */
-        EC_ZERO_LOG(sqlite3_bind_int64(stmt, 3,
-                                       (sqlite3_int64)(max_results + 1)));
+        /* The table stores host-order integers; the API traffics in network
+         * order */
+        find_return = sqlite3_bind_int64(stmt, 1,
+                                         (sqlite3_int64) ntohl(scope_did));
+
+        if (find_return == SQLITE_OK) {
+            find_return = sqlite3_bind_text(stmt, 2, namelike,
+                                            (int) strlen(namelike),
+                                            SQLITE_STATIC);
+        }
+
+        if (find_return == SQLITE_OK) {
+            /* LIMIT max_results + 1: peek for an extra row to detect "more
+             * results exist" without a second query. */
+            find_return = sqlite3_bind_int64(stmt, 3,
+                                             (sqlite3_int64)(max_results + 1));
+        }
     } else {
-        stmt = db->cnid_find_stmt;
-        sqlite3_reset(stmt);
-        sqlite3_clear_bindings(stmt);
-        EC_ZERO_LOG(sqlite3_bind_text(stmt, 1, namelike, strlen(namelike),
-                                      SQLITE_STATIC));
-        /* LIMIT max_results + 1: peek for an extra row to detect "more
-         * results exist" without a second query. */
-        EC_ZERO_LOG(sqlite3_bind_int64(stmt, 2,
-                                       (sqlite3_int64)(max_results + 1)));
+        find_return = sqlite3_bind_text(stmt, 1, namelike,
+                                        (int) strlen(namelike), SQLITE_STATIC);
+
+        if (find_return == SQLITE_OK) {
+            /* LIMIT max_results + 1: peek for an extra row to detect "more
+             * results exist" without a second query. */
+            find_return = sqlite3_bind_int64(stmt, 2,
+                                             (sqlite3_int64)(max_results + 1));
+        }
+    }
+
+    if (find_return != SQLITE_OK) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_find: bind failed: %s",
+            sqlite3_errmsg(db->cnid_sqlite_con));
+        cnid_sqlite_set_errno(find_return);
+        EC_FAIL;
     }
 
     /* Fetch up to max_results + 1 rows. The (max_results + 1)-th row, if
      * it exists, is the "more available" sentinel and is not stored in
      * cnids[]. */
-    while (sqlite3_step(stmt) == SQLITE_ROW
+    /* The step return is the only reliable source here: sqlite3_errcode() is
+     * sticky on the connection, so a SQLITE_CONSTRAINT that cnid_sqlite_add()
+     * handled and moved on from would make this successful search look failed. */
+    while ((find_return = sqlite3_step(stmt)) == SQLITE_ROW
             && count <= (int)max_results) {
+        uint64_t rowid = sqlite3_column_int64(stmt, 0);
+
+        /* A corrupt row is skipped, not fatal: the remaining matches are sound */
+        if (!cnid_sqlite_rowid_ok(rowid)) {
+            LOG(log_error, logtype_cnid,
+                "cnid_sqlite_find: out of range id %" PRIu64
+                " for name like '%s', skipped", rowid, name);
+            continue;
+        }
+
         if (count < (int)max_results) {
-            cnids[count] = htonl((uint32_t)sqlite3_column_int64(stmt, 0));
+            cnids[count] = htonl((uint32_t) rowid);
         }
 
         count++;
@@ -1210,11 +1618,11 @@ int cnid_sqlite_find(struct _cnid_db *cdb, const char *name, size_t namelen _U_,
         count = (int)max_results;
     }
 
-    if (sqlite3_errcode(db->cnid_sqlite_con) != SQLITE_OK
-            && sqlite3_errcode(db->cnid_sqlite_con) != SQLITE_DONE) {
+    if (find_return != SQLITE_ROW && find_return != SQLITE_DONE) {
         LOG(log_error, logtype_cnid,
             "cnid_sqlite_find: sqlite query error: %s",
             sqlite3_errmsg(db->cnid_sqlite_con));
+        cnid_sqlite_set_errno(find_return);
         EC_FAIL;
     }
 
@@ -1222,8 +1630,8 @@ int cnid_sqlite_find(struct _cnid_db *cdb, const char *name, size_t namelen _U_,
 EC_CLEANUP:
     LOG(log_maxdebug, logtype_cnid, "cnid_sqlite_find(): END");
 
-    if (cdb && db && stmt) {
-        sqlite3_reset(stmt);
+    if (db && stmt) {
+        cnid_sqlite_stmt_reset(stmt);
     }
 
     if (namelike) {
@@ -1251,24 +1659,25 @@ cnid_t cnid_sqlite_rebuild_add(struct _cnid_db *cdb _U_,
 int cnid_sqlite_wipe(struct _cnid_db *cdb)
 {
     EC_INIT;
-    CNID_sqlite_private *db = cdb->cnid_db_private;
+    CNID_sqlite_private *db = NULL;
     char *sql = NULL;
-    LOG(log_maxdebug, logtype_cnid, "cnid_sqlite_wipe(\"%s\"): BEGIN",
-        cdb->cnid_db_vol->v_localname);
+    int owned = 0;
 
-    if (!cdb || !db) {
+    if (!cdb || !(db = cdb->cnid_db_private) || !cdb->cnid_db_vol) {
         LOG(log_error, logtype_cnid, "cnid_sqlite_wipe: Parameter error");
         errno = CNID_ERR_PARAM;
         return -1;
     }
 
-    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "BEGIN"));
+    LOG(log_maxdebug, logtype_cnid, "cnid_sqlite_wipe(\"%s\"): BEGIN",
+        cdb->cnid_db_vol->v_localname);
+    EC_NEG1(cnid_sqlite_begin(db->cnid_sqlite_con, &owned));
     EC_NEG1(asprintf(&sql,
-                     "UPDATE volumes SET Depleted = 0 WHERE VolUUID = \"%s\";",
+                     "UPDATE volumes SET Depleted = 0 WHERE VolUUID = '%s';",
                      db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+        cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
         EC_FAIL;
     }
 
@@ -1277,7 +1686,7 @@ int cnid_sqlite_wipe(struct _cnid_db *cdb)
     EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\";", db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+        cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
         EC_FAIL;
     }
 
@@ -1288,7 +1697,7 @@ int cnid_sqlite_wipe(struct _cnid_db *cdb)
                      db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+        cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
         EC_FAIL;
     }
 
@@ -1299,17 +1708,39 @@ int cnid_sqlite_wipe(struct _cnid_db *cdb)
                      db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+        cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
         EC_FAIL;
     }
 
     free(sql);
     sql = NULL;
-    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "COMMIT"));
-    EC_ZERO(init_prepared_stmt(db));
+    EC_NEG1(cnid_sqlite_commit(db->cnid_sqlite_con, &owned));
+
+    if (init_prepared_stmt(db) != 0) {
+        /* The wipe is committed and the handles past the failure are NULL.
+         * Finalizing the rest leaves no half-prepared set to bind into, and
+         * cnid_sqlite_stmt_ready() then fails every operation until reopen. */
+        close_prepared_stmt(db);
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_wipe: could not re-prepare statements for volume "
+            "'%s'; the CNID database has to be reopened",
+            cdb->cnid_db_vol->v_localname);
+        errno = CNID_ERR_CLOSE;
+        EC_FAIL;
+    }
+
 EC_CLEANUP:
     LOG(log_maxdebug, logtype_cnid, "cnid_sqlite_wipe(\"%s\"): END",
         cdb->cnid_db_vol->v_localname);
+
+    if (sql) {
+        free(sql);
+    }
+
+    if (db) {
+        cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
+    }
+
     EC_EXIT;
 }
 
@@ -1342,6 +1773,7 @@ static struct _cnid_db *cnid_sqlite_new(struct vol *vol)
 struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
 {
     EC_INIT;
+    int owned = 0;
     CNID_sqlite_private *db = NULL;
     struct _cnid_db *cdb = NULL;
     char *sql = NULL;
@@ -1398,6 +1830,18 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
     EC_NULL(dbpath = bformat("%s/%s.sqlite", dirpath, vol->v_localname));
     dbpath_str = bdata(dbpath);
     EC_NULL(db->cnid_sqlite_voluuid_str = uuid_strip_dashes(vol->v_uuid));
+
+    /* The UUID names this volume's CNID table and is its key in the volumes
+     * table. Volumes sharing an empty one would share a single table named ""
+     * and collide on that primary key, serving each other's CNIDs. */
+    if (db->cnid_sqlite_voluuid_str[0] == '\0') {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_open: volume '%s' has no UUID, so its CNID table "
+            "cannot be named; check that %s is writable",
+            vol->v_path, vol->v_obj ? vol->v_obj->options.uuidconf : "the UUID file");
+        EC_FAIL;
+    }
+
     EC_ZERO(sqlite3_initialize());
     become_root();
     is_root = true;
@@ -1410,6 +1854,13 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
             dbpath_str);
         EC_FAIL;
     }
+
+    /* Without this every result code arrives masked to its primary value and
+     * the READONLY sub-codes cnid_sqlite_set_errno() distinguishes can never
+     * be seen: a transient recovery state would classify as a read-only
+     * volume. Everything else classifies through a & 0xff mask, so the wider
+     * codes change nothing there. */
+    sqlite3_extended_result_codes(db->cnid_sqlite_con, 1);
 
     /* Setting permissions of the sqlite db file to world-writable.
      * This is to allow CNID records to be updated by any authenticated AFP user.
@@ -1428,9 +1879,24 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
         }
     }
 
-    sqlite3_busy_timeout(db->cnid_sqlite_con, 2000);
-    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "PRAGMA synchronous=NORMAL;"));
-    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "PRAGMA journal_mode=WAL;"));
+    sqlite3_busy_timeout(db->cnid_sqlite_con, CNID_SQLITE_BUSY_TIMEOUT);
+
+    /* Neither pragma is worth refusing the volume over: a contended
+     * journal_mode conversion leaves the database in rollback-journal mode,
+     * which is slower but correct */
+    if (cnid_sqlite_execute(db->cnid_sqlite_con,
+                            "PRAGMA synchronous=NORMAL;") < 0) {
+        LOG(log_warning, logtype_cnid,
+            "cnid_sqlite_open: could not set synchronous=NORMAL for volume '%s'",
+            vol->v_path);
+    }
+
+    if (cnid_sqlite_execute(db->cnid_sqlite_con, "PRAGMA journal_mode=WAL;") < 0) {
+        LOG(log_warning, logtype_cnid,
+            "cnid_sqlite_open: could not switch volume '%s' to WAL mode",
+            vol->v_path);
+    }
+
     /* Setting permissions of the WAL and SHM files to world-writable.
      * These files are created by SQLite when WAL mode is enabled above.
      * Without this, files created by root would be inaccessible to non-root
@@ -1463,7 +1929,6 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
                             "Stamp BINARY(8), "
                             "Depleted INT"
                             ")") < 0) {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
         EC_FAIL;
     }
 
@@ -1471,7 +1936,6 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
     if (cnid_sqlite_execute(db->cnid_sqlite_con,
                             "CREATE INDEX IF NOT EXISTS idx_volpath "
                             "ON volumes(VolPath)") < 0) {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
         EC_FAIL;
     }
 
@@ -1494,59 +1958,93 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
          * early and leaving stale entries behind. */
         char *stale_uuids[64];
         int stale_count = 0;
+        int stale_return;
 
-        while (sqlite3_step(transient_stmt) == SQLITE_ROW
+        while ((stale_return = sqlite3_step(transient_stmt)) == SQLITE_ROW
                 && stale_count < 64) {
             const char *stale_uuid = (const char *)sqlite3_column_text(transient_stmt, 0);
 
-            if (stale_uuid) {
-                stale_uuids[stale_count] = strdup(stale_uuid);
-
-                if (stale_uuids[stale_count]) {
-                    stale_count++;
-                }
+            if (stale_uuid == NULL
+                    || (stale_uuids[stale_count] = strdup(stale_uuid)) == NULL) {
+                continue;
             }
+
+            stale_count++;
+        }
+
+        if (stale_return != SQLITE_DONE) {
+            LOG(log_warning, logtype_cnid,
+                "cnid_sqlite_open: stale volume scan for path '%s' stopped "
+                "early; the remainder is retried at the next open", vol->v_path);
         }
 
         sqlite3_finalize(transient_stmt);
         transient_stmt = NULL;
 
+        /* Each volumes row is the only record of its table's name, so a row is
+         * removed only once its own table and sequence entry are gone: a
+         * blanket delete after a failed or truncated drop pass would orphan
+         * every table it missed. Deleting per UUID also converges past the
+         * collection cap, one batch per open. */
         for (int i = 0; i < stale_count; i++) {
+            char *stale_sql = NULL;
+            int removed;
+
+            /* A UUID that is not 32 hex digits names no table this code
+             * created, so only its row is removed. The row is what brings it
+             * back at the next open. */
+            if (!cnid_sqlite_uuid_usable(stale_uuids[i])) {
+                LOG(log_error, logtype_cnid,
+                    "cnid_sqlite_open: refusing to act on malformed stale volume "
+                    "UUID for path '%s'; removing its entry", vol->v_path);
+                removed = cnid_sqlite_delete_volumes_row(db->cnid_sqlite_con,
+                          stale_uuids[i]) == 0;
+
+                if (!removed) {
+                    LOG(log_warning, logtype_cnid,
+                        "cnid_sqlite_open: could not remove malformed stale volume "
+                        "entry for path '%s'", vol->v_path);
+                }
+
+                free(stale_uuids[i]);
+                continue;
+            }
+
             LOG(log_warning, logtype_cnid,
                 "cnid_sqlite_open: removing stale volume entry UUID '%s' for path '%s'",
                 stale_uuids[i], vol->v_path);
-            char *drop_sql = NULL;
 
-            if (asprintf(&drop_sql, "DROP TABLE IF EXISTS \"%s\"", stale_uuids[i]) != -1) {
-                cnid_sqlite_execute(db->cnid_sqlite_con, drop_sql);
-                free(drop_sql);
+            if (asprintf(&stale_sql, "DROP TABLE IF EXISTS \"%s\"",
+                         stale_uuids[i]) == -1) {
+                stale_sql = NULL;
+                removed = 0;
+            } else {
+                removed = cnid_sqlite_execute(db->cnid_sqlite_con, stale_sql) == 0;
+                free(stale_sql);
             }
 
-            if (asprintf(&drop_sql,
-                         "DELETE FROM sqlite_sequence WHERE name = '%s'", stale_uuids[i]) != -1) {
-                cnid_sqlite_execute(db->cnid_sqlite_con, drop_sql);
-                free(drop_sql);
+            if (removed) {
+                removed = cnid_sqlite_delete_sequence_row(db->cnid_sqlite_con,
+                          stale_uuids[i]) == 0;
+            }
+
+            if (removed) {
+                removed = cnid_sqlite_delete_volumes_row(db->cnid_sqlite_con,
+                          stale_uuids[i]) == 0;
+            }
+
+            if (!removed) {
+                LOG(log_warning, logtype_cnid,
+                    "cnid_sqlite_open: could not fully remove stale volume UUID "
+                    "'%s' for path '%s'; keeping its entry to retry at the next "
+                    "open", stale_uuids[i], vol->v_path);
             }
 
             free(stale_uuids[i]);
         }
-
-        /* Remove stale volume rows */
-        sqlite3_stmt *delete_stmt = NULL;
-
-        if (sqlite3_prepare_v2(db->cnid_sqlite_con,
-                               "DELETE FROM volumes WHERE VolPath = ? AND VolUUID != ?",
-                               -1, &delete_stmt, NULL) == SQLITE_OK) {
-            sqlite3_bind_text(delete_stmt, 1, vol->v_path, -1, SQLITE_STATIC);
-            sqlite3_bind_text(delete_stmt, 2, db->cnid_sqlite_voluuid_str, -1,
-                              SQLITE_STATIC);
-            sqlite3_step(delete_stmt);
-            sqlite3_finalize(delete_stmt);
-        }
     }
 
-    /* Create a blob.  The MySQL code used an escape string function,
-           but we're going to use a prepared statement */
+    /* The stamp is binary, so it is bound rather than built into the SQL */
     time_t now = time(NULL);
     char stamp[8];
     memset(stamp, 0, 8);
@@ -1557,18 +2055,18 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
              "(VolUUID, Volpath, Stamp, Depleted) "
              "VALUES(?, ?, ?, 0)"));
     EC_ZERO_LOG(sqlite3_prepare_v2
-                (db->cnid_sqlite_con, sql, strlen(sql), &transient_stmt, NULL));
+                (db->cnid_sqlite_con, sql, (int) strlen(sql), &transient_stmt, NULL));
     free(sql);
     sql = NULL;
     EC_ZERO_LOG(sqlite3_bind_text(transient_stmt,
                                   1, db->cnid_sqlite_voluuid_str,
-                                  strlen(db->cnid_sqlite_voluuid_str), SQLITE_STATIC));
+                                  (int) strlen(db->cnid_sqlite_voluuid_str), SQLITE_STATIC));
     EC_ZERO_LOG(sqlite3_bind_text(transient_stmt,
                                   2, vol->v_path,
-                                  strlen(vol->v_path), SQLITE_STATIC));
+                                  (int) strlen(vol->v_path), SQLITE_STATIC));
     EC_ZERO_LOG(sqlite3_bind_text(transient_stmt,
                                   3, stamp,
-                                  strlen(stamp), SQLITE_STATIC));
+                                  (int) strlen(stamp), SQLITE_STATIC));
 
     if (sqlite3_step(transient_stmt) != SQLITE_DONE) {
         LOG(log_error, logtype_cnid,
@@ -1639,32 +2137,55 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
                      db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql)) {
-        EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
         EC_FAIL;
     }
 
     free(sql);
     sql = NULL;
-    /* Check if the table was just created (not just exists) */
-    int table_row_count = -1;
+    /* Whether the table was just created. LIMIT 1 answers that: only its
+     * emptiness matters, not the row count. */
+    int table_is_empty = -1;
     char *check_sql = NULL;
     sqlite3_stmt *check_table_stmt = NULL;
+    EC_NEG1(asprintf(&check_sql, "SELECT 1 FROM \"%s\" LIMIT 1;",
+                     db->cnid_sqlite_voluuid_str));
 
-    if (asprintf(&check_sql, "SELECT count(*) FROM \"%s\";",
-                 db->cnid_sqlite_voluuid_str) != -1) {
+    /* The seeding below needs a definite answer: it rewrites a live sequence on
+     * a populated table, and an unseeded empty one hands out the CNIDs AFP
+     * reserves. The prepare is inside the loop because it takes the schema lock
+     * and can itself return SQLITE_BUSY. */
+    for (int attempt = 0; attempt < CNID_SQLITE_EMPTY_PROBE_TRIES
+            && table_is_empty < 0; attempt++) {
         if (sqlite3_prepare_v2(db->cnid_sqlite_con, check_sql, -1, &check_table_stmt,
                                NULL) == SQLITE_OK) {
-            if (sqlite3_step(check_table_stmt) == SQLITE_ROW) {
-                table_row_count = sqlite3_column_int(check_table_stmt, 0);
+            int check_return = sqlite3_step(check_table_stmt);
+
+            if (check_return == SQLITE_ROW) {
+                table_is_empty = 0;
+            } else if (check_return == SQLITE_DONE) {
+                table_is_empty = 1;
+            } else {
+                LOG(log_warning, logtype_cnid,
+                    "cnid_sqlite_open: emptiness probe for volume '%s' failed: "
+                    "%s", vol->v_path, sqlite3_errmsg(db->cnid_sqlite_con));
             }
 
             sqlite3_finalize(check_table_stmt);
+            check_table_stmt = NULL;
         }
-
-        free(check_sql);
     }
 
-    if (table_row_count == 0) {
+    free(check_sql);
+    check_sql = NULL;
+
+    if (table_is_empty < 0) {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_open: could not determine whether the CNID table for "
+            "volume '%s' is empty", vol->v_path);
+        EC_FAIL;
+    }
+
+    if (table_is_empty == 1) {
         /* Directory IDs from 1 to 16 are reserved.
          * The Directory ID of the root is always 2.
          * The root’s Parent ID is always 1.
@@ -1678,12 +2199,15 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
         LOG(log_debug, logtype_cnid,
             "Creating new CNID table for volume '%s' with ID sequence starting at 16",
             vol->v_path);
+        /* Seeding is one unit: a partly seeded sequence would hand out CNIDs
+         * from the range AFP reserves */
+        EC_NEG1(cnid_sqlite_begin(db->cnid_sqlite_con, &owned));
         EC_NEG1(asprintf(&sql,
                          "UPDATE sqlite_sequence SET seq = 16 WHERE name = '%s';",
                          db->cnid_sqlite_voluuid_str));
 
         if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-            EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+            cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
             EC_FAIL;
         }
 
@@ -1696,12 +2220,13 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
                          db->cnid_sqlite_voluuid_str));
 
         if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-            EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
+            cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
             EC_FAIL;
         }
 
         free(sql);
         sql = NULL;
+        EC_NEG1(cnid_sqlite_commit(db->cnid_sqlite_con, &owned));
         /* Verify the sequence was set correctly */
         sqlite3_stmt *verify_stmt = NULL;
         EC_NEG1(asprintf(&sql, "SELECT seq FROM sqlite_sequence WHERE name = '%s';",
@@ -1728,8 +2253,7 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
         sql = NULL;
     } else {
         LOG(log_info, logtype_cnid,
-            "CNID table already initialized with %d existing entries",
-            table_row_count);
+            "CNID table for volume '%s' is already initialized", vol->v_path);
     }
 
     EC_ZERO(init_prepared_stmt(db));
@@ -1754,6 +2278,19 @@ EC_CLEANUP:
         cdb = NULL;
 
         if (db) {
+            /* The connection is unreachable after this, so an abandoned
+             * transaction would hold the write lock for the life of the
+             * process */
+            if (db->cnid_sqlite_con) {
+                cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
+                close_prepared_stmt(db);
+                sqlite3_close(db->cnid_sqlite_con);
+            }
+
+            if (db->cnid_sqlite_voluuid_str) {
+                free(db->cnid_sqlite_voluuid_str);
+            }
+
             free(db);
         }
     }

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1644,8 +1644,11 @@ static struct vol *creatvol(AFPObj *obj,
         volume->v_cnidport = strdup(obj->options.Cnid_port);
     }
 
+    /* iniparser answers an empty "volume uuid =" with "", not NULL, so the
+     * emptiness test is what routes such a volume to get_vol_uuid() below.
+     * The sqlite CNID backend names its per-volume table after this. */
     if ((val = getoption_str(obj->iniconfig, section, "volume uuid", preset,
-                             NULL))) {
+                             NULL)) && val[0] != '\0') {
         EC_NULL(volume->v_uuid = strdup(val));
         LOG(log_debug, logtype_afpd, "Volume '%s': UUID set from config: '%s'",
             name, volume->v_uuid);

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -103,6 +103,7 @@ if build_afpd_tests
         'faultinject.c',
         'peer_lock.c',
         'test_capabilities.c',
+        'subtests_cnid.c',
         'subtests_conf.c',
         'subtests_lock.c',
         'subtests_pfd.c',
@@ -158,6 +159,10 @@ if build_afpd_tests
         verbose: true,
         is_parallel: false,
         priority: 0,
+        # The CNID contention test waits out the backend's full busy timeout,
+        # and the valgrind CI leg multiplies everything else; meson's 30s
+        # default is too close for a loaded runner
+        timeout: 120,
     )
 
 endif

--- a/test/afpd/subtests_cnid.c
+++ b/test/afpd/subtests_cnid.c
@@ -1,0 +1,751 @@
+/*
+  Copyright (c) 2026 Andy Lemin (andylemin)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#ifdef CNID_BACKEND_SQLITE
+#include <sqlite3.h>
+#endif
+
+#include <atalk/cnid.h>
+#include <atalk/cnid_bdb_private.h>
+#include <atalk/globals.h>
+#include <atalk/util.h>
+#include <atalk/volume.h>
+
+#include "subtests_cnid.h"
+#include "test.h"
+
+#ifdef CNID_BACKEND_SQLITE
+/*!
+ * @brief Second connection to the volume's CNID database
+ *
+ * The view a peer session, or any other writer of the world-writable db file,
+ * has. The sqlite backend keeps that file at v_dbpath/v_localname.sqlite, mode
+ * 0666. NULL when the volume is not on the sqlite backend.
+ */
+static sqlite3 *cnid_peer_open(struct vol *vol)
+{
+    sqlite3 *peer = NULL;
+    char dbfile[MAXPATHLEN];
+    struct stat st;
+
+    if (vol->v_cdb == NULL || vol->v_dbpath == NULL
+            || vol->v_cnidscheme == NULL
+            || strcmp(vol->v_cnidscheme, "sqlite") != 0) {
+        return NULL;
+    }
+
+    snprintf(dbfile, sizeof(dbfile), "%s/%s.sqlite", vol->v_dbpath,
+             vol->v_localname);
+
+    if (stat(dbfile, &st) != 0) {
+        return NULL;
+    }
+
+    if (sqlite3_open(dbfile, &peer) != SQLITE_OK) {
+        if (peer) {
+            sqlite3_close(peer);
+        }
+
+        return NULL;
+    }
+
+    return peer;
+}
+
+/*!
+ * @brief Read the volume's AUTOINCREMENT high-water mark
+ *
+ * sqlite keeps the mark in sqlite_sequence keyed by table name, and the sqlite
+ * backend names each per-volume table after the volume UUID with the dashes
+ * stripped.
+ *
+ * @returns the mark, or -1 when it cannot be read -- in which case a test must
+ *          not plant a row that raises it, having no way to put it back
+ */
+static long long cnid_peer_get_seq(sqlite3 *peer, const char *uuid)
+{
+    sqlite3_stmt *stmt = NULL;
+    long long seq = -1;
+    char *sql = NULL;
+
+    if (asprintf(&sql, "SELECT seq FROM sqlite_sequence WHERE name = '%s'",
+                 uuid) == -1) {
+        return -1;
+    }
+
+    if (sqlite3_prepare_v2(peer, sql, -1, &stmt, NULL) == SQLITE_OK) {
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            seq = sqlite3_column_int64(stmt, 0);
+        }
+
+        sqlite3_finalize(stmt);
+    }
+
+    free(sql);
+    return seq;
+}
+
+/*!
+ * @brief Restore the AUTOINCREMENT high-water mark a probe row raised
+ *
+ * An explicit rowid above 2^32 lifts sqlite_sequence past the CNID range, and
+ * from there every add on the volume mints out-of-range rowids that fail the
+ * rest of the suite. A negative @p seq means the mark was never read, so no
+ * caller should have planted such a row; the mismatch is reported rather than
+ * passed over in silence.
+ */
+static void cnid_peer_set_seq(sqlite3 *peer, const char *uuid, long long seq)
+{
+    char *sql = NULL;
+
+    if (seq < 0) {
+        fprintf(stderr,
+                "# cnid_peer_set_seq: no saved sequence for '%s', cannot restore\n",
+                uuid);
+        return;
+    }
+
+    if (asprintf(&sql, "UPDATE sqlite_sequence SET seq = %lld WHERE name = '%s'",
+                 seq, uuid) != -1) {
+        sqlite3_exec(peer, sql, NULL, NULL, NULL);
+        free(sql);
+    }
+}
+#endif /* CNID_BACKEND_SQLITE */
+
+/*!
+ * @brief Every CNID_INVALID from the wrapper carries its own errno
+ *
+ * Callers branch on the CNID_ERR_* values to choose between a permanent reply
+ * and a retryable one, and get_id() (etc/afpd/file.c) ends the session on
+ * CNID_ERR_DB, so a rejection sets errno itself rather than leaving an earlier
+ * operation's value in place. The poison value here, EPERM, is what a failed
+ * chown or seteuid leaves behind and is also CNID_DBD_RES_NOTFOUND's value.
+ */
+int utest_cnid_wrapper_sets_errno(void)
+{
+    cnid_t id;
+    errno = EPERM;
+    /* len == 0 is rejected before cdb is dereferenced, so NULL is safe here */
+    id = cnid_add(NULL, NULL, htonl(2), "name", 0, CNID_INVALID);
+
+    if (id != CNID_INVALID) {
+        return 1;
+    }
+
+    if (CNID_ERRNO() != CNID_ERR_PARAM) {
+        return 2;
+    }
+
+    return 0;
+}
+
+static cnid_t fake_get_result;
+
+/*!
+ * @brief Backend cnid_get that answers with fake_get_result, whatever is asked
+ */
+static cnid_t fake_cnid_get(struct _cnid_db *cdb _U_, cnid_t did _U_,
+                            const char *name _U_, size_t len _U_)
+{
+    return fake_get_result;
+}
+
+/*!
+ * @brief valide() compares CNIDs in the right byte order
+ *
+ * Backends return CNIDs in network byte order, and valide()
+ * (libatalk/cnid/cnid.c) screens them against the host-order CNID_START of 17.
+ * On a little-endian host 16 valid ids byte-swap to below that bound, the
+ * lowest being host id 0x01000000, and the reserved ids 1-16 swap to above it.
+ */
+int utest_cnid_valide_byteorder(void)
+{
+    struct _cnid_db cdb = { 0 };
+    char name[] = "name";
+    cnid_t id;
+    cdb.cnid_get = fake_cnid_get;
+    /* Host id 0x01000000 is valid; its network representation on
+     * little-endian is 1, below CNID_START */
+    fake_get_result = htonl(0x01000000u);
+    errno = 0;
+    id = cnid_get(&cdb, htonl(2), name, 4);
+
+    if (id != fake_get_result) {
+        return 1;
+    }
+
+    /* Host id 3 is reserved and must be rejected whatever the host order */
+    fake_get_result = htonl(3);
+    errno = 0;
+    id = cnid_get(&cdb, htonl(2), name, 4);
+
+    if (id != CNID_INVALID) {
+        return 2;
+    }
+
+    if (CNID_ERRNO() != CNID_ERR_CORRUPT) {
+        return 3;
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief A contended CNID database classifies as BUSY, not as a dead backend
+ *
+ * A peer connection holding the write lock is ordinary contention between two
+ * sessions on one volume. afpd ends the session on CNID_ERR_DB (get_id() in
+ * etc/afpd/file.c), so contention must not report as one. The blocked add
+ * waits out the backend's busy timeout, so this test stalls for that long.
+ */
+int utest_cnid_add_busy_not_fatal(struct vol *vol)
+{
+#ifndef CNID_BACKEND_SQLITE
+    (void) vol;
+    return TEST_SKIP;
+#else
+    sqlite3 *peer;
+    char probe[MAXPATHLEN];
+    const char *name;
+    struct stat st;
+    cnid_t id;
+    int fd;
+    int result = 0;
+
+    /* NULL when the volume is not on the sqlite backend: a leftover .sqlite
+     * file beside a differently-backed volume must not be locked instead */
+    if ((peer = cnid_peer_open(vol)) == NULL) {
+        return TEST_SKIP;
+    }
+
+    snprintf(probe, sizeof(probe), "%s/cnid_busy_XXXXXX", vol->v_path);
+
+    if ((fd = mkstemp(probe)) < 0) {
+        sqlite3_close(peer);
+        return 1;
+    }
+
+    if (fstat(fd, &st) != 0) {
+        result = 2;
+        goto exit;
+    }
+
+    name = strrchr(probe, '/') + 1;
+
+    /* Take the writer lock the way a sibling session's transaction would */
+    if (sqlite3_exec(peer, "BEGIN EXCLUSIVE", NULL, NULL, NULL) != SQLITE_OK) {
+        result = 4;
+        goto exit;
+    }
+
+    errno = 0;
+    id = cnid_add(vol->v_cdb, &st, htonl(2), name, strlen(name), CNID_INVALID);
+
+    if (id != CNID_INVALID) {
+        /* The row this unexpected success minted must not outlive the test */
+        cnid_delete(vol->v_cdb, id);
+        result = 5;
+        goto exit;
+    }
+
+    if (CNID_ERRNO() != CNID_ERR_BUSY) {
+        result = 6;
+        goto exit;
+    }
+
+    sqlite3_exec(peer, "ROLLBACK", NULL, NULL, NULL);
+    sqlite3_close(peer);
+    peer = NULL;
+    /* The lock is gone: the very same add must now succeed */
+    id = cnid_add(vol->v_cdb, &st, htonl(2), name, strlen(name), CNID_INVALID);
+
+    if (id == CNID_INVALID) {
+        result = 7;
+        goto exit;
+    }
+
+    cnid_delete(vol->v_cdb, id);
+exit:
+
+    if (peer) {
+        sqlite3_exec(peer, "ROLLBACK", NULL, NULL, NULL);
+        sqlite3_close(peer);
+    }
+
+    close(fd);
+    unlink(probe);
+    return result;
+#endif /* CNID_BACKEND_SQLITE */
+}
+
+/*!
+ * @brief The CNID error codes stay distinct and out of the errno range
+ *
+ * The codes travel in errno and are compared against it, so each must be
+ * unique and clear of every system errno value. Their handling diverges
+ * sharply: get_id() (etc/afpd/file.c) ends the session on CNID_ERR_DB and
+ * fails just the one operation on the rest.
+ */
+int utest_cnid_error_codes_distinct(void)
+{
+    static const int codes[] = {
+        CNID_ERR_PARAM, CNID_ERR_PATH, CNID_ERR_DB, CNID_ERR_MAX,
+        CNID_ERR_CLOSE, CNID_ERR_BUSY, CNID_ERR_CORRUPT,
+        CNID_ERR_NOTFOUND,
+    };
+    const int count = (int)(sizeof(codes) / sizeof(codes[0]));
+
+    for (int i = 0; i < count; i++) {
+        /* Above INT_MAX, well clear of any system errno, so a stale errno
+         * cannot read as a CNID condition */
+        if ((unsigned int)codes[i] < 0x80000000u) {
+            return 1;
+        }
+
+        for (int j = i + 1; j < count; j++) {
+            if (codes[i] == codes[j]) {
+                return 2;
+            }
+        }
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief A not-found answer classifies out of the syscall errno range
+ *
+ * The dbd wire constant CNID_DBD_RES_NOTFOUND equals EPERM, and callers that
+ * switch on raw errno map EPERM to AFPERR_ACCESS (movecwd() in
+ * etc/afpd/directory.c), so an absent row answers CNID_ERR_NOTFOUND. The CNID
+ * probed here is high in the range and has no row.
+ */
+int utest_cnid_resolve_notfound_errno(struct vol *vol)
+{
+    char buf[MAXPATHLEN];
+    cnid_t id = htonl(0x00fffff0u);
+
+    if (vol->v_cdb == NULL || vol->v_cnidscheme == NULL
+            || strcmp(vol->v_cnidscheme, "sqlite") != 0) {
+        return TEST_SKIP;
+    }
+
+    errno = 0;
+
+    if (cnid_resolve(vol->v_cdb, &id, buf, sizeof(buf)) != NULL) {
+        return 1;
+    }
+
+    if (CNID_ERRNO() != CNID_ERR_NOTFOUND) {
+        return 2;
+    }
+
+    return 0;
+}
+
+static char fake_resolve_dotdot[] = "..";
+
+/*!
+ * @brief Backend cnid_resolve that answers "..", the corrupt name to reject
+ */
+static char *fake_cnid_resolve(struct _cnid_db *cdb _U_, cnid_t *id,
+                               void *buffer _U_, size_t len _U_)
+{
+    *id = htonl(2);
+    return fake_resolve_dotdot;
+}
+
+/*!
+ * @brief The wrapper's ".." rejection fails like a backend failure
+ *
+ * cnid_resolve() (libatalk/cnid/cnid.c) refuses a ".." name from the backend
+ * as a whole failure: NULL return, *id overwritten with CNID_INVALID in place
+ * of the parent DID the backend wrote, and errno set to CNID_ERR_CORRUPT.
+ */
+int utest_cnid_resolve_dotdot_rejected(void)
+{
+    struct _cnid_db cdb = { 0 };
+    char buf[64];
+    cnid_t id = htonl(1234);
+    cdb.cnid_resolve = fake_cnid_resolve;
+    errno = 0;
+
+    if (cnid_resolve(&cdb, &id, buf, sizeof(buf)) != NULL) {
+        return 1;
+    }
+
+    if (id != CNID_INVALID) {
+        return 2;
+    }
+
+    if (CNID_ERRNO() != CNID_ERR_CORRUPT) {
+        return 3;
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief 64-bit rows that do not fit a CNID classify as corrupt, not truncate
+ *
+ * A narrowed rowid names an unrelated live file, to hand out or to delete
+ * through, so an out-of-range Id or Did fails as CNID_ERR_CORRUPT. The db file
+ * is mode 0666, so such a row is one plain INSERT away.
+ */
+int utest_cnid_corrupt_row_classified(struct vol *vol)
+{
+#ifndef CNID_BACKEND_SQLITE
+    (void) vol;
+    return TEST_SKIP;
+#else
+    sqlite3 *peer;
+    char *uuid = NULL;
+    char *sql = NULL;
+    char buf[MAXPATHLEN];
+    char name_id[] = "cnid_corrupt_id";
+    cnid_t id;
+    int result = 0;
+
+    if ((peer = cnid_peer_open(vol)) == NULL) {
+        return TEST_SKIP;
+    }
+
+    if ((uuid = uuid_strip_dashes(vol->v_uuid)) == NULL) {
+        sqlite3_close(peer);
+        return 1;
+    }
+
+    long long saved_seq = cnid_peer_get_seq(peer, uuid);
+
+    /* The row below raises the high-water mark past the CNID range, so it is
+     * only planted when the mark can be restored afterwards */
+    if (saved_seq < 0) {
+        free(uuid);
+        sqlite3_close(peer);
+        return TEST_SKIP;
+    }
+
+    /* Id 2^32 + 17, which narrows to CNID 17, the first valid id */
+    if (asprintf(&sql,
+                 "INSERT INTO \"%s\" (Id, Name, Did, DevNo, InodeNo) "
+                 "VALUES (4294967313, 'cnid_corrupt_id', 2, 424241, 4242424241)",
+                 uuid) == -1) {
+        /* asprintf leaves the pointer indeterminate on failure, so it must not
+         * reach the free() at the exit label */
+        sql = NULL;
+        result = 2;
+        goto exit;
+    }
+
+    if (sqlite3_exec(peer, sql, NULL, NULL, NULL) != SQLITE_OK) {
+        result = 2;
+        goto exit;
+    }
+
+    free(sql);
+    sql = NULL;
+    errno = 0;
+    id = cnid_get(vol->v_cdb, htonl(2), name_id, strlen(name_id));
+
+    if (id != CNID_INVALID) {
+        result = 3;
+        goto exit;
+    }
+
+    if (CNID_ERRNO() != CNID_ERR_CORRUPT) {
+        result = 4;
+        goto exit;
+    }
+
+    /* Did too large for a CNID on the resolve read */
+    if (asprintf(&sql,
+                 "INSERT INTO \"%s\" (Id, Name, Did, DevNo, InodeNo) "
+                 "VALUES (16777001, 'cnid_corrupt_did', 4294967300, 424242, 4242424242)",
+                 uuid) == -1) {
+        sql = NULL;
+        result = 5;
+        goto exit;
+    }
+
+    if (sqlite3_exec(peer, sql, NULL, NULL, NULL) != SQLITE_OK) {
+        result = 5;
+        goto exit;
+    }
+
+    free(sql);
+    sql = NULL;
+    id = htonl(16777001);
+    errno = 0;
+
+    if (cnid_resolve(vol->v_cdb, &id, buf, sizeof(buf)) != NULL) {
+        result = 6;
+        goto exit;
+    }
+
+    if (CNID_ERRNO() != CNID_ERR_CORRUPT) {
+        result = 7;
+        goto exit;
+    }
+
+exit:
+
+    if (sql) {
+        free(sql);
+    }
+
+    if (asprintf(&sql, "DELETE FROM \"%s\" WHERE Name LIKE 'cnid_corrupt_%%'",
+                 uuid) != -1) {
+        sqlite3_exec(peer, sql, NULL, NULL, NULL);
+        free(sql);
+    }
+
+    cnid_peer_set_seq(peer, uuid, saved_seq);
+    free(uuid);
+    sqlite3_close(peer);
+    return result;
+#endif /* CNID_BACKEND_SQLITE */
+}
+
+/*!
+ * @brief A search never returns a CNID narrowed out of a 64-bit rowid
+ *
+ * cnid_find() feeds FPCatSearch, and a client opens what the search reports, so
+ * a narrowed Id hands it an unrelated live file. The out-of-range row is left
+ * out of the results.
+ */
+int utest_cnid_find_no_truncated_id(struct vol *vol)
+{
+#ifndef CNID_BACKEND_SQLITE
+    (void) vol;
+    return TEST_SKIP;
+#else
+    sqlite3 *peer;
+    char *uuid = NULL;
+    char *sql = NULL;
+    char name[] = "cnid_find_trunc";
+    cnid_t results[CNID_FIND_MIN_RESULTS];
+    bool more = false;
+    int count;
+    int result = 0;
+
+    if ((peer = cnid_peer_open(vol)) == NULL) {
+        return TEST_SKIP;
+    }
+
+    if ((uuid = uuid_strip_dashes(vol->v_uuid)) == NULL) {
+        sqlite3_close(peer);
+        return 1;
+    }
+
+    long long saved_seq = cnid_peer_get_seq(peer, uuid);
+
+    if (saved_seq < 0) {
+        free(uuid);
+        sqlite3_close(peer);
+        return TEST_SKIP;
+    }
+
+    /* Id 2^32 + 4242 narrows to 4242, the id the search must not report for
+     * this name */
+    if (asprintf(&sql,
+                 "INSERT INTO \"%s\" (Id, Name, Did, DevNo, InodeNo) "
+                 "VALUES (4294971538, 'cnid_find_trunc', 2, 434341, 4343434341)",
+                 uuid) == -1) {
+        sql = NULL;
+        result = 2;
+        goto exit;
+    }
+
+    if (sqlite3_exec(peer, sql, NULL, NULL, NULL) != SQLITE_OK) {
+        result = 2;
+        goto exit;
+    }
+
+    free(sql);
+    sql = NULL;
+    errno = 0;
+    count = cnid_find(vol->v_cdb, name, strlen(name), results, sizeof(results),
+                      &more);
+
+    if (count < 0) {
+        result = 3;
+        goto exit;
+    }
+
+    for (int i = 0; i < count; i++) {
+        if (ntohl(results[i]) == 4242) {
+            result = 4;
+            goto exit;
+        }
+    }
+
+exit:
+
+    if (sql) {
+        free(sql);
+    }
+
+    if (asprintf(&sql, "DELETE FROM \"%s\" WHERE Name = 'cnid_find_trunc'",
+                 uuid) != -1) {
+        sqlite3_exec(peer, sql, NULL, NULL, NULL);
+        free(sql);
+    }
+
+    cnid_peer_set_seq(peer, uuid, saved_seq);
+    free(uuid);
+    sqlite3_close(peer);
+    return result;
+#endif /* CNID_BACKEND_SQLITE */
+}
+
+/*!
+ * @brief Duplicate-row cleanup never deletes through a truncated rowid
+ *
+ * Two rows can legitimately satisfy lookup's disjuncts, (Name, Did) and
+ * (DevNo, InodeNo), and the surplus one is deleted. A surplus Id that does not
+ * fit a CNID narrows onto an unrelated live row, so it is reported as
+ * corruption and both rows are left in place.
+ */
+int utest_cnid_dup_row_no_truncated_delete(struct vol *vol)
+{
+#ifndef CNID_BACKEND_SQLITE
+    (void) vol;
+    return TEST_SKIP;
+#else
+    sqlite3 *peer;
+    char *uuid = NULL;
+    char *sql = NULL;
+    char name_a[] = "cnid_dup_a";
+    struct stat st;
+    cnid_t id;
+    int result = 0;
+
+    if ((peer = cnid_peer_open(vol)) == NULL) {
+        return TEST_SKIP;
+    }
+
+    if (vol->v_cdb->cnid_db_flags & CNID_FLAG_NODEV) {
+        sqlite3_close(peer);
+        return TEST_SKIP;
+    }
+
+    if ((uuid = uuid_strip_dashes(vol->v_uuid)) == NULL) {
+        sqlite3_close(peer);
+        return 1;
+    }
+
+    long long saved_seq = cnid_peer_get_seq(peer, uuid);
+
+    /* As above: row B's explicit rowid lifts the high-water mark out of the
+     * CNID range, so it is only planted when the mark can be restored */
+    if (saved_seq < 0) {
+        free(uuid);
+        sqlite3_close(peer);
+        return TEST_SKIP;
+    }
+
+    /* A matches lookup by (Name, Did); B matches by (DevNo, InodeNo) with an
+     * Id of 2^32 + 99999926, which narrows to C's Id; C matches nothing and is
+     * the live bystander a narrowed DELETE reaches */
+    if (asprintf(&sql,
+                 "INSERT INTO \"%s\" (Id, Name, Did, DevNo, InodeNo) VALUES "
+                 "(99999903, 'cnid_dup_a', 2, 515151, 616161), "
+                 "(4394967222, 'cnid_dup_b', 3, 717171, 818181), "
+                 "(99999926, 'cnid_dup_c', 5, 919191, 101010)",
+                 uuid) == -1) {
+        sql = NULL;
+        result = 2;
+        goto exit;
+    }
+
+    if (sqlite3_exec(peer, sql, NULL, NULL, NULL) != SQLITE_OK) {
+        result = 2;
+        goto exit;
+    }
+
+    free(sql);
+    sql = NULL;
+    memset(&st, 0, sizeof(st));
+    st.st_dev = 717171;
+    st.st_ino = 818181;
+    errno = 0;
+    id = cnid_lookup(vol->v_cdb, &st, htonl(2), name_a, strlen(name_a));
+
+    if (id != CNID_INVALID) {
+        result = 3;
+        goto exit;
+    }
+
+    /* Which row the cursor returned first is unspecified: the out-of-range
+     * surplus classifies as corrupt, a deletable surplus as not-found */
+    if (CNID_ERRNO() != CNID_ERR_CORRUPT
+            && CNID_ERRNO() != CNID_ERR_NOTFOUND) {
+        result = 4;
+        goto exit;
+    }
+
+    /* The bystander and the out-of-range row itself must both survive */
+    sqlite3_stmt *check = NULL;
+
+    if (asprintf(&sql,
+                 "SELECT COUNT(*) FROM \"%s\" WHERE Id IN (99999926, 4394967222)",
+                 uuid) == -1) {
+        sql = NULL;
+        result = 6;
+        goto exit;
+    }
+
+    if (sqlite3_prepare_v2(peer, sql, -1, &check, NULL) != SQLITE_OK) {
+        result = 6;
+        goto exit;
+    }
+
+    if (sqlite3_step(check) != SQLITE_ROW
+            || sqlite3_column_int(check, 0) != 2) {
+        result = 7;
+    }
+
+    sqlite3_finalize(check);
+exit:
+
+    if (sql) {
+        free(sql);
+    }
+
+    if (asprintf(&sql, "DELETE FROM \"%s\" WHERE Name LIKE 'cnid_dup_%%'",
+                 uuid) != -1) {
+        sqlite3_exec(peer, sql, NULL, NULL, NULL);
+        free(sql);
+    }
+
+    cnid_peer_set_seq(peer, uuid, saved_seq);
+    free(uuid);
+    sqlite3_close(peer);
+    return result;
+#endif /* CNID_BACKEND_SQLITE */
+}

--- a/test/afpd/subtests_cnid.h
+++ b/test/afpd/subtests_cnid.h
@@ -1,0 +1,16 @@
+#ifndef SUBTESTS_CNID_H
+#define SUBTESTS_CNID_H
+
+struct vol;
+
+extern int utest_cnid_wrapper_sets_errno(void);
+extern int utest_cnid_error_codes_distinct(void);
+extern int utest_cnid_valide_byteorder(void);
+extern int utest_cnid_resolve_dotdot_rejected(void);
+extern int utest_cnid_add_busy_not_fatal(struct vol *vol);
+extern int utest_cnid_resolve_notfound_errno(struct vol *vol);
+extern int utest_cnid_corrupt_row_classified(struct vol *vol);
+extern int utest_cnid_find_no_truncated_id(struct vol *vol);
+extern int utest_cnid_dup_row_no_truncated_delete(struct vol *vol);
+
+#endif /* SUBTESTS_CNID_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -43,6 +43,7 @@
 #include "filedir.h"
 #include "hash.h"
 #include "subtests.h"
+#include "subtests_cnid.h"
 #include "subtests_conf.h"
 #include "subtests_lock.h"
 #include "subtests_pfd.h"
@@ -516,6 +517,14 @@ int main(int argc, char *argv[])
                      "ea = samba reverts performance-oriented compiled defaults (freq 100, rfork on)");
     TEST_int_or_skip(utest_conf_load_afp_conf_vols_locked(), 0,
                      "config loader fails closed under lock contention, state-neutral");
+    TEST_int(utest_cnid_wrapper_sets_errno(), 0,
+             "CNID wrapper rejection sets its own errno, not a stale one");
+    TEST_int(utest_cnid_error_codes_distinct(), 0,
+             "CNID error codes are distinct and clear of the errno range");
+    TEST_int(utest_cnid_valide_byteorder(), 0,
+             "CNID wrapper validates returned ids in host byte order");
+    TEST_int(utest_cnid_resolve_dotdot_rejected(), 0,
+             "CNID wrapper '..' rejection invalidates *id and classifies corrupt");
     TEST_int_or_skip(utest_conf_dircache_resolve_size(), 0,
                      "dircache_resolve_size: default, minimum, round-up, clamp");
     TEST(afp_options_parse_cmdline(&obj, 3, &args[0]),
@@ -575,6 +584,16 @@ int main(int argc, char *argv[])
               vol->v_cnidport != NULL
               && strcmp(vol->v_cnidport, "4700") == 0,
               "volume: CNID port defaults to 4700");
+    TEST_int_or_skip(utest_cnid_add_busy_not_fatal(vol), 0,
+                     "cnid_add: contended backend classifies BUSY, not session-fatal");
+    TEST_int_or_skip(utest_cnid_resolve_notfound_errno(vol), 0,
+                     "cnid_resolve: not-found classifies out of the syscall errno range");
+    TEST_int_or_skip(utest_cnid_corrupt_row_classified(vol), 0,
+                     "cnid_get/resolve: 64-bit rows classify corrupt, never truncate");
+    TEST_int_or_skip(utest_cnid_find_no_truncated_id(vol), 0,
+                     "cnid_find: search results never carry a truncated id");
+    TEST_int_or_skip(utest_cnid_dup_row_no_truncated_delete(vol), 0,
+                     "cnid_lookup: duplicate cleanup never deletes through a truncated id");
     /* test directory.c stuff */
     TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT_PARENT), retdir != NULL,
               "dirlookup: root parent directory");

--- a/test/afpd/test.sh
+++ b/test/afpd/test.sh
@@ -25,8 +25,20 @@ if [ $? -ne 0 ]; then
 fi
 
 SIGNATURE=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 16)
-VOLUUID=$(uuidgen | tr 'a-z' 'A-Z')
-VOLUUIDSYS=$(uuidgen | tr 'a-z' 'A-Z')
+
+gen_uuid() {
+    hex=$(od -An -tx1 -N16 /dev/urandom | tr -d ' \n')
+    printf '%s-%s-%s-%s-%s\n' \
+        "$(echo "$hex" | cut -c1-8)" \
+        "$(echo "$hex" | cut -c9-12)" \
+        "$(echo "$hex" | cut -c13-16)" \
+        "$(echo "$hex" | cut -c17-20)" \
+        "$(echo "$hex" | cut -c21-32)" | tr 'a-z' 'A-Z'
+    return 0
+}
+
+VOLUUID=$(gen_uuid)
+VOLUUIDSYS=$(gen_uuid)
 
 if [ -f test.conf ]; then
     echo "Removing stale configuration template test.conf ..."

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -156,7 +156,9 @@ STATIC void test222()
 
     FAIL(FPCloseFork(Conn, fork1))
 fin:
-    action.sa_handler =  SIG_DFL;
+    /* Back to the process-wide SIG_IGN main() installed, not SIG_DFL: a
+     * dead server must fail a test, never kill the suite and its report */
+    action.sa_handler =  SIG_IGN;
     sigemptyset(&action.sa_mask);
     action.sa_flags = 0;
 
@@ -479,7 +481,7 @@ STATIC void test339()
     }
 
     FAIL(FPLogOut(loc_conn2));
-    action.sa_handler = SIG_DFL;
+    action.sa_handler = SIG_IGN;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
 
@@ -663,7 +665,7 @@ STATIC void test370()
     }
 
     FAIL(ntohl(AFPERR_MISC) != FPDisconnectOldSession(loc_conn2, 0, len, token))
-    action.sa_handler = SIG_DFL;
+    action.sa_handler = SIG_IGN;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
 

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <dlfcn.h>
 #include <getopt.h>
+#include <signal.h>
 #include <string.h>
 
 #include "afpclient.h"
@@ -428,6 +429,11 @@ int main(int ac, char **av)
 {
     int cc;
     int ret;
+    /* A server child dying mid-run must fail the test in flight, not kill
+     * the suite: unhandled, the next write to the dead session raises
+     * SIGPIPE and the run ends with no summary and no report file. Ignored,
+     * the write fails with EPIPE and is handled like any other error. */
+    signal(SIGPIPE, SIG_IGN);
 
     if (ac == 1) {
         usage(av[0]);


### PR DESCRIPTION
`get_id()` ends the AFP session on `CNID_ERR_DB` — the right answer for a CNID backend that has gone away, and the wrong one for a lock that will free. The sqlite backend (now the default) reported every failure as `CNID_ERR_DB`, so two sessions writing to one volume — or a full disk — disconnected clients mid-operation, and a contended *read* came back "not found", which `afp_resolveid` turns into a permanent `AFPERR_NOID`.

This PR gives the backend a real error contract (`CNID_ERR_BUSY` for what clears, `CNID_ERR_CORRUPT` for unusable data, `EROFS` for a read-only database), applies it to every path — write, read, bind, cleanup — and keeps the classification alive from the sqlite result code to the AFP reply. `CNID_ERR_DB` is no longer emitted by this backend at all: it means the backend process is gone, which a local database file cannot be. Along the way it fixes the adjacent defects it found (silent 64-bit truncation that could delete the wrong file, a NULL dereference, a byte-order bug in id validation, a failed COMMIT stranding the volume's write lock), and makes the write paths materially cheaper: the common-case update drops from six SQL statements to one, delete from three to one, and every value is bound on cached prepared statements instead of being pasted into SQL text ([details below](#per-operation-sql-cost)).

The test harness also stops destroying the evidence when something does go wrong mid-run: a dying server child now yields a named test failure, a finished JUnit report, and an afpd log dump in the CI job, where it previously killed the whole suite by SIGPIPE and left nothing but an exit code that looked like runner trouble ([details](#harness-observability)).

## Root cause

Three layers each made a locally reasonable choice; the composition is wrong:

1. **afpd's policy** (`get_id()`): `CNID_ERR_DB` ⇒ backend gone ⇒ `exit(EXITERR_SYS)`. Correct for the dbd backend, where it means the `cnid_dbd` companion process died and nothing can be catalogued until it returns.
2. **The backend's classification**: the mysql backend mapped every SQL failure to `CNID_ERR_DB` — defensible for a remote server. The sqlite backend was built on that shape, but an embedded WAL engine answers `SQLITE_BUSY` routinely and by design; there is no remote server to lose.
3. **errno as the carrier**: the classification travels in `errno`, but every cleanup path (`sqlite3_reset()`, `ROLLBACK`) enters the VFS and can overwrite it — and the not-found sentinel `CNID_DBD_RES_NOTFOUND` shares its value (1) with `EPERM`, so wherever raw errno gets switched on, "row absent" reads as a permission error.

With sqlite the default, that composition turned ordinary concurrency into disconnects.

## How the error contract got here

Each commit is locally correct; the defects are the seams between them:

- **`c08d8903` — didg, 2009.** `valide()` is born: reject junk ids from a confused DB. It compares the network-order id against the host-order `CNID_START` — invisible on big-endian, and volumes rarely reached id 0x01000000.
- **`f254fd61` — Ralph Boehme, 2013.** The MySQL backend, and with it "any SQL failure → `CNID_ERR_DB`". For a remote server, mostly true.
- **`3e7f6ed1` — Daniel Markstedt, 2023.** The tdb fallback is removed and `CNID_ERR_DB` becomes deliberately session-fatal — the right call for a dead `cnid_dbd` with no fallback left to mask it.
- **`68efab70` — Daniel Markstedt, 2025.** The SQLite backend arrives, built on the mysql implementation — inheriting the one-class error shape into an engine where `SQLITE_BUSY` is a routine answer, not a failure.
- **sqlite becomes the default backend, 2025–2026.** The composition is now every new install's default path.

## The defects, before and after

| failure | before | after |
|---|---|---|
| peer transaction holds the write lock | write path: **session disconnected**; read path: permanent `AFPERR_NOID` | `CNID_ERR_BUSY` → `AFPERR_MISC`, the client retries |
| disk full / I/O error / OOM | **session disconnected** | `CNID_ERR_BUSY` → `AFPERR_MISC`; the session survives while the condition clears |
| read-only database | **session disconnected** | `EROFS` → `AFPERR_VLOCK`, the answer for a locked volume — not an invitation to retry |
| unrecognised sqlite result (`SQLITE_ERROR`, `SCHEMA`, `CANTOPEN`, `LOCKED`, `MISUSE`) | **session disconnected** via `CNID_ERR_DB` | `CNID_ERR_CORRUPT` → the one operation fails |
| corrupt database / not-a-db file | disconnected, with no hint what to do | `CNID_ERR_CORRUPT` → `AFPERR_MISC`, rebuild advice in the log |
| 64-bit column that does not fit a CNID (`get`, `resolve`, lookup's duplicate cleanup) | silently truncated — the wrong file addressed, or **deleted** | range-checked through `cnid_sqlite_rowid_ok()` → `CNID_ERR_CORRUPT` |
| lookup's `Did` column outside 32 bits | unchecked: a truncated `Did` equals the queried did, so the identity comparison passes on a row `resolve` calls corrupt | range-checked with `Id` |
| `find` returning a narrowed id | an unrelated live file's CNID entered an `FPCatSearch` result, and the client opens that file | out-of-range row skipped and reported; the sound matches still return |
| `FPExchangeFiles`, `FPMoveAndRename` on a backend that could not answer | read as "no CNID recorded": the on-disk rename completed with the id swap skipped, silently breaking both files' identity | classified → `AFPERR_MISC`, nothing renamed |
| `movecwd()` returning to a caller that switches on raw errno | its self-heal's CNID calls left a `CNID_ERR_*` value there, so ~20 call sites hit their `default:` arm | the chdir errno is restored before every failure return, and `dirlookup_strict`'s `AFPERR_MISC` is not overwritten |
| `dir_modify()` on a curdir whose CNID lookup failed | fell through and re-indexed curdir under DID 0 (`CNID_INVALID`), tripping the dircache DID assert | the DID re-index runs only for a valid CNID |
| `get_id()`'s `CNID_ERR_CLOSE` arm | left `afp_errno` untouched, so callers replied with the previous call's value | sets `afp_errno` like every other arm |
| NULL statement handle after a failed re-prepare in `wipe` | `sqlite3_step(NULL)` — undefined | `cnid_sqlite_stmt_ready()` fails it closed as `CNID_ERR_CLOSE`; `wipe` finalizes the rest |
| parameter guards | evaluated after the dereference they guard, so the `CNID_ERR_PARAM` arms were unreachable | validated first; `resolve` also checks `id` |
| empty `volume uuid =` | iniparser returns `""`, not NULL, bypassing UUID generation: every such volume shared one CNID table named `""` and collided on the `volumes` primary key | routed to `get_vol_uuid()`, which generates via `randombytes()`; `cnid_sqlite_open()` refuses an empty UUID |
| NULL `Name` column in `resolve` | **afpd segfault** (`strlcpy` on NULL; the db file is world-writable) | guarded → `CNID_ERR_CORRUPT` |
| `getstamp`: missing `volumes` row; parameter failure | session-fatal; returned 0, which callers read as success | `CNID_ERR_CORRUPT`; returns −1 |
| bind failure | logged, then returned with stale errno | classified like every other failure |
| valid CNID ≥ 0x01000000 on little-endian (~16.7M creates) | falsely rejected as corruption by `valide()` and `getmetadata` — and a rebuild reproduces the rejection | `ntohl()` compares; the genuinely reserved ids 1–16 are now actually rejected |
| not-found leaking as `EPERM` | the stale-cache self-heal answered `AFPERR_ACCESS` for a directory another session had deleted (spectest `Error:test174`) | not-found is carried as `CNID_ERR_NOTFOUND`, out of the errno range, and `movecwd()` latches the chdir errno before its self-heal runs |
| `find` after a handled constraint | the connection's sticky `sqlite3_errcode()` made a successful search look failed | reads the step return |
| failed COMMIT | ownership released anyway — the write lock stranded for the connection's life, blocking every sibling session | ownership kept until COMMIT succeeds; the cleanup rollback closes what a failed COMMIT leaves open |
| stale volume-entry cleanup; `wipe` quoting | a blanket DELETE off an incomplete scan could orphan CNID tables for good; `-DSQLITE_DQS=0` builds could never wipe/rebuild | per-UUID removal — converges past the collection cap, cannot orphan; single-quoted literals |
| stale `VolUUID` read back out of the world-writable db | interpolated into the `sqlite_sequence` and `volumes` deletes | bound as a parameter; a UUID that is not 32 hex digits names no table this code created, so only its row goes and the scan converges |

## The fix, in brief

- **The contract.** BUSY = nothing is wrong with the backend (contention, or an environmental condition that clears); CORRUPT = unusable data, rebuild advised; `EROFS` = a read-only database, which `afp_deleteid()` already answers with `AFPERR_VLOCK`. `SQLITE_PROTOCOL` (WAL's bounded handshake giving up) is BUSY; `SQLITE_LOCKED` deliberately is not — the busy handler never waits on it, so a retry finds the same state. `CNID_ERR_DB` is left unused here: it means the backend process is gone, and a local file has no such state, so an unrecognised code fails the one operation as CORRUPT.
- **Classified everywhere.** `cnid_sqlite_set_errno()` runs at every failure site: steps, execs, and binds.
- **The classification survives its own cleanup.** `cnid_sqlite_stmt_reset()` and an errno-preserving rollback wrap every cleanup path, and `cnid_sqlite_add` proceeds to its insert only on a genuine not-found — any other failure cannot be fixed by inserting.
- **Not-found moved out of the errno range.** `CNID_ERR_NOTFOUND` replaces the errno use of the dbd wire constant `CNID_DBD_RES_NOTFOUND` (== `EPERM`), whose value leaked into raw errno switches downstream.
- **Consumers act on the difference, through one predicate.** `CNID_ERRNO_IS_BACKEND_FAILURE()` in `include/atalk/cnid.h` replaces the hand-copied classification triplets. `get_id()`, `getmetadata()`, `dirlookup()`, `afp_resolveid()`, `afp_deleteid()`, `afp_exchangefiles()`, `moveandrename()` and `enumerate()`'s v2→EA conversion answer BUSY/CORRUPT with `AFPERR_MISC` instead of a permanent error, and honour each other's classification instead of flattening it.
- **errno is primed in the wrapper, not at each call site.** `libatalk/cnid/cnid.c` clears it before dispatching to any backend, so one reset covers every backend and every caller — dbd and mysql say nothing on not-found, so a stale value would otherwise be read as the verdict.
- **One prepared-statement skeleton.** The eleven per-volume statements go through `init_prepared_stmt_one()` rather than eleven copies of the same finalize/asprintf/prepare block.

## Per-operation SQL cost

Beyond classification, the rewrite cuts what each CNID operation costs the engine — fewer statements, no SQL parsing on the hot paths, and no value interpolated into statement text:

| operation | before | after |
|---|---|---|
| `update` (common case) | **6 statements**: exec `BEGIN`, three `DELETE`s built with `asprintf` and parsed per call, prepared `INSERT`, exec `COMMIT` — delete-then-reinsert on *every* update, inside an **unbounded** retry loop | **1 statement**: a cached prepared `UPDATE` under autocommit; the reinsert runs only if the row vanished |
| `update` (proven UNIQUE collision) | the same six, again and again | one bounded second attempt: two cached prepared `DELETE`s + the write, inside one owned transaction |
| `delete` | exec `BEGIN` + prepared `DELETE` + exec `COMMIT` (3 statements, 2 parsed per call) | **1** prepared `DELETE` — a single-statement autocommit is already atomic |
| `add` | insert (re)attempted after *any* lookup failure, loop unbounded | insert only on a genuine not-found; cycle bounded by `CNID_SQLITE_ADD_ATTEMPTS` |
| parameter passing on the paths above | ids, dev/ino — and the **filename** — interpolated into SQL text: one parse per call, and a name containing a double quote broke the statement outright | all values bound as parameters on per-volume cached prepared statements (eleven now; `update` and the two collision `DELETE`s are newly cached) |
| session close | WAL carried over, growing across sessions | `SQLITE_CHECKPOINT_TRUNCATE` folds the WAL back — with the busy timeout zeroed first so it skips rather than stalls behind readers, retrying at the next close |

## Behaviour changes

- Ordinary contention and disk-full fail the operation; they do not end the session. No sqlite result code ends the session any more.
- Transient backend trouble is retryable (`AFPERR_MISC`) — never a permanent `AFPERR_NOID`/`AFPERR_NOOBJ`/`AFPERR_PARAM` for an object that exists.
- Corruption is reported as corruption, with rebuild advice — and can no longer address the wrong file, delete through a truncated id, or crash afpd.
- Little-endian volumes past ~16.7M CNIDs resolve correctly.
- A failed COMMIT no longer blocks the volume for the life of the connection, and `-DSQLITE_DQS=0` builds can wipe/rebuild the database.
- A read-only database answers `AFPERR_VLOCK` (volume locked) rather than inviting a retry that cannot succeed.
- `FPExchangeFiles` and `FPMoveAndRename` fail rather than completing a rename whose CNID swap was skipped.
- A volume with an empty `volume uuid` gets a generated one instead of sharing a CNID table named `""`. Where the UUID file cannot be written, its CNID database is refused instead — a louder failure than before for that state.
- Filenames containing a double quote no longer break the update path (they were interpolated into the SQL text; all values are bound now).

## Testing

### Unit tests
- afpd unit suite: **0 fail** (Alpine container, meson `-Dwith-tests=true`), including nine CNID tests:
  - **the headline behaviour**: a peer sqlite connection holds `BEGIN EXCLUSIVE`; `cnid_add()` must return `CNID_ERR_BUSY` (not session-fatal `CNID_ERR_DB`), and the very same add must succeed once the lock is released;
  - a not-found answer classifies as `CNID_ERR_NOTFOUND`, out of the syscall errno range — not the `EPERM`-valued dbd wire sentinel;
  - 64-bit rows injected through a peer connection classify as `CNID_ERR_CORRUPT` in `cnid_get`/`cnid_resolve` instead of truncating to a live file's id;
  - the duplicate-row cleanup never deletes through a truncated rowid (a live row whose id equals the narrowed value survives);
  - a search never returns a narrowed id: a row with `Id` = 2^32 + 4242 must not put CNID 4242 into an `FPCatSearch` result (fails without the `find` range check);
  - the wrapper errno contract, starting from a poisoned `errno = EPERM` (the `CNID_DBD_RES_NOTFOUND` collision);
  - the CNID error codes stay mutually distinct and clear of the system errno range;
  - `valide()` byte order and the `cnid_resolve()` `".."` rejection, via fake backends (the former fails without the `ntohl()` fix on little-endian).
- A probe row is only planted when the AUTOINCREMENT high-water mark it raises can be read back and restored, so a failed read cannot leave the volume minting out-of-range rowids for the rest of the suite. sqlite-specific tests compile out and skip on builds without the sqlite backend.
- Valgrind (`meson test --wrapper='valgrind --leak-check=full --error-exitcode=1'`): 0 errors, no leaks.
- The harness generates its volume UUIDs from `/dev/urandom`, so the suite no longer needs `uuidgen` (absent from the project's own container images, where it silently produced empty volume UUIDs).

### Spectests (sqlite backend, single-container loopback)
- ea = sys leg: **288 passed / 94 skipped / 0 failed**
- ea = ad leg (`AFP_ADOUBLE=1`): **288 passed / 94 skipped / 0 failed**
- ARC stress leg (`AFP_DIRCACHESIZE=1024`, `AFP_DIRCACHE_MODE=arc`, `AFP_DIRCACHE_VALIDATION_FREQ=100`): **288 passed / 94 skipped / 0 failed**, including `Error:test174`, the cross-session deleted-directory case that exposed the `EPERM`-valued not-found leak

### Harness observability

A server child dying mid-run used to kill `afp_spectest` with SIGPIPE before the summary or the JUnit report were written — the job then looked like a CI-runner failure with no artifacts (three distinct one-off leg failures on this PR shared exactly that shape, each passing on rerun). Now:

- `afp_spectest` ignores SIGPIPE, so a write to a dead session fails the test in flight with EPIPE and the run completes with a summary and a report;
- the `FPDisconnectOldSession` tests restore the process-wide ignore rather than `SIG_DFL`;
- the container entrypoint dumps `/var/log/afpd.log` on any non-zero exit, so a dying child ships its own post-mortem.

Validated by killing afpd 35s into a run: the suite recorded 22 failures, wrote the JUnit report, dumped the server log, and exited 1 — where it previously died at exit 141 with nothing.

## Not in this PR (follow-ups)

- **Everything reset-shaped lands in the exhaustion-recovery follow-up branch**, and is entirely absent here: `CNID_ERR_RESET` (defined there, where it is first raised and announced to every session), the dead depletion guard in `cnid_sqlite_add` (`(uint32_t) lastid > UINT32_MAX` cannot fire; that branch rewrites the block with the correct 64-bit compare and the recovery announcement), the hint-channel rework, and two mechanical cleanups (`get_id()`'s switch tails, the triplicated `sqlite_sequence` seeding SQL) whose sites collide with its hunks.
- **The mysql backend** gets this contract in its own follow-up branch — its resolve/not-found errno, `getstamp`'s 0-on-error, and the `CNID_ERR_NOTFOUND` adoption land there.
- **`catsearch`, `mangle` and `spotlight`** still ignore errno on their resolve paths; all degrade gracefully (mangled-name fallback, skipped search entry) rather than answer wrongly and permanently.
- **`spotlight.c`'s `memcpy(uuid.sl_uuid, v->v_uuid, 16)`** is guarded only against a NULL `v_uuid`, so a short one is a 16-byte read off a smaller buffer. Generation now keeps it 36 bytes, but the read wants a length check of its own.
- **The dbd backend is untouched**: its `CNID_ERR_DB` genuinely means the companion process died, its exhaustion signal `CNID_ERR_MAX` still falls to `get_id()`'s `default:` arm, and it never wipes, so it degrades safely.

---

The diagram is the contract: which sqlite results become which classification, what preserves it in transit, and what each consumer does with it. Every defect above is a divergence between two adjacent columns.

```mermaid
%%{init: {'flowchart': {'curve': 'basis'}, 'themeVariables': {'edgeLabelBackground': '#e5e7eb'}}}%%
flowchart LR
    classDef rc     fill:#374151,stroke:#4b5563,color:#f9fafb,stroke-width:1px;
    classDef cls    fill:#0f766e,stroke:#0d9488,color:#f0fdfa,stroke-width:1px;
    classDef err    fill:#b45309,stroke:#d97706,color:#fffbeb,stroke-width:1px;
    classDef cons   fill:#5b21b6,stroke:#6d28d9,color:#f5f3ff,stroke-width:1px;
    classDef ok     fill:#1e3a8a,stroke:#1e40af,color:#eff6ff,stroke-width:1px;
    classDef fatal  fill:#9f1239,stroke:#be123c,color:#fff1f2,stroke-width:1px;

    subgraph SQLITE["sqlite result codes"]
        BUSYRC("SQLITE_BUSY<br/>SQLITE_PROTOCOL<br/><i>lock will free</i>"):::rc
        ENVRC("SQLITE_FULL · IOERR<br/>NOMEM · READONLY<br/><i>environment, clears</i>"):::rc
        CORRC("SQLITE_CORRUPT<br/>SQLITE_NOTADB"):::rc
        ROWRC("row guards (cnid_sqlite_rowid_ok):<br/>Id/Did outside 32-bit<br/>NULL Name · no stamp row"):::rc
        RORC("SQLITE_READONLY<br/><i>read-only database</i>"):::rc
        DEFRC("everything else<br/><i>incl. SQLITE_LOCKED —<br/>busy handler never waits on it</i>"):::rc
        DONERC("SQLITE_DONE<br/><i>no row</i>"):::rc
    end

    SET("cnid_sqlite_set_errno()<br/>at every step, exec and bind"):::cls

    subgraph CARRY["classification in transit"]
        PRESERVE("cnid_sqlite_stmt_reset()<br/>errno-preserving rollback<br/><i>cleanups cannot clobber errno</i>"):::cls
        VALIDE("wrapper valide(): ntohl(id) < CNID_START<br/>→ CNID_ERR_CORRUPT"):::cls
    end

    EBUSY("CNID_ERR_BUSY"):::err
    ECORR("CNID_ERR_CORRUPT"):::err
    EROFSN("EROFS"):::err
    ENF("CNID_ERR_NOTFOUND<br/><i>out of the errno range,<br/>unlike the dbd sentinel<br/>== EPERM</i>"):::err

    subgraph AFPD["afpd consumers"]
        GETID("get_id()<br/><i>cnid_add, write path</i>"):::cons
        RESOLVE("afp_resolveid()<br/>afp_deleteid()<br/>dirlookup()"):::cons
    end

    MISC("AFPERR_MISC<br/><i>operation fails,<br/>client retries,<br/>session survives</i>"):::ok
    VLOCK("AFPERR_VLOCK<br/><i>volume locked</i>"):::ok
    NOID("AFPERR_NOID / NOOBJ<br/><i>only for a genuine<br/>not-found</i>"):::ok
    EXIT("exit(EXITERR_SYS)<br/><i>dbd only: no sqlite<br/>result reaches this</i>"):::fatal

    BUSYRC --> SET
    ENVRC --> SET
    CORRC --> SET
    ROWRC --> SET
    RORC --> SET
    DEFRC --> SET
    DONERC --> ENF
    SET --> EBUSY
    SET --> ECORR
    SET --> EROFSN
    EBUSY --> PRESERVE
    ECORR --> PRESERVE
    EROFSN --> PRESERVE
    ENF --> PRESERVE
    PRESERVE --> VALIDE
    VALIDE --> GETID
    VALIDE --> RESOLVE
    GETID -->|"BUSY · CORRUPT"| MISC
    RESOLVE -->|"BUSY · CORRUPT"| MISC
    RESOLVE -->|"EROFS"| VLOCK
    RESOLVE -->|"NOTFOUND"| NOID
```



