### PR TITLE
ci: prune stale perf-history keys; 30-PR rolling dashboard baseline

### DIFF
--- a/.github/scripts/perf_history.pl
+++ b/.github/scripts/perf_history.pl
@@ -24,14 +24,17 @@
 # where render is "table" (a row in the section's markdown table) or
 # "inline" (a bold run-on stat for the section header). Keys are free-form
 # and self-describing (e.g. lantest.creating_2000_files.mean_ms); a renamed
-# test simply starts a new key while the old one goes stale, so nothing is
-# positional and metrics can be added or dropped at any time.
+# test simply starts a new key, and the old key is pruned automatically
+# once it stops receiving entries, so nothing is positional and metrics
+# can be added, renamed or dropped at any time.
 #
 # The history file is a YAML mapping of key -> list of {pr, ts, value}
 # entries. Each PR holds at most one entry per key: a re-run of the same PR
 # replaces its previous value (so a PR's repeated CI pushes don't skew the
 # baseline), and each list is trimmed to the newest 100 entries. The
-# historical stats for the delta exclude the current PR's own entry.
+# historical stats for the delta exclude the current PR's own entry and
+# cover only the newest 30 stored values, so the baseline follows recent
+# performance instead of averaging the whole stored series.
 #
 # The YAML reader/writer below handles exactly the shape this script
 # writes (block mapping of block sequences of flat mappings); anything it
@@ -62,6 +65,17 @@ use File::Basename qw(dirname);
 use File::Path     qw(make_path);
 
 my $MAX_ENTRIES_PER_METRIC = 100;
+
+# Historical stats window: hist_stats() averages only this many of a key's
+# newest entries. Long enough to smooth runner variance, short enough that
+# an accepted performance change becomes the new baseline within weeks
+# rather than being diluted by the full 100-entry series.
+my $HIST_STATS_WINDOW = 30;
+
+# A key with no entry in its group's most recent runs (distinct PRs) is
+# obsolete — its test was renamed or removed — and gets pruned. Three runs
+# of grace keep a test that merely skipped a run or two alive.
+my $PRUNE_GRACE_RUNS = 3;
 
 # Parse pipe-separated metric lines; skip anything malformed.
 sub load_metrics {
@@ -164,12 +178,15 @@ sub fmt_delta {
     return sprintf('%+.1f%%', 100.0 * ($cur - $avg) / $avg);
 }
 
-# (avg, min, max, count) of stored values for key, excluding the current
-# PR's own entry. Returns an empty list when no history exists.
+# (avg, min, max, count) of the newest $HIST_STATS_WINDOW stored values
+# for key, excluding the current PR's own entry. Returns an empty list
+# when no history exists.
 sub hist_stats {
     my ($hist, $key, $current_pr) = @_;
     my @values = map { $_->{value} + 0 }
       grep { $_->{pr} ne $current_pr } @{$hist->{$key} // []};
+    splice @values, 0, @values - $HIST_STATS_WINDOW
+      if @values > $HIST_STATS_WINDOW;
     return unless @values;
     my ($sum, $min, $max) = (0, $values[0], $values[0]);
     for my $v (@values) {
@@ -187,6 +204,40 @@ sub upsert {
     splice @entries, 0, @entries - $MAX_ENTRIES_PER_METRIC
       if @entries > $MAX_ENTRIES_PER_METRIC;
     $hist->{$key} = \@entries;
+}
+
+# Prune obsolete keys after the current run's rows have been upserted.
+# When a test is renamed or removed, its old key stops receiving entries
+# while the rest of its group (keys sharing the first dot-separated
+# segment, e.g. "lantest") moves on; without pruning the dead key stays in
+# the history — and in every future trend-chart legend — forever, since
+# the per-key entry cap only trims keys that still receive data. A key
+# with no entry in its group's $PRUNE_GRACE_RUNS most recent runs
+# (distinct PRs, ranked by their newest timestamp) is dropped. Only groups
+# with rows in the current run are examined: a section whose CI job failed
+# contributes no rows, and its keys must not age toward pruning on another
+# section's clock.
+sub prune_stale {
+    my ($hist, $rows) = @_;
+    my %groups = map { ((split /\./, $_->[1], 2)[0]) => 1 } @$rows;
+    for my $group (keys %groups) {
+        my @keys = grep { (split /\./, $_, 2)[0] eq $group } keys %$hist;
+        my %pr_ts;
+        for my $key (@keys) {
+            for my $e (@{$hist->{$key}}) {
+                my $ts = $e->{ts} // '';
+                $pr_ts{$e->{pr}} = $ts
+                  if !exists $pr_ts{$e->{pr}} || $ts gt $pr_ts{$e->{pr}};
+            }
+        }
+        my @recent =
+          (sort { $pr_ts{$b} cmp $pr_ts{$a} } keys %pr_ts)[0 .. $PRUNE_GRACE_RUNS - 1];
+        my %recent = map { $_ => 1 } grep {defined} @recent;
+        for my $key (@keys) {
+            delete $hist->{$key}
+              unless grep { $recent{$_->{pr}} } @{$hist->{$key}};
+        }
+    }
 }
 
 sub median {
@@ -328,6 +379,7 @@ sub main {
 
     open my $out, '>>:encoding(UTF-8)', $github_output
       or die "cannot append $github_output: $!\n";
+    my @all_rows;
     for my $spec (@sections) {
         my ($name, $path) = split /=/, $spec, 2;
         die "bad --section (want NAME=FILE): $spec\n" unless defined $path && length $path;
@@ -337,9 +389,11 @@ sub main {
         write_output($out, "${name}_table",  $table_md);
         write_output($out, "${name}_inline", $inline_md);
         upsert($hist, $_->[1], $pr, $timestamp, $_->[4]) for @$rows;
+        push @all_rows, @$rows;
     }
     close $out;
 
+    prune_stale($hist, \@all_rows);
     save_history($history_path, $hist);
     return 0;
 }

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -2278,8 +2278,10 @@ jobs:
           # value" lines. Merge them into the YAML history on gh-pages
           # (per-PR upsert: a re-run replaces this PR's stored values, so
           # only its final CI figures feed the baseline; series are capped
-          # at 100 entries), and emit the dashboard fragments comparing the
-          # current run against the historical average.
+          # at 100 entries and keys of renamed/removed tests are pruned
+          # after a few runs without data), and emit the dashboard
+          # fragments comparing the current run against the recent
+          # historical average.
           printf '%s\n' "$LANTEST_METRICS" > lantest-metrics.txt
           printf '%s\n' "$SPEEDTEST_METRICS" > speedtest-metrics.txt
           git clone --depth 1 --branch gh-pages \
@@ -2369,7 +2371,7 @@ jobs:
           if perl contrib/scripts/plot_perf_history.pl \
             gh-pages/perf-history/history.yml \
             -o perf-trend \
-            --subtitle "commit ${SHORT_SHA} · band: decaying min–max envelope · solid: cumulative average"
+            --subtitle "commit ${SHORT_SHA} · band: decaying min–max envelope · solid: rolling average (last 30 PRs)"
           then
             echo "rendered=1" >> "$GITHUB_OUTPUT"
             URL="https://netatalk.github.io/netatalk/perf-history/pr-${PR_NUMBER}.png"

--- a/contrib/scripts/plot_perf_history.pl
+++ b/contrib/scripts/plot_perf_history.pl
@@ -27,11 +27,14 @@
 #   * points: the single value each PR recorded
 #   * band:   a decaying min..max envelope — collapsed to a point at the
 #             first PR, pushed out whenever a PR lands outside it, and
-#             otherwise relaxing exponentially back toward the cumulative
+#             otherwise relaxing exponentially back toward the rolling
 #             average so one freak outlier does not pin the band open
 #             forever
 #   * lines:  envelope max (dashed), envelope min (dashed) and the
-#             cumulative average (solid) at each position in the series
+#             trailing 30-PR rolling average (solid) at each position in
+#             the series, so the baseline follows genuine performance
+#             shifts within a few PRs instead of averaging the whole
+#             stored series
 #
 # All tests share one plot with X = PR sequence (chronological) and
 # Y = mean runtime in ms (log scale, since tests span ~2ms to ~1300ms).
@@ -80,18 +83,14 @@ my @SHORT_LABELS = (
                     ['creating_2000_files'       => 'Create files 2k'],
                     ['open_write_1024'           => 'Write 2k'],
                     ['open_read_1024'            => 'Read 2k'],
-                    ['open_read_512'             => 'Read 2k'],
                     ['copying_1000_files_client' => 'Copy (R+W) 1k'],
-                    ['copying_2000_files_client' => 'Copy 2k'],
                     ['copying_2000_files_server' => 'ServerCopy 2k'],
                     ['lock_then_unlock_2000'     => 'Fork lock 2k'],
                     ['stat_lookup_getparams'     => 'Stat 2k'],
-                    ['stat_2000_files'           => 'Stat 2k'],
                     ['enumerate_dir'             => 'Enumerate 2k'],
                     ['deleting_2000_files'       => 'Delete 2k'],
                     ['byte_range_lock_unlock'    => 'Byte lock 2k'],
                     ['create_2000_dirs_tree'     => 'Create Dirs 2k'],
-                    ['create_directory_tree'     => 'Create tree'],
                     ['directory_cache_hits'      => 'Dircache hits'],
                     ['mixed_cache_operations'    => 'Mixed cache'],
                     ['deep_path_traversal'       => 'Deep traverse'],
@@ -198,15 +197,20 @@ sub plot {
 
     # Per-step decay factor for the envelope edges: after a new extreme,
     # each subsequent in-band PR moves the edge this fraction of its
-    # remaining distance back toward the cumulative average (0.15 ≈ half
+    # remaining distance back toward the rolling average (0.15 ≈ half
     # the excursion forgotten after ~4 PRs, fully faded after ~20 — one
     # fifth of the 100-entry series cap).
     my $DECAY = 0.15;
 
-    # Columns per series row: x, value, env_min, env_max, cum_avg. The
-    # stats are computed left-to-right: the envelope opens when a value
-    # lands outside it and decays toward the average while values stay
-    # inside.
+    # Trailing window for the solid average line, matching perf_history.pl's
+    # table baseline: long enough to smooth runner variance, short enough
+    # that an accepted performance change becomes the new baseline within
+    # weeks instead of being diluted by the whole stored series.
+    my $AVG_WINDOW = 30;
+
+    # Columns per series row: x, value, env_min, env_max, avg. The stats
+    # are computed left-to-right: the envelope opens when a value lands
+    # outside it and decays toward the average while values stay inside.
     my $blocks = '';
     my (@bands, @maxlines, @minlines, @avglines, @points, @keyentries);
     my ($data_min, $data_max);
@@ -217,12 +221,13 @@ sub plot {
         my $light   = '#80' . substr($color, 1);
         my $tag     = "S$idx";
         $blocks .= "\$$tag << EOD\n";
-        my ($env_min, $env_max, $sum, $count) = (undef, undef, 0, 0);
+        my ($env_min, $env_max, $win_sum, @win) = (undef, undef, 0);
         for my $e (@entries) {
             my $v = $e->{value} + 0;
-            $sum += $v;
-            $count++;
-            my $avg = $sum / $count;
+            push @win, $v;
+            $win_sum += $v;
+            $win_sum -= shift @win if @win > $AVG_WINDOW;
+            my $avg = $win_sum / @win;
             # Relax each edge part-way toward the average, then push it
             # back out if this PR's value lands beyond it.
             if (defined $env_min) {
@@ -246,7 +251,7 @@ sub plot {
           . 'notitle';
         # Running max (slowest seen) and min (fastest seen) trace the band
         # edges, alpha-blended (#80 = 50% transparent) so they read lighter
-        # than the solid cumulative average.
+        # than the solid rolling average.
         push @maxlines,
           "\$$tag using 1:4 with lines dashtype (2,1) linewidth 0.7 " . "linecolor rgb \"$light\" notitle";
         push @minlines,
@@ -267,12 +272,12 @@ sub plot {
     # Line-style legend entries explaining the three marks, appended after
     # the per-test colors.
     push @keyentries,
-      'keyentry with lines linewidth 1.1 linecolor rgb "#333333" ' . 'title "cumulative avg"',
+      'keyentry with lines linewidth 1.1 linecolor rgb "#333333" ' . 'title "avg (last 30 PRs)"',
       'keyentry with lines dashtype (2,1) linewidth 0.7 ' . 'linecolor rgb "#888888" title "max (decaying)"',
       'keyentry with lines dashtype (3,2) linewidth 0.7 ' . 'linecolor rgb "#888888" title "min (decaying)"';
 
     # Bottom-to-top: bands, then band-edge min/max traces, then the solid
-    # cumulative averages and the raw per-PR points on top.
+    # rolling averages and the raw per-PR points on top.
     my @plots = (@bands, @maxlines, @minlines, @avglines, @points, @keyentries);
 
     # Log y-axis with the same explicit per-decade tic list as


### PR DESCRIPTION
The Performance Dashboard's cross-PR trend chart (the "All operations" details block) had two presentation-corrupting defects: the legend listed 22 series for the 17 tests lantest actually runs — several visibly duplicated — and the solid per-test baseline was a cumulative average over the entire stored series, so it could never forget old performance levels. This PR makes the history writer prune obsolete metric keys automatically and switches both the chart baseline and the dashboard tables to a trailing 30-PR window.

## Root cause

Two independent faults compounding in one chart:

1. **The metric key space is append-only.** Keys are free-form and self-describing, so a renamed test simply starts a new key — but nothing ever removed the old one. The per-key 100-entry cap in `perf_history.pl` only trims keys that *still receive data*; a key that stops receiving entries keeps its last values forever. The chart plots every `lantest.*.mean_ms` key in the file, and its short-label table maps old and new key names to the same label ("Stat 2k", "Cache validate", …), which is why the extra series read as duplicates.
2. **The baseline was cumulative from the first stored entry**, both in the chart's solid line and in the tables' Hist avg/min/max, so an accepted performance change stayed diluted by up to 100 PRs of pre-change history.

## How it got here

- `ef8250d1` introduced the trend chart, drawing every stored key — correct at the time, when keys and tests were 1:1.
- `d603f135` added the runner-normalized Adj Δ% column, with historical stats over all stored entries — fine while the series was young.
- `46d207c4` realigned five lantest workloads (2000→500 files, 3→4 lookups, …), renaming their metric keys mid-stream. The old keys' single entries stayed behind, and no component of the pipeline was responsible for removing them.

Each change is locally sound; the ghost series are the emergent gap between "keys are disposable" (writer) and "every key is a test" (chart).

## Defect → fix

| Defect | Fix |
|---|---|
| Renamed/removed tests leave ghost series in `history.yml` forever | `prune_stale()` in `perf_history.pl`: a key with no entry in its group's 3 most recent runs (distinct PRs, newest-timestamp ranked) is deleted after each merge |
| A pruning pass could wipe a section whose CI job failed that run | Only key groups (first dot-separated segment) with rows in the current run are examined; a failed lantest or speedtest job leaves its keys untouched |
| Legend shows duplicate labels for old+new key names | Ghost series pruned; the four dead entries in the chart's short-label table removed |
| Baseline never forgets: cumulative average over the whole stored series | Chart solid line and table Hist avg/min/max now use a trailing 30-entry window per key |

## Behaviour changes

- On the first dashboard run after merge, the five ghost keys vanish from `history.yml` on gh-pages — no manual cleanup.
- Table stats (Hist avg/min/max, Cur Avg Δ%, Adj Δ% baseline) cover each key's newest 30 entries (excluding the current PR) instead of all stored entries.
- The chart still plots the full stored series — up to the existing 100-PR sliding window — but the solid line is now labelled "avg (last 30 PRs)" and converges to a new performance level within 30 PRs; the decaying min–max envelope relaxes toward that rolling mean.
- A test that skips one or two dashboard runs (flaky job, partial CSV) keeps its history; only three consecutive absent runs classify a key as obsolete.

```mermaid
flowchart LR
    A[lantest / speedtest jobs] -->|"render|key|name|unit|value"| B[perf_history.pl]
    H[(gh-pages history.yml)] --> B
    B -->|upsert current PR| C[trim to 100 entries/key]
    C --> D[prune keys absent from last 3 runs]
    D --> H2[(updated history.yml)]
    B -->|"tables: stats over newest 30 entries"| E[PR dashboard comment]
    H2 --> F[plot_perf_history.pl]
    F -->|"solid line: trailing 30-PR average"| G[perf-trend.png]
    G --> E
```

## Testing

All against a copy of the live gh-pages `history.yml` (31 PRs, 22 lantest series):

- Simulated dashboard run: all five ghost keys pruned (22 → 17 series), speedtest and inline keys untouched, output re-parses as valid YAML.
- Windowed table stats cross-checked against an independent calculation (avg 506.3 over newest 30 vs 508.3 full-series; Δ% cells match).
- Section-failure safety: a run with an empty speedtest metrics file leaves all 12 speedtest keys intact.
- Grace: a test missing from one run survives; a renamed test's old key survives runs 1–2 and is pruned on run 3, while the new key accumulates.
- Rolling window on a synthetic step series (100 ms → 40 ms): the average fully converges to 40 ms once the window passes the step; the previous cumulative mean would settle at 55 ms.
- Rendered the chart from the pruned history: legend shows exactly 17 tests plus the three line-style entries, no duplicates.
- `perl -c` clean on both scripts; `codefmt.sh -s perl` applied; `containers.yml` parses as valid YAML.

## Not in this PR

- The 100-entry per-key storage cap is unchanged; only the averaging window narrowed.
- The speedtest MB/s series still have no cross-PR trend chart (the plotter's `--prefix`/`--suffix` options already support one if wanted).
