### PR TITLE
cnid: reach exhaustion recovery, announce it, and classify mysql errors

### DIFF
--- a/bin/dbd/cmd_dbd.c
+++ b/bin/dbd/cmd_dbd.c
@@ -325,6 +325,7 @@ int main(int argc, char **argv)
 
     if (cmd_dbd_scanvol(vol, flags) < 0) {
         dbd_log(LOGSTD, "Error repairing database.");
+        EC_STATUS(-1);
     }
 
 EC_CLEANUP:

--- a/bin/dbd/cmd_dbd_scanvol.c
+++ b/bin/dbd/cmd_dbd_scanvol.c
@@ -690,6 +690,16 @@ static cnid_t check_cnid(const char *name, cnid_t did, struct stat *st,
     /* Get CNID from database */
     if ((db_cnid = cnid_add(vol->v_cdb, st, did, (char *)name, strlen(name),
                             ad_cnid)) == CNID_INVALID) {
+        if (CNID_ERRNO() == CNID_ERR_RESET) {
+            dbd_log(LOGSTD,
+                    "CNID space exhausted at \"%s/%s\": the table was emptied "
+                    "and this scan is incomplete. Rerun to renumber the volume.",
+                    cwdbuf, name);
+            /* Walking on would renumber every remaining file against the
+             * emptied table, leaving the volume half old, half new ids */
+            longjmp(jmp, 2);
+        }
+
         return CNID_INVALID;
     }
 
@@ -978,8 +988,15 @@ int cmd_dbd_scanvol(struct vol *vol_in, dbd_flags_t flags)
      */
     cnid_getstamp(vol->v_cdb, stamp, sizeof(stamp));
 
-    if (setjmp(jmp) != 0) {
+    switch (setjmp(jmp)) {
+    case 1:
         EC_EXIT_STATUS(0); /* Got signal, jump from dbd_readdir */
+
+    case 2:
+        EC_EXIT_STATUS(-1); /* CNID table reset, jump from check_cnid */
+
+    default:
+        break;
     }
 
     strlcpy(cwdbuf, vol->v_path, sizeof(cwdbuf));

--- a/bin/nad/megatron.c
+++ b/bin/nad/megatron.c
@@ -263,6 +263,7 @@ static int update_created_file_cnid(const struct nad_volume *volume,
     cnid = cnid_for_path(vol->v_cdb, vol->v_path, path, &did);
 
     if (cnid == CNID_INVALID) {
+        nad_report_cnid_reset(vol->v_path);
         fprintf(stderr, "Error resolving CNID for %s\n", path);
         errno = EIO;
         return -1;

--- a/bin/nad/nad.h
+++ b/bin/nad/nad.h
@@ -81,6 +81,7 @@ extern void nad_not_inside_volume(FILE *out, const char *path, int force_hint);
 extern void closevol(afpvol_t *vol);
 extern cnid_t cnid_for_paths_parent(const afpvol_t *vol, const char *path,
                                     cnid_t *did);
+extern void nad_report_cnid_reset(const char *volpath);
 extern char *utompath(const struct vol *, const char *);
 extern int convert_dots_encoding(const afpvol_t *svol, const afpvol_t *dvol,
                                  char *path);

--- a/bin/nad/nad_adouble.c
+++ b/bin/nad/nad_adouble.c
@@ -747,6 +747,7 @@ static int nad_update_cnid(void)
                          &did);
 
     if (cnid == CNID_INVALID) {
+        nad_report_cnid_reset(nad.vol->v_path);
         fprintf(stderr, "Error resolving CNID for %s\n", nad.adpath[DATA]);
         errno = EIO;
         return -1;

--- a/bin/nad/nad_cp.c
+++ b/bin/nad/nad_cp.c
@@ -521,6 +521,7 @@ static int copy(const char *path,
 
             if ((did = cnid_for_path(dvolume.vol->v_cdb, dvolume.vol->v_path, to.p_path,
                                      &pdid)) == CNID_INVALID) {
+                nad_report_cnid_reset(dvolume.vol->v_path);
                 NAD_INFO("Error resolving CNID for %s", to.p_path);
                 badcp = rval = 1;
                 return -1;
@@ -598,6 +599,7 @@ static int copy(const char *path,
 
             if ((cnid = cnid_for_path(dvolume.vol->v_cdb, dvolume.vol->v_path, to.p_path,
                                       &did)) == CNID_INVALID) {
+                nad_report_cnid_reset(dvolume.vol->v_path);
                 NAD_INFO("Error resolving CNID for %s", to.p_path);
                 badcp = rval = 1;
                 return -1;

--- a/bin/nad/nad_mkdir.c
+++ b/bin/nad/nad_mkdir.c
@@ -84,6 +84,7 @@ static int mkdir_with_cnid(const char *path, mode_t mode, afpvol_t *vol)
 
     if ((did = cnid_for_path(vol->vol->v_cdb, vol->vol->v_path, path,
                              &pdid)) == CNID_INVALID) {
+        nad_report_cnid_reset(vol->vol->v_path);
         NAD_INFO("Error resolving CNID for %s", path);
         return -1;
     }

--- a/bin/nad/nad_mv.c
+++ b/bin/nad/nad_mv.c
@@ -302,6 +302,7 @@ static int do_move(const char *from, const char *to)
     if (!mustcopy) {
         if ((cnid = cnid_for_path(svolume.vol->v_cdb, svolume.vol->v_path, from,
                                   &did)) == CNID_INVALID) {
+            nad_report_cnid_reset(svolume.vol->v_path);
             NAD_INFO("Couldn't resolve CNID for %s", from);
             return -1;
         }

--- a/bin/nad/nad_rm.c
+++ b/bin/nad/nad_rm.c
@@ -196,6 +196,7 @@ static int rm(const char *path,
 
             if ((cnid = cnid_for_path(volume.vol->v_cdb, volume.vol->v_path, path,
                                       &did)) == CNID_INVALID) {
+                nad_report_cnid_reset(volume.vol->v_path);
                 NAD_INFO("Error resolving CNID for %s", path);
                 return -1;
             }
@@ -235,6 +236,7 @@ static int rm(const char *path,
             /* Get CNID of Parent and add new childir to CNID database */
             if ((did = cnid_for_path(volume.vol->v_cdb, volume.vol->v_path, path,
                                      &pdid)) == CNID_INVALID) {
+                nad_report_cnid_reset(volume.vol->v_path);
                 NAD_INFO("Error resolving CNID for %s", path);
                 return -1;
             }
@@ -286,6 +288,7 @@ static int rm(const char *path,
 
             if ((cnid = cnid_for_path(volume.vol->v_cdb, volume.vol->v_path, path,
                                       &did)) == CNID_INVALID) {
+                nad_report_cnid_reset(volume.vol->v_path);
                 NAD_INFO("Error resolving CNID for %s", path);
                 return -1;
             }

--- a/bin/nad/nad_rmdir.c
+++ b/bin/nad/nad_rmdir.c
@@ -113,6 +113,7 @@ static int rmdir_with_cnid(const char *path, afpvol_t *vol)
         /* Resolve CNID before any modifications */
         if ((did = cnid_for_path(vol->vol->v_cdb, vol->vol->v_path, path,
                                  &pdid)) == CNID_INVALID) {
+            nad_report_cnid_reset(vol->vol->v_path);
             NAD_INFO("Error resolving CNID for %s", path);
             return -1;
         }

--- a/bin/nad/nad_util.c
+++ b/bin/nad/nad_util.c
@@ -298,6 +298,24 @@ int convert_dots_encoding(const afpvol_t *svol, const afpvol_t *dvol,
 }
 
 /*!
+ * @brief Report a CNID table reset behind a failed resolve
+ *
+ * A reset empties the volume's CNID table as a side effect of the failing
+ * call, which the caller's generic resolve error would hide.
+ *
+ * @param[in] volpath  path of the volume the failing call ran against
+ */
+void nad_report_cnid_reset(const char *volpath)
+{
+    if (CNID_ERRNO() == CNID_ERR_RESET) {
+        fprintf(stderr,
+                "CNID space exhausted for volume \"%s\": the table was "
+                "emptied, so every session on it now holds stale CNIDs\n",
+                volpath);
+    }
+}
+
+/*!
  * @brief Resolves CNID of a given paths parent directory
  *
  * path might be:
@@ -352,6 +370,7 @@ cnid_t cnid_for_paths_parent(const afpvol_t *vol,
                              cfrombstr(l->entry[i]),
                              blength(l->entry[i]),
                              0)) == CNID_INVALID) {
+            nad_report_cnid_reset(vol->vol->v_path);
             EC_FAIL;
         }
 

--- a/doc/manual/CNID.md
+++ b/doc/manual/CNID.md
@@ -8,13 +8,21 @@ for example: "server, please open the file named 'Test' in the directory with ID
 Mac aliases work by CNID, with a fallback to the absolute path in more recent AFP clients.
 (This fallback applies only to the Finder, not to applications.)
 
-Every file in an AFP volume must have a unique file ID.
-According to the AFP specification, CNIDs must never be reused.
-IDs are represented as 32-bit numbers, and directories share the same ID pool.
-After approximately 4 billion files and directories have been written to an AFP volume,
-the ID pool is depleted and no new files can be written to the volume.
-Some of Netatalk's CNID backends may attempt to reuse available IDs after depletion,
-which technically violates the spec but may allow continuous use on long-lived volumes.
+Every file in an AFP volume must have a unique file ID,
+and according to the AFP specification CNIDs must never be reused.
+IDs are 32-bit numbers, and directories share the same pool,
+so it is depleted after roughly 4 billion files and directories have been written.
+
+What happens then depends on the backend.
+The *dbd* backend stops allocating IDs, and no new files can be written to the volume.
+The *sqlite* and *mysql* backends empty the CNID table, restart numbering,
+and trigger all clients connected to the volume to reconnect
+so that everyone uses the new IDs.
+This keeps a long-lived volume writable, but it violates the spec
+and breaks Mac aliases pointing at the old IDs.
+Both backends log a warning as a volume approaches the ceiling,
+so it can optionally be renumbered with the **dbd** utility beforehand,
+during a maintenance window.
 
 Netatalk maps IDs to files and directories in the host filesystem.
 Several CNID backends are available and can be selected with the **cnid scheme** option in *afp.conf*.
@@ -26,7 +34,8 @@ of your system's state directory path, e.g. */var/lib*.
 You can change the state directory path with *-Dwith-statedir-path=PATH*
 at compile time.
 
-The **dbd** command-line utility can verify, repair, and rebuild the CNID database.
+The **dbd** command-line utility can verify, repair, and rebuild the CNID database
+of any backend, not just *dbd*.
 
 > **NOTE:** Keep the following CNID-related considerations in mind:
 

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -477,6 +477,12 @@ static int crit_check(struct vol *vol, struct path *path)
                         (int)uname_len);
 
             if (!id) {
+                if (CNID_ERRNO() == CNID_ERR_RESET) {
+                    /* Later entries would get reseeded CNIDs and still be
+                     * sent in this reply, so fail the search */
+                    return -1;
+                }
+
                 LOG(log_debug, logtype_afpd,
                     "crit_check: get_id failed for '%s', skipping file in search results",
                     path->u_name);
@@ -891,6 +897,11 @@ static int catsearch(const AFPObj *obj,
 
             ccr = crit_check(vol, &path);
 
+            if (ccr < 0) {
+                result = AFPERR_MISC;
+                goto catsearch_end;
+            }
+
             /* bit 0 means that criteria has been met */
             if (ccr & 1) {
                 r = rslt_add(obj, vol, &path, &rrbuf, ext);
@@ -1082,6 +1093,11 @@ static int catsearch_db(const AFPObj *obj,
             cfrombstr(dir->d_fullpath), getcwdpath(), path.u_name);
         /* At last we can check the search criteria */
         ccr = crit_check(vol, &path);
+
+        if (ccr < 0) {
+            result = AFPERR_MISC;
+            goto catsearch_end;
+        }
 
         if (ccr & 1) {
             LOG(log_debug, logtype_afpd, "catsearch_db: match: %s/%s",

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -19,6 +19,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -2756,6 +2757,44 @@ void process_cache_hints(AFPObj *obj)
         memcpy(&hint, buf + offset + IPC_HEADERLEN, sizeof(hint));
         offset += msg_size;
         cache_hint_stat.hints_received++;
+
+        /* Resolved by tag, not vid: vid is per-process, so acting on it here
+         * could end a session whose CNIDs are fine. The tag travels in the
+         * otherwise unused cnid field. */
+        if (hint.event == CACHE_HINT_VOLUME_RESET) {
+            uint32_t reset_tag = ntohl(hint.cnid);
+            struct vol *reset_vol = NULL;
+
+            /* Tag 0 means "no UUID"; matching it would end sessions on
+             * every UUID-less volume */
+            if (reset_tag != 0) {
+                for (struct vol *v = getvolumes(); v; v = v->v_next) {
+                    if ((v->v_flags & AFPVOL_OPEN)
+                            && cnid_volume_tag(v) == reset_tag) {
+                        reset_vol = v;
+                        break;
+                    }
+                }
+            }
+
+            if (!reset_vol) {
+                cache_hint_stat.hints_no_match++;
+                continue;
+            }
+
+            cache_hint_stat.hints_acted_on++;
+            /* hints_processed counts hints that changed state */
+            hints_processed++;
+            LOG(log_warning, logtype_afpd,
+                "process_cache_hints: CNID table for volume '%s' was reset, "
+                "disconnecting so the client picks up the rebuilt table",
+                reset_vol->v_path);
+            /* Not cnid_volume_reset(): re-broadcasting would loop */
+            raise(SIGTERM);
+            /* The remaining hints mend a cache this session no longer has */
+            break;
+        }
+
         /* Resolve volume from vid (already network byte order).
          * Cannot be const — passed to dir_remove/dir_modify which take non-const vol. */
         struct vol *vol = getvolbyvid(hint.vid); // NOSONAR

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1210,6 +1210,7 @@ int dir_modify(const struct vol *vol, struct dir *dir,
                             dir->dcache_ino != args->st->st_ino);
         bool ctime_changed = (dir->dcache_ctime != 0 &&
                               dir->dcache_ctime != args->st->st_ctime);
+        bool keep_old_ino = false;
 
         if (ino_changed) {
             /* Object replaced — a cached parent fd would pin the old
@@ -1235,10 +1236,28 @@ int dir_modify(const struct vol *vol, struct dir *dir,
             AFP_CNID_DONE();
 
             if (new_cnid == CNID_INVALID) {
-                const char *why = CNID_ERRNO_IS_BACKEND_FAILURE()
-                                  ? "CNID backend could not answer" : "no CNID for new inode";
+                const char *why = "no CNID for new inode";
 
-                if (dir == curdir) {
+                if (CNID_ERRNO_IS_BACKEND_FAILURE() && dir != curdir) {
+                    /* The next access misses the cache, re-stats, and retries
+                     * the CNID refresh once the backend recovers. Keeping the
+                     * entry instead would serve its pre-change stat from the
+                     * cache-hit path, which never re-stats. */
+                    LOG(log_debug, logtype_afpd,
+                        "dir_modify: CNID backend could not answer for did:%u, "
+                        "removing entry", ntohl(dir->d_did));
+                    dir_remove(vol, dir, 0);
+                    return 0;
+                } else if (CNID_ERRNO_IS_BACKEND_FAILURE()) {
+                    /* curdir must stay valid. The stat refresh below keeps the
+                     * served metadata current, but recording the new inode
+                     * against the old CNID would consume the ino_changed
+                     * trigger that brings us back here */
+                    keep_old_ino = true;
+                    LOG(log_debug, logtype_afpd,
+                        "dir_modify: CNID backend could not answer for "
+                        "curdir did:%u, keeping entry", ntohl(dir->d_did));
+                } else if (dir == curdir) {
                     /* Do not remove curdir — callers rely on it being valid.
                      * AD cache already invalidated (AD_RLEN_UNKNOWN above).
                      * The DID re-index below runs only for a valid CNID, as
@@ -1301,7 +1320,11 @@ int dir_modify(const struct vol *vol, struct dir *dir,
         }
 
         dir->dcache_ctime = args->st->st_ctime;
-        dir->dcache_ino = args->st->st_ino;
+
+        if (!keep_old_ino) {
+            dir->dcache_ino = args->st->st_ino;
+        }
+
         dir->dcache_mode = args->st->st_mode;
         dir->dcache_mtime = args->st->st_mtime;
         dir->dcache_uid = args->st->st_uid;

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -371,13 +371,22 @@ uint32_t get_id(struct vol *vol,
 
         /* Throw errors if cnid_add fails. */
         if (dbcnid == CNID_INVALID) {
-            switch (errno) {
+            /* Callers distinguish a reset by errno, and the logging and IPC
+             * send below clobber it (cnid_volume_reset()'s poll leaves EAGAIN) */
+            const int cnid_errno = errno;
+
+            switch (cnid_errno) {
             case CNID_ERR_CLOSE: /* the db is closed */
                 /* Callers reply with afp_errno after a CNID_INVALID result */
                 LOG(log_error, logtype_afpd,
                     "get_id: CNID database is not open for \"%s\"", upath);
                 afp_errno = AFPERR_MISC;
-                goto exit;
+                break;
+
+            case CNID_ERR_RESET:
+                cnid_volume_reset(vol);
+                afp_errno = AFPERR_MISC;
+                break;
 
             case CNID_ERR_BUSY:
                 /* Contention, not a broken backend: retryable, unlike the
@@ -385,14 +394,14 @@ uint32_t get_id(struct vol *vol,
                 LOG(log_warning, logtype_afpd,
                     "get_id: CNID backend busy for \"%s\"", upath);
                 afp_errno = AFPERR_MISC;
-                goto exit;
+                break;
 
             case CNID_ERR_CORRUPT:
                 LOG(log_error, logtype_afpd,
                     "get_id: CNID backend returned unusable data for \"%s\"; "
                     "the CNID database for this volume should be rebuilt", upath);
                 afp_errno = AFPERR_MISC;
-                goto exit;
+                break;
 
             case CNID_ERR_DB:
                 LOG(log_error, logtype_afpd,
@@ -406,16 +415,18 @@ uint32_t get_id(struct vol *vol,
             case CNID_ERR_PARAM:
                 LOG(log_error, logtype_afpd, "get_id: Incorrect parameters passed to cnid_add");
                 afp_errno = AFPERR_PARAM;
-                goto exit;
+                break;
 
             case CNID_ERR_PATH:
                 afp_errno = AFPERR_PARAM;
-                goto exit;
+                break;
 
             default:
                 afp_errno = AFPERR_MISC;
-                goto exit;
+                break;
             }
+
+            errno = cnid_errno;
         } else if (adp && adcnid && (adcnid != dbcnid)) { /* (3) */
             /* Update the resource fork. For a folder adp is always null */
             LOG(log_debug, logtype_afpd,
@@ -431,7 +442,6 @@ uint32_t get_id(struct vol *vol,
         }
     }
 
-exit:
     return dbcnid;
 }
 
@@ -2593,9 +2603,19 @@ static int reenumerate_loop(struct dirent *de, char *mname _U_, void *data)
 
     /* update or add to cnid */
     AFP_CNID_START("cnid_add");
-    /* ignore errors */
+    /* Errors ignored, except a table reset: it invalidates every CNID this
+     * session holds, so it is reported */
     aint = cnid_add(vol->v_cdb, &path.st, did, de->d_name, strlen(de->d_name), 0);
     AFP_CNID_DONE();
+
+    if (aint == CNID_INVALID && CNID_ERRNO() == CNID_ERR_RESET) {
+        cnid_volume_reset(vol);
+        /* Continuing would mint reseeded CNIDs — values the client already
+         * holds for other objects — into a reply sent before the deferred
+         * exit. */
+        return -1;
+    }
+
     return 0;
 }
 
@@ -2731,7 +2751,12 @@ retry:
 
         if (errno == ENOENT && !retry) {
             /* cnid db is out of sync, reenumerate the directory and update ids */
-            reenumerate_id(vol, ".", dir);
+            if (reenumerate_id(vol, ".", dir) < 0) {
+                /* The table was reset: a retry would resolve this CNID against
+                 * refilled rows and return another object's metadata */
+                return AFPERR_NOID;
+            }
+
             id = cnid;
             retry = 1;
             goto retry;

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -14,6 +14,7 @@
 #include <inttypes.h>
 #include <netinet/in.h>
 #include <pwd.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1071,6 +1072,70 @@ openvol_err:
     free(vol_mname);
     *rbuflen = 0;
     return ret;
+}
+
+/*!
+ * @brief Stable cross-process identifier for a volume's CNID table
+ *
+ * v_vid is per-process, so the same vid names different volumes in different
+ * children. v_uuid is what every child agrees on.
+ *
+ * @returns FNV-1a of v_uuid, or 0 if the volume has no UUID
+ */
+uint32_t cnid_volume_tag(const struct vol *vol)
+{
+    uint32_t hash = 2166136261u;
+
+    if (!vol || !vol->v_uuid) {
+        return 0;
+    }
+
+    for (const unsigned char *p = (const unsigned char *)vol->v_uuid; *p; p++) {
+        hash ^= *p;
+        hash *= 16777619u;
+    }
+
+    /* 0 is reserved for "no tag" */
+    return hash ? hash : 1;
+}
+
+/*!
+ * @brief Announce a CNID table reset and end this session
+ *
+ * Only the session that reset the table sends the hint; a responder that
+ * re-broadcast would loop between children. No AFP attention exists for "the
+ * ID space was recycled" — the protocol guarantees IDs are never reused — so
+ * the disconnect is the signal.
+ */
+void cnid_volume_reset(const struct vol *vol)
+{
+    extern AFPObj *AFPobj;
+
+    if (!AFPobj || !vol) {
+        return;
+    }
+
+    uint32_t tag = cnid_volume_tag(vol);
+
+    if (tag == 0) {
+        LOG(log_error, logtype_afpd,
+            "cnid_volume_reset: volume '%s' has no UUID, cannot tell other "
+            "sessions its CNID table was reset", vol->v_path);
+    } else if (ipc_send_cache_hint(AFPobj, vol->v_vid, htonl(tag),
+                                   CACHE_HINT_VOLUME_RESET) != 0) {
+        LOG(log_error, logtype_afpd,
+            "cnid_volume_reset: could not tell other sessions that the CNID "
+            "table for volume '%s' was reset; they may serve stale CNIDs until "
+            "they reconnect", vol->v_path);
+    }
+
+    LOG(log_warning, logtype_afpd,
+        "cnid_volume_reset: CNID table for volume '%s' was reset, disconnecting "
+        "so the client picks up the rebuilt table", vol->v_path);
+    /* Both transports defer, so the session ends between requests: the request
+     * in flight is still answered, and callers that could return recycled
+     * CNIDs stop their own walk for that reason. */
+    raise(SIGTERM);
 }
 
 void closevol(const AFPObj *obj, struct vol *vol)

--- a/etc/afpd/volume.h
+++ b/etc/afpd/volume.h
@@ -35,4 +35,6 @@ int afp_closevol(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,
 /* netatalk functions */
 extern void close_all_vol(const AFPObj *obj);
 extern void closevol(const AFPObj *obj, struct vol *vol);
+extern void cnid_volume_reset(const struct vol *vol);
+extern uint32_t cnid_volume_tag(const struct vol *vol);
 #endif

--- a/etc/spotlight/cnid/sl_cnid.c
+++ b/etc/spotlight/cnid/sl_cnid.c
@@ -36,6 +36,7 @@
 #include <atalk/util.h>
 #include <atalk/volume.h>
 
+#include "etc/afpd/volume.h"
 #include "etc/spotlight/spotlight_private.h"
 
 static int cnid_comp_fn(const void *p1, const void *p2)
@@ -851,6 +852,17 @@ static int sl_cnid_open_query(slq_t *slq)
                                   slq->slq_scope, &pdid);
 
         if (scope_did == CNID_INVALID) {
+            if (CNID_ERRNO() == CNID_ERR_RESET) {
+                /* Resolving a scope inserts its path components, so a search
+                 * can trip the wipe */
+                LOG(log_error, logtype_sl,
+                    "cnid backend: CNID table for volume '%s' was reset while "
+                    "resolving the search scope", slq->slq_vol->v_path);
+                cnid_volume_reset(slq->slq_vol);
+                slq->slq_state = SLQ_STATE_ERROR;
+                EC_FAIL;
+            }
+
             LOG(log_info, logtype_sl,
                 "cnid backend: cannot resolve scope \"%s\", "
                 "returning 0 results", slq->slq_scope);

--- a/etc/spotlight/localsearch/sl_localsearch.c
+++ b/etc/spotlight/localsearch/sl_localsearch.c
@@ -17,6 +17,7 @@
 #endif
 
 #include <arpa/inet.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -42,6 +43,7 @@
 #include <atalk/util.h>
 #include <atalk/volume.h>
 
+#include "etc/afpd/volume.h"
 #include "etc/spotlight/localsearch/sparql_parser.h"
 #include "etc/spotlight/spotlight_private.h"
 
@@ -190,6 +192,19 @@ static void tracker_cursor_cb(GObject      *object,
     id = cnid_for_path(slq->slq_vol->v_cdb, slq->slq_vol->v_path, path, &did);
 
     if (id == CNID_INVALID) {
+        if (CNID_ERRNO() == CNID_ERR_RESET) {
+            /* The lookup emptied the table: CNIDs every session holds will
+             * name other files as it refills. Not a missing result. */
+            LOG(log_error, logtype_sl,
+                "CNID table for volume '%s' was reset during search",
+                slq->slq_vol->v_path);
+            cnid_volume_reset(slq->slq_vol);
+            /* The exit path asks for the next row, which would mint another
+             * CNID from the emptied table */
+            slq->slq_state = SLQ_STATE_ERROR;
+            return;
+        }
+
         LOG(log_debug, logtype_sl,
             "skipping result, no CNID (file moved or deleted?): %s", path);
         goto exit;

--- a/etc/spotlight/xapian/sl_xapian.c
+++ b/etc/spotlight/xapian/sl_xapian.c
@@ -36,6 +36,7 @@
 #include <atalk/util.h>
 #include <atalk/volume.h>
 
+#include "etc/afpd/volume.h"
 #include "etc/spotlight/spotlight_private.h"
 #include "etc/spotlight/xapian/sl_xapian.h"
 
@@ -357,6 +358,19 @@ static int sl_xapian_fill_results(slq_t *slq)
         id = cnid_for_path(slq->slq_vol->v_cdb, slq->slq_vol->v_path, path, &did);
 
         if (id == CNID_INVALID) {
+            if (CNID_ERRNO() == CNID_ERR_RESET) {
+                /* The lookup emptied the table: CNIDs every session holds
+                 * will name other files as it refills. Not a missing result. */
+                LOG(log_error, logtype_sl,
+                    "xapian backend: CNID table for volume '%s' was reset "
+                    "during search", slq->slq_vol->v_path);
+                cnid_volume_reset(slq->slq_vol);
+                /* Breaking would report the pre-wipe rows as a successful,
+                 * resumable result set, every CNID in it recycled */
+                slq->slq_state = SLQ_STATE_ERROR;
+                EC_FAIL;
+            }
+
             LOG(log_debug, logtype_sl,
                 "xapian backend: no CNID for result: %s", path);
             continue;

--- a/include/atalk/cnid.h
+++ b/include/atalk/cnid.h
@@ -52,6 +52,7 @@
 #define CNID_ERR_DB    0x80000003   /*!< the backend itself is gone */
 #define CNID_ERR_CLOSE 0x80000004   /*!< the db was not open */
 #define CNID_ERR_MAX   0x80000005
+#define CNID_ERR_RESET 0x80000006   /*!< CNID table was reset, all CNIDs stale */
 #define CNID_ERR_BUSY  0x80000007   /*!< contended or transient, retryable */
 #define CNID_ERR_CORRUPT 0x80000008 /*!< unusable data returned for a CNID */
 #define CNID_ERR_NOTFOUND 0x80000009 /*!< no row for the query */

--- a/include/atalk/cnid_mysql_private.h
+++ b/include/atalk/cnid_mysql_private.h
@@ -7,6 +7,8 @@
 #include <atalk/uuid.h>
 
 #define CNID_MYSQL_FLAG_DEPLETED (1 << 0) /*!< CNID set overflowed */
+#define CNID_MYSQL_FLAG_HINT_RANGE_LOGGED (1 << 1) /*!< out-of-range hint warned once */
+#define CNID_MYSQL_FLAG_NEAR_DEPLETION (1 << 2) /*!< approaching-ceiling warned once */
 
 typedef struct CNID_mysql_private {
     struct vol *vol;

--- a/include/atalk/cnid_sqlite_private.h
+++ b/include/atalk/cnid_sqlite_private.h
@@ -5,6 +5,8 @@
 #include <atalk/uuid.h>
 
 #define CNID_SQLITE_FLAG_DEPLETED (1 << 0) /*!< CNID set overflowed */
+#define CNID_SQLITE_FLAG_NEAR_DEPLETION (1 << 1) /*!< depletion warning logged */
+#define CNID_SQLITE_FLAG_HINT_RANGE_LOGGED (1 << 2) /*!< hint range warning logged */
 
 typedef struct CNID_sqlite_private {
     struct vol *vol;

--- a/include/atalk/server_ipc.h
+++ b/include/atalk/server_ipc.h
@@ -25,11 +25,13 @@
 #define CACHE_HINT_REFRESH          0  /*!< ostat + dir_modify(DCMOD_STAT) */
 #define CACHE_HINT_DELETE           1  /*!< direct dir_remove() by CNID */
 #define CACHE_HINT_DELETE_CHILDREN  2  /*!< dircache_remove_children() + remove/refresh parent */
+#define CACHE_HINT_VOLUME_RESET     3  /*!< volume CNID table reset; cnid carries cnid_volume_tag() */
+#define CACHE_HINT_COUNT            4  /*!< number of CACHE_HINT_* event types */
 
 /* Hint payload — sent inside standard IPC wire header framing.
  * Packed to guarantee sizeof == 8. vid and cnid in network byte order. */
 struct __attribute__((packed)) ipc_cache_hint_payload {
-    uint8_t   event;       /* Hint type: CACHE_HINT_REFRESH/DELETE/DELETE_CHILDREN */
+    uint8_t   event;       /* Hint type: one of the CACHE_HINT_* values */
     uint8_t   reserved;    /* Alignment padding (could be version field in future) */
     uint16_t  vid;         /* Volume ID — network byte order (matches vol->v_vid) */
     cnid_t    cnid;        /* CNID of affected file/dir — network byte order */
@@ -37,6 +39,13 @@ struct __attribute__((packed)) ipc_cache_hint_payload {
 
 _Static_assert(sizeof(struct ipc_cache_hint_payload) == 8,
                "Hint payload must be exactly 8 bytes");
+
+/* Every event is validated against CACHE_HINT_COUNT, then used as an index */
+_Static_assert(CACHE_HINT_REFRESH < CACHE_HINT_COUNT
+               && CACHE_HINT_DELETE < CACHE_HINT_COUNT
+               && CACHE_HINT_DELETE_CHILDREN < CACHE_HINT_COUNT
+               && CACHE_HINT_VOLUME_RESET < CACHE_HINT_COUNT,
+               "CACHE_HINT_COUNT must cover every CACHE_HINT_* value");
 
 /* Hint buffer capacity — main.c checks this to trigger immediate flush
  * when buffer is full after fd event processing. */

--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -42,6 +42,22 @@
 #include <atalk/util.h>
 #include <atalk/volume.h>
 
+/* A hint binds as an explicit Id, raising the AUTO_INCREMENT high-water mark.
+ * Hints come from AppleDouble/EA metadata any file owner can write, so the
+ * reserve must be wide enough that a planted hint cannot put the depletion
+ * reset — which empties the table and disconnects every session — within reach
+ * of ordinary file creation. Hints inside the reserve are not inserted. */
+#define CNID_MYSQL_HINT_RESERVE    (1u << 28)
+#define CNID_MYSQL_MAX_HINT        (UINT32_MAX - CNID_MYSQL_HINT_RESERVE)
+
+/* Bound on the lookup-then-insert and update-then-verify cycles: a duplicate-key
+ * race that keeps repeating would otherwise spin the session forever */
+#define CNID_MYSQL_ADD_ATTEMPTS 16
+
+/* Bound on CR_SERVER_LOST recovery: a server that reconnects but keeps dropping
+ * the execute would otherwise hold the child inside cnid_add() indefinitely,
+ * out of reach of the deferred-die path */
+#define CNID_MYSQL_RECONNECT_ATTEMPTS 2
 
 static MYSQL_BIND lookup_param[4], lookup_result[5];
 static MYSQL_BIND add_param[4], put_param[5];
@@ -73,6 +89,19 @@ static unsigned long long get_result_id;
 static unsigned long long resolve_result_did;
 static char               resolve_result_name[MAXPATHLEN];
 static unsigned long      resolve_result_name_len;
+
+/*!
+ * @brief Whether a CNID hint from AppleDouble/EA metadata is safe to bind
+ *
+ * Rejects the reserved range below CNID_START and anything above
+ * CNID_MYSQL_MAX_HINT, which as an explicit Id would raise the
+ * AUTO_INCREMENT high-water mark towards the depletion reset.
+ */
+static bool cnid_mysql_hint_usable(cnid_t hint)
+{
+    uint32_t id = ntohl(hint);
+    return id >= CNID_START && id <= CNID_MYSQL_MAX_HINT;
+}
 
 static int init_prepared_stmt_lookup(CNID_mysql_private *db)
 {
@@ -338,6 +367,63 @@ static void close_prepared_stmt(CNID_mysql_private *db)
     }
 }
 
+/* Distinguish a contended database from a broken one: afpd ends the session on
+ * CNID_ERR_DB, which is right for a backend that has gone away and wrong for a
+ * lock that will free. InnoDB reports a deadlock immediately rather than
+ * waiting, and concurrent sessions inserting into one volume's CNID table hit
+ * both codes routinely, so misclassifying them disconnects clients for ordinary
+ * contention. */
+static void cnid_mysql_set_errno(unsigned int mysql_error_code)
+{
+    switch (mysql_error_code) {
+    case ER_LOCK_WAIT_TIMEOUT:
+    case ER_LOCK_DEADLOCK:
+        errno = CNID_ERR_BUSY;
+        break;
+
+    case ER_CRASHED_ON_USAGE:
+    case ER_CRASHED_ON_REPAIR:
+        errno = CNID_ERR_CORRUPT;
+        break;
+
+    default:
+        errno = CNID_ERR_DB;
+        break;
+    }
+}
+
+/*!
+ * @brief Drain the remaining results of a multi-statement batch
+ *
+ * cnid_mysql_execute() reports only the batch's first statement.
+ * mysql_next_result() returns >0 when a later one failed, which a plain
+ * "== 0" loop reads as the end of the batch — so a wipe whose TRUNCATE or
+ * ALTER failed would be taken for a completed one.
+ *
+ * @returns 0 when every statement succeeded, -1 otherwise
+ */
+static int cnid_mysql_drain_results(MYSQL *con)
+{
+    int next;
+
+    do {
+        MYSQL_RES *result = mysql_store_result(con);
+
+        if (result) {
+            mysql_free_result(result);
+        }
+    } while ((next = mysql_next_result(con)) == 0);
+
+    if (next > 0) {
+        LOG(log_error, logtype_cnid, "MySQL multi-statement error: %s",
+            mysql_error(con));
+        cnid_mysql_set_errno(mysql_errno(con));
+        return -1;
+    }
+
+    return 0;
+}
+
 /*!
  * stmtp must point at the handle field in CNID_mysql_private:
  * CR_SERVER_LOST recovery reallocates every handle, and the retry
@@ -348,6 +434,8 @@ static int cnid_mysql_stmt_execute(CNID_mysql_private *db, MYSQL_STMT **stmtp)
 {
     EC_INIT;
     bool retry = true;
+    unsigned int stmt_errno = 0;
+    int reconnects = 0;
 
     /* A failed earlier recovery leaves handles NULL; re-prepare before use. */
     if (*stmtp == NULL) {
@@ -361,6 +449,14 @@ static int cnid_mysql_stmt_execute(CNID_mysql_private *db, MYSQL_STMT **stmtp)
         if (mysql_stmt_execute(*stmtp)) {
             switch (mysql_stmt_errno(*stmtp)) {
             case CR_SERVER_LOST:
+                if (++reconnects >= CNID_MYSQL_RECONNECT_ATTEMPTS) {
+                    LOG(log_error, logtype_cnid,
+                        "cnid_mysql_stmt_execute: server lost on %d successive "
+                        "executes, giving up", reconnects);
+                    stmt_errno = CR_SERVER_LOST;
+                    EC_FAIL;
+                }
+
                 close_prepared_stmt(db);
                 EC_ZERO(init_prepared_stmt(db));
                 retry = true;
@@ -369,6 +465,7 @@ static int cnid_mysql_stmt_execute(CNID_mysql_private *db, MYSQL_STMT **stmtp)
             default:
                 LOG(log_error, logtype_cnid, "MySQL statement error: %s",
                     mysql_stmt_error(*stmtp));
+                stmt_errno = mysql_stmt_errno(*stmtp);
                 EC_FAIL;
             }
         }
@@ -377,25 +474,27 @@ static int cnid_mysql_stmt_execute(CNID_mysql_private *db, MYSQL_STMT **stmtp)
 EC_CLEANUP:
 
     if (ret != 0) {
-        errno = CNID_ERR_DB;
+        /* 0 for the re-prepare failures above, which classify as CNID_ERR_DB */
+        cnid_mysql_set_errno(stmt_errno);
     }
 
     EC_EXIT;
 }
 
+/* Returns -1, not mysql_query()'s non-zero, so that the EC_NEG1() call sites
+ * detect a failure; the callers that test truthiness are unaffected. */
 static int cnid_mysql_execute(MYSQL *con, const char *sql)
 {
-    int rv;
     LOG(log_maxdebug, logtype_cnid, "SQL: %s", sql);
-    rv = mysql_query(con, sql);
 
-    if (rv) {
+    if (mysql_query(con, sql)) {
         LOG(log_debug, logtype_cnid, "MySQL query \"%s\", error: %s", sql,
             mysql_error(con));
-        errno = CNID_ERR_DB;
+        cnid_mysql_set_errno(mysql_errno(con));
+        return -1;
     }
 
-    return rv;
+    return 0;
 }
 
 int cnid_mysql_delete(struct _cnid_db *cdb, const cnid_t id)
@@ -454,6 +553,7 @@ int cnid_mysql_update(struct _cnid_db *cdb,
     EC_INIT;
     CNID_mysql_private *db;
     cnid_t update_id = 0;
+    int attempts = 0;
 
     if (!cdb || !(db = cdb->cnid_db_private) || !id || !st || !name) {
         LOG(log_error, logtype_cnid, "cnid_update: Parameter error");
@@ -500,12 +600,24 @@ int cnid_mysql_update(struct _cnid_db *cdb,
                 continue;
 
             default:
+                LOG(log_error, logtype_cnid, "cnid_mysql_update: %s",
+                    mysql_stmt_error(db->cnid_put_stmt));
+                cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_put_stmt));
                 EC_FAIL;
             }
         }
 
         update_id = (cnid_t)mysql_stmt_insert_id(db->cnid_put_stmt);
-    } while (update_id != ntohl(id));
+    } while (update_id != ntohl(id) && ++attempts < CNID_MYSQL_ADD_ATTEMPTS);
+
+    if (update_id != ntohl(id)) {
+        LOG(log_error, logtype_cnid,
+            "cnid_mysql_update: giving up after %d attempts for id: %" PRIu32
+            ", did: %" PRIu32 ", name: \"%s\"",
+            attempts, ntohl(id), ntohl(did), name);
+        errno = CNID_ERR_CORRUPT;
+        EC_FAIL;
+    }
 
 EC_CLEANUP:
     EC_EXIT;
@@ -551,9 +663,28 @@ cnid_t cnid_mysql_lookup(struct _cnid_db *cdb,
     stmt_param_dev = dev;
     stmt_param_ino = ino;
     EC_ZERO(cnid_mysql_stmt_execute(db, &db->cnid_lookup_stmt));
-    EC_ZERO_LOG(mysql_stmt_store_result(db->cnid_lookup_stmt));
+
+    /* Classified rather than left to the caller's stale errno: CNID_INVALID
+     * with errno untouched would reach cnid_mysql_add()'s not-found gate.
+     * Not-found is carried as CNID_ERR_NOTFOUND, clear of the syscall errno
+     * range — the dbd wire code CNID_DBD_RES_NOTFOUND is 0x01, the same value
+     * as EPERM, and leaks into raw errno switches downstream. */
+    if (mysql_stmt_store_result(db->cnid_lookup_stmt)) {
+        LOG(log_error, logtype_cnid, "cnid_mysql_lookup: store_result: %s",
+            mysql_stmt_error(db->cnid_lookup_stmt));
+        cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_lookup_stmt));
+        EC_FAIL;
+    }
+
     have_result = true;
-    EC_ZERO_LOG(mysql_stmt_bind_result(db->cnid_lookup_stmt, lookup_result));
+
+    if (mysql_stmt_bind_result(db->cnid_lookup_stmt, lookup_result)) {
+        LOG(log_error, logtype_cnid, "cnid_mysql_lookup: bind_result: %s",
+            mysql_stmt_error(db->cnid_lookup_stmt));
+        cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_lookup_stmt));
+        EC_FAIL;
+    }
+
     uint64_t retdev, retino;
     cnid_t retid, retdid;
     const char *retname;
@@ -564,12 +695,19 @@ cnid_t cnid_mysql_lookup(struct _cnid_db *cdb,
         LOG(log_debug, logtype_cnid,
             "cnid_mysql_lookup: name: '%s', did: %u is not in the CNID database",
             name, ntohl(did));
-        errno = CNID_DBD_RES_NOTFOUND;
+        errno = CNID_ERR_NOTFOUND;
         EC_FAIL;
 
     case 1:
+
         /* either both OR clauses matched the same id or only one matched, handled below */
-        EC_ZERO(mysql_stmt_fetch(db->cnid_lookup_stmt));
+        if (mysql_stmt_fetch(db->cnid_lookup_stmt)) {
+            LOG(log_error, logtype_cnid, "cnid_mysql_lookup: fetch: %s",
+                mysql_stmt_error(db->cnid_lookup_stmt));
+            cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_lookup_stmt));
+            EC_FAIL;
+        }
+
         break;
 
     case 2: {
@@ -587,19 +725,26 @@ cnid_t cnid_mysql_lookup(struct _cnid_db *cdb,
 
         for (int i = 0; i < nfetched; i++) {
             if (cnid_mysql_delete(cdb, mismatched[i])) {
+                /* errno carries the delete's own classification: overwriting it
+                 * would turn a lock that will free into a session-fatal error */
                 LOG(log_error, logtype_cnid, "MySQL query error: %s",
                     mysql_error(db->cnid_mysql_con));
-                errno = CNID_ERR_DB;
                 EC_FAIL;
             }
         }
 
-        errno = CNID_DBD_RES_NOTFOUND;
+        errno = CNID_ERR_NOTFOUND;
         EC_FAIL;
     }
 
     default:
-        errno = CNID_ERR_DB;
+        /* More rows than the two UNIQUE indexes can produce: unusable data
+         * rather than a failing backend, so not session-fatal */
+        LOG(log_error, logtype_cnid,
+            "cnid_mysql_lookup: %llu rows for did: %" PRIu32 ", name: \"%s\"",
+            (unsigned long long)mysql_stmt_num_rows(db->cnid_lookup_stmt),
+            ntohl(did), name);
+        errno = CNID_ERR_CORRUPT;
         EC_FAIL;
     }
 
@@ -617,13 +762,13 @@ cnid_t cnid_mysql_lookup(struct _cnid_db *cdb,
 
         if (hint != retid) {
             if (cnid_mysql_delete(cdb, retid) != 0) {
+                /* errno carries the delete's own classification */
                 LOG(log_error, logtype_cnid, "MySQL query error: %s",
                     mysql_error(db->cnid_mysql_con));
-                errno = CNID_ERR_DB;
                 EC_FAIL;
             }
 
-            errno = CNID_DBD_RES_NOTFOUND;
+            errno = CNID_ERR_NOTFOUND;
             EC_FAIL;
         }
 
@@ -631,9 +776,9 @@ cnid_t cnid_mysql_lookup(struct _cnid_db *cdb,
             "cnid_mysql_lookup: server side mv, got hint, updating");
 
         if (cnid_mysql_update(cdb, retid, st, did, name, len) != 0) {
+            /* errno carries the update's own classification */
             LOG(log_error, logtype_cnid, "MySQL query error: %s",
                 mysql_error(db->cnid_mysql_con));
-            errno = CNID_ERR_DB;
             EC_FAIL;
         }
 
@@ -644,30 +789,36 @@ cnid_t cnid_mysql_lookup(struct _cnid_db *cdb,
             ntohl(did), name);
 
         if (cnid_mysql_delete(cdb, retid) != 0) {
+            /* errno carries the delete's own classification */
             LOG(log_error, logtype_cnid, "MySQL query error: %s",
                 mysql_error(db->cnid_mysql_con));
-            errno = CNID_ERR_DB;
             EC_FAIL;
         }
 
-        errno = CNID_DBD_RES_NOTFOUND;
+        errno = CNID_ERR_NOTFOUND;
         EC_FAIL;
     } else {
         /* everythings good */
         id = retid;
     }
 
-EC_CLEANUP:
-    LOG(log_debug, logtype_cnid, "cnid_mysql_lookup: id: %" PRIu32, ntohl(id));
+EC_CLEANUP: {
+        /* cnid_mysql_add() inserts only on an exact CNID_ERR_NOTFOUND, so an
+         * errno clobbered by the logging or the free below would stop CNID
+         * allocation rather than merely misreport the cause */
+        const int saved_errno = errno;
+        LOG(log_debug, logtype_cnid, "cnid_mysql_lookup: id: %" PRIu32, ntohl(id));
 
-    if (have_result) {
-        mysql_stmt_free_result(db->cnid_lookup_stmt);
+        if (have_result) {
+            mysql_stmt_free_result(db->cnid_lookup_stmt);
+        }
+
+        if (ret != 0) {
+            id = CNID_INVALID;
+        }
+
+        errno = saved_errno;
     }
-
-    if (ret != 0) {
-        id = CNID_INVALID;
-    }
-
     return id;
 }
 
@@ -679,12 +830,12 @@ cnid_t cnid_mysql_add(struct _cnid_db *cdb,
                       cnid_t hint)
 {
     EC_INIT;
-    CNID_mysql_private *db;
+    CNID_mysql_private *db = NULL;
     char *sql = NULL;
     cnid_t id = CNID_INVALID;
-    MYSQL_RES *result = NULL;
     MYSQL_STMT *stmt;
     my_ulonglong lastid;
+    int attempts = 0;
 
     if (!cdb || !(db = cdb->cnid_db_private) || !st || !name) {
         LOG(log_error, logtype_cnid, "cnid_mysql_add: Parameter error");
@@ -705,6 +856,28 @@ cnid_t cnid_mysql_add(struct _cnid_db *cdb,
     }
 
     uint64_t ino = st->st_ino;
+    /* The reserve gate governs inserting the hint as an explicit Id only.
+     * The raw hint still drives lookup's update-in-place vs delete-and-reinsert
+     * choice: existing databases hold rows in the reserve range, and a
+     * server-side move must not renumber them. */
+    bool hint_insertable = hint != CNID_INVALID && cnid_mysql_hint_usable(hint);
+
+    if (hint != CNID_INVALID && !hint_insertable) {
+        /* A scan over a volume whose AppleDouble metadata is uniformly out of
+         * range would log this per file, so only the first is a warning */
+        if (db->cnid_mysql_flags & CNID_MYSQL_FLAG_HINT_RANGE_LOGGED) {
+            LOG(log_debug, logtype_cnid,
+                "cnid_mysql_add: not inserting out-of-range CNID hint %" PRIu32
+                " for name: \"%s\"", ntohl(hint), name);
+        } else {
+            db->cnid_mysql_flags |= CNID_MYSQL_FLAG_HINT_RANGE_LOGGED;
+            LOG(log_warning, logtype_cnid,
+                "cnid_mysql_add: not inserting out-of-range CNID hint %" PRIu32
+                " for name: \"%s\" (further occurrences logged at debug level)",
+                ntohl(hint), name);
+        }
+    }
+
     db->cnid_mysql_hint = hint;
     LOG(log_maxdebug, logtype_cnid,
         "cnid_mysql_add(did: %" PRIu32 ", name: \"%s\", hint: %" PRIu32 "): START",
@@ -712,15 +885,25 @@ cnid_t cnid_mysql_add(struct _cnid_db *cdb,
 
     do {
         if ((id = cnid_mysql_lookup(cdb, st, did, name, len)) == CNID_INVALID) {
-            if (errno == CNID_ERR_DB) {
+            /* Only a genuine "not in the database" answer justifies an insert.
+             * Any other failure — contention, a corrupt row, a bad parameter —
+             * cannot be resolved by inserting, so retrying would waste an
+             * attempt and then report the wrong cause. errno carries the
+             * lookup's classification to the caller unchanged. */
+            if (errno != CNID_ERR_NOTFOUND) {
+                LOG(log_error, logtype_cnid,
+                    "cnid_mysql_add: lookup failed for did: %" PRIu32
+                    ", name: \"%s\", errno=%d", ntohl(did), name, errno);
                 EC_FAIL;
             }
 
             /*
-             * If the CNID set overflowed before (CNID_MYSQL_FLAG_DEPLETED)
-             * ignore the CNID "hint" taken from the AppleDouble file
+             * The CNID "hint" from the AppleDouble file is only bound as an
+             * explicit Id when in range and the set has not overflowed
+             * before (CNID_MYSQL_FLAG_DEPLETED).
              */
-            if (!db->cnid_mysql_hint || (db->cnid_mysql_flags & CNID_MYSQL_FLAG_DEPLETED)) {
+            if (!db->cnid_mysql_hint || !hint_insertable
+                    || (db->cnid_mysql_flags & CNID_MYSQL_FLAG_DEPLETED)) {
                 stmt = db->cnid_add_stmt;
             } else {
                 stmt = db->cnid_put_stmt;
@@ -744,6 +927,9 @@ cnid_t cnid_mysql_add(struct _cnid_db *cdb,
                     continue;
 
                 default:
+                    LOG(log_error, logtype_cnid, "cnid_mysql_add: %s",
+                        mysql_stmt_error(stmt));
+                    cnid_mysql_set_errno(mysql_stmt_errno(stmt));
                     EC_FAIL;
                 }
 
@@ -761,8 +947,24 @@ cnid_t cnid_mysql_add(struct _cnid_db *cdb,
 
             lastid = mysql_stmt_insert_id(stmt);
 
+            if (lastid >= (my_ulonglong) CNID_MYSQL_MAX_HINT
+                    && !(db->cnid_mysql_flags & CNID_MYSQL_FLAG_NEAR_DEPLETION)) {
+                db->cnid_mysql_flags |= CNID_MYSQL_FLAG_NEAR_DEPLETION;
+                LOG(log_warning, logtype_cnid,
+                    "cnid_mysql_add: volume '%s' has reached CNID %llu"
+                    " of %" PRIu32 "; when the ceiling is reached the CNID table "
+                    "is emptied and every session on the volume is "
+                    "disconnected. Rebuild with dbd to reclaim the range gracefully.",
+                    cdb->cnid_db_vol->v_localname, (unsigned long long) lastid,
+                    UINT32_MAX);
+            }
+
             if (lastid > UINT32_MAX) {
                 /* CNID set ist depleted, restart from scratch */
+                LOG(log_warning, logtype_cnid,
+                    "cnid_mysql_add: CNID set is depleted, emptying the CNID "
+                    "table for volume '%s'; entries are rebuilt on access",
+                    cdb->cnid_db_vol->v_localname);
                 EC_NEG1(asprintf(&sql,
                                  "START TRANSACTION;"
                                  "UPDATE volumes SET Depleted=1 WHERE VolUUID='%s';"
@@ -775,35 +977,54 @@ cnid_t cnid_mysql_add(struct _cnid_db *cdb,
                 EC_NEG1(cnid_mysql_execute(db->cnid_mysql_con, sql));
                 free(sql);
                 sql = NULL;
+                /* Checked before the table is called reset: announcing a reset
+                 * of a table still holding its rows, with the sequence not
+                 * reseeded, would disconnect every session and do it again on
+                 * the next insert. */
+                EC_NEG1(cnid_mysql_drain_results(db->cnid_mysql_con));
                 db->cnid_mysql_flags |= CNID_MYSQL_FLAG_DEPLETED;
-
-                do {
-                    result = mysql_store_result(db->cnid_mysql_con);
-
-                    if (result) {
-                        mysql_free_result(result);
-                    }
-                } while (mysql_next_result(db->cnid_mysql_con) == 0);
-
-                continue;
+                /* CNIDs issued before the reset now name nothing, or name a
+                 * different file as the table refills. Report rather than
+                 * retry: the caller ends the session. */
+                errno = CNID_ERR_RESET;
+                EC_FAIL;
             }
 
             /* Finally assign our result */
             id = htonl((uint32_t)lastid);
         }
-    } while (id == CNID_INVALID);
+    } while (id == CNID_INVALID && ++attempts < CNID_MYSQL_ADD_ATTEMPTS);
 
-EC_CLEANUP:
-    LOG(log_debug, logtype_cnid, "cnid_mysql_add: id: %" PRIu32, ntohl(id));
-
-    if (result) {
-        mysql_free_result(result);
+    if (id == CNID_INVALID) {
+        /* Every attempt ended in a duplicate-key collision that the following
+         * lookup then failed to find: a row owns the name or the dev/ino pair
+         * but is not reachable through either index. */
+        LOG(log_error, logtype_cnid,
+            "cnid_mysql_add: giving up after %d attempts for did: %" PRIu32
+            ", name: \"%s\": colliding row is not reachable by lookup",
+            attempts, ntohl(did), name);
+        errno = CNID_ERR_CORRUPT;
+        EC_FAIL;
     }
 
-    if (sql) {
-        free(sql);
-    }
+EC_CLEANUP: {
+        /* Callers read errno to tell a table reset from an ordinary failure */
+        const int saved_errno = errno;
+        LOG(log_debug, logtype_cnid, "cnid_mysql_add: id: %" PRIu32, ntohl(id));
 
+        if (sql) {
+            free(sql);
+        }
+
+        if (db) {
+            /* The hint channel spans only this add: a later direct lookup
+             * acting on a stale hint would rewrite an unrelated row's identity
+             * in the server-side-move branch */
+            db->cnid_mysql_hint = CNID_INVALID;
+        }
+
+        errno = saved_errno;
+    }
     return id;
 }
 
@@ -834,13 +1055,36 @@ cnid_t cnid_mysql_get(struct _cnid_db *cdb, cnid_t did, const char *name,
     stmt_param_name_len = len;
     stmt_param_did = ntohl(did);
     EC_ZERO(cnid_mysql_stmt_execute(db, &db->cnid_get_stmt));
-    EC_ZERO_LOG(mysql_stmt_store_result(db->cnid_get_stmt));
+
+    /* A contended database must not be reported as a missing name: the caller
+     * turns that into a permanent AFPERR_NOOBJ for the client */
+    if (mysql_stmt_store_result(db->cnid_get_stmt)) {
+        LOG(log_error, logtype_cnid, "cnid_mysql_get: store_result: %s",
+            mysql_stmt_error(db->cnid_get_stmt));
+        cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_get_stmt));
+        EC_FAIL;
+    }
+
     have_result = true;
-    EC_ZERO_LOG(mysql_stmt_bind_result(db->cnid_get_stmt, get_result));
+
+    if (mysql_stmt_bind_result(db->cnid_get_stmt, get_result)) {
+        LOG(log_error, logtype_cnid, "cnid_mysql_get: bind_result: %s",
+            mysql_stmt_error(db->cnid_get_stmt));
+        cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_get_stmt));
+        EC_FAIL;
+    }
 
     if (mysql_stmt_num_rows(db->cnid_get_stmt)) {
-        EC_ZERO(mysql_stmt_fetch(db->cnid_get_stmt));
+        if (mysql_stmt_fetch(db->cnid_get_stmt)) {
+            LOG(log_error, logtype_cnid, "cnid_mysql_get: fetch: %s",
+                mysql_stmt_error(db->cnid_get_stmt));
+            cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_get_stmt));
+            EC_FAIL;
+        }
+
         id = htonl((uint32_t)get_result_id);
+    } else {
+        errno = CNID_ERR_NOTFOUND;
     }
 
 EC_CLEANUP:
@@ -868,15 +1112,38 @@ char *cnid_mysql_resolve(struct _cnid_db *cdb, cnid_t *id, void *buffer,
 
     stmt_param_id = ntohl(*id);
     EC_ZERO(cnid_mysql_stmt_execute(db, &db->cnid_resolve_stmt));
-    EC_ZERO_LOG(mysql_stmt_store_result(db->cnid_resolve_stmt));
-    have_result = true;
-    EC_ZERO_LOG(mysql_stmt_bind_result(db->cnid_resolve_stmt, resolve_result));
 
-    if (mysql_stmt_num_rows(db->cnid_resolve_stmt) != 1) {
+    /* A contended database must not be reported as a missing id: afp_resolveid
+     * turns that into a permanent AFPERR_NOID and the client gives up on the
+     * alias, where a retry would have succeeded */
+    if (mysql_stmt_store_result(db->cnid_resolve_stmt)) {
+        LOG(log_error, logtype_cnid, "cnid_mysql_resolve: store_result: %s",
+            mysql_stmt_error(db->cnid_resolve_stmt));
+        cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_resolve_stmt));
         EC_FAIL;
     }
 
-    EC_ZERO(mysql_stmt_fetch(db->cnid_resolve_stmt));
+    have_result = true;
+
+    if (mysql_stmt_bind_result(db->cnid_resolve_stmt, resolve_result)) {
+        LOG(log_error, logtype_cnid, "cnid_mysql_resolve: bind_result: %s",
+            mysql_stmt_error(db->cnid_resolve_stmt));
+        cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_resolve_stmt));
+        EC_FAIL;
+    }
+
+    if (mysql_stmt_num_rows(db->cnid_resolve_stmt) != 1) {
+        errno = CNID_ERR_NOTFOUND;
+        EC_FAIL;
+    }
+
+    if (mysql_stmt_fetch(db->cnid_resolve_stmt)) {
+        LOG(log_error, logtype_cnid, "cnid_mysql_resolve: fetch: %s",
+            mysql_stmt_error(db->cnid_resolve_stmt));
+        cnid_mysql_set_errno(mysql_stmt_errno(db->cnid_resolve_stmt));
+        EC_FAIL;
+    }
+
     /* The connector is not guaranteed to NUL-terminate string results;
      * Name is VARCHAR(255) against a MAXPATHLEN buffer, so there is room. */
     resolve_result_name[resolve_result_name_len] = '\0';
@@ -907,14 +1174,18 @@ int cnid_mysql_getstamp(struct _cnid_db *cdb, void *buffer, const size_t len)
     MYSQL_RES *result = NULL;
     MYSQL_ROW row;
 
+    /* CNID_INVALID is 0, which this int-returning function's callers read as
+     * success, so parameter failures have to return -1 like every other path */
     if (!cdb || !(db = cdb->cnid_db_private)) {
-        LOG(log_error, logtype_cnid, "cnid_find: Parameter error");
+        LOG(log_error, logtype_cnid, "cnid_mysql_getstamp: Parameter error");
         errno = CNID_ERR_PARAM;
-        return CNID_INVALID;
+        return -1;
     }
 
     if (!buffer) {
-        EC_EXIT_STATUS(0);
+        LOG(log_error, logtype_cnid, "cnid_mysql_getstamp: bad buffer");
+        errno = CNID_ERR_PARAM;
+        return -1;
     }
 
     EC_NEG1(asprintf(&sql, "SELECT Stamp FROM volumes WHERE VolPath='%s'",
@@ -933,7 +1204,7 @@ int cnid_mysql_getstamp(struct _cnid_db *cdb, void *buffer, const size_t len)
     if ((result = mysql_store_result(db->cnid_mysql_con)) == NULL) {
         LOG(log_error, logtype_cnid, "MySQL query error: %s",
             mysql_error(db->cnid_mysql_con));
-        errno = CNID_ERR_DB;
+        cnid_mysql_set_errno(mysql_errno(db->cnid_mysql_con));
         EC_FAIL;
     }
 
@@ -1205,7 +1476,6 @@ int cnid_mysql_wipe(struct _cnid_db *cdb)
     EC_INIT;
     CNID_mysql_private *db;
     char *sql = NULL;
-    MYSQL_RES *result = NULL;
 
     if (!cdb || !(db = cdb->cnid_db_private)) {
         LOG(log_error, logtype_cnid, "cnid_wipe: Parameter error");
@@ -1225,15 +1495,16 @@ int cnid_mysql_wipe(struct _cnid_db *cdb)
     EC_NEG1(cnid_mysql_execute(db->cnid_mysql_con, sql));
     free(sql);
     sql = NULL;
-
-    do {
-        result = mysql_store_result(db->cnid_mysql_con);
-
-        if (result) {
-            mysql_free_result(result);
-        }
-    } while (mysql_next_result(db->cnid_mysql_con) == 0);
-
+    /* Before the latch is cleared: a caller told the wipe succeeded rebuilds
+     * against a table that still holds its rows, with explicit-Id hint inserts
+     * re-enabled against a sequence that was never reseeded. */
+    EC_NEG1(cnid_mysql_drain_results(db->cnid_mysql_con));
+    /* The Depleted column is cleared above, but this connection latched the
+     * flag at open. Leaving it set would make the rest of a dbd rebuild
+     * silently discard every AppleDouble CNID hint it is trying to restore,
+     * renumbering the volume from scratch. */
+    db->cnid_mysql_flags &= ~(CNID_MYSQL_FLAG_DEPLETED
+                              | CNID_MYSQL_FLAG_NEAR_DEPLETION);
 EC_CLEANUP:
 
     if (sql) {
@@ -1545,7 +1816,7 @@ struct _cnid_db *cnid_mysql_open(struct cnid_open_args *args)
     if ((result = mysql_store_result(db->cnid_mysql_con)) == NULL) {
         LOG(log_error, logtype_cnid, "MySQL query error: %s",
             mysql_error(db->cnid_mysql_con));
-        errno = CNID_ERR_DB;
+        cnid_mysql_set_errno(mysql_errno(db->cnid_mysql_con));
         EC_FAIL;
     }
 

--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -63,10 +63,13 @@
  * out CNID_SQLITE_BUSY_TIMEOUT, so this only covers sustained contention. */
 #define CNID_SQLITE_EMPTY_PROBE_TRIES   3
 
-/* Ceiling for a CNID hint. A hint binds as an explicit rowid, which raises the
- * AUTOINCREMENT high-water mark, so the headroom below the 32-bit ceiling
- * keeps a hint out of corrupt AppleDouble/EA metadata from reaching it. */
-#define CNID_SQLITE_MAX_HINT    (UINT32_MAX - 65536)
+/* A hint binds as an explicit rowid, raising the AUTOINCREMENT high-water mark.
+ * Hints come from AppleDouble/EA metadata any file owner can write, so the
+ * reserve must be wide enough that a planted hint cannot put the depletion
+ * reset — which empties the table and disconnects every session — within reach
+ * of ordinary file creation. Hints inside the reserve are not inserted. */
+#define CNID_SQLITE_HINT_RESERVE    (1u << 28)
+#define CNID_SQLITE_MAX_HINT        (UINT32_MAX - CNID_SQLITE_HINT_RESERVE)
 
 static void cnid_sqlite_set_errno(int sqlite_return);
 
@@ -463,6 +466,39 @@ static void cnid_sqlite_rollback(sqlite3 *con, int *owned)
         sqlite3_exec(con, "ROLLBACK", NULL, NULL, NULL);
         errno = saved_errno;
     }
+}
+
+/*!
+ * @brief Reseed the volume's AUTOINCREMENT sequence to the reserved floor
+ *
+ * UPDATE first, then INSERT only where the UPDATE changed no row:
+ * sqlite_sequence has no UNIQUE constraint to upsert against. Runs inside
+ * the caller's transaction; on failure the caller owns the rollback.
+ */
+static int cnid_sqlite_seed_sequence(CNID_sqlite_private *db)
+{
+    EC_INIT;
+    char *sql = NULL;
+    EC_NEG1(asprintf(&sql,
+                     "UPDATE sqlite_sequence SET seq = %d WHERE name = '%s';",
+                     CNID_START - 1, db->cnid_sqlite_voluuid_str));
+    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, sql));
+    free(sql);
+    sql = NULL;
+    EC_NEG1(asprintf(&sql,
+                     "INSERT INTO sqlite_sequence (name,seq) SELECT '%s', %d "
+                     "WHERE NOT EXISTS "
+                     "(SELECT changes() AS change "
+                     "FROM sqlite_sequence WHERE change <> 0);",
+                     db->cnid_sqlite_voluuid_str, CNID_START - 1));
+    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, sql));
+EC_CLEANUP:
+
+    if (sql) {
+        free(sql);
+    }
+
+    EC_EXIT;
 }
 
 int cnid_sqlite_delete(struct _cnid_db *cdb, const cnid_t id)
@@ -1004,12 +1040,26 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
     }
 
     ino = st->st_ino;
+    /* The reserve gate governs inserting the hint as an explicit rowid only.
+     * The raw hint still drives lookup's update-in-place vs delete-and-reinsert
+     * choice: existing databases hold rows in the reserve range, and a
+     * server-side move must not renumber them. */
+    bool hint_insertable = hint != CNID_INVALID && cnid_sqlite_hint_usable(hint);
 
-    if (hint != CNID_INVALID && !cnid_sqlite_hint_usable(hint)) {
-        LOG(log_warning, logtype_cnid,
-            "cnid_sqlite_add: ignoring out-of-range CNID hint %" PRIu32
-            " for name: \"%s\"", ntohl(hint), name);
-        hint = CNID_INVALID;
+    if (hint != CNID_INVALID && !hint_insertable) {
+        /* A scan over a volume whose AppleDouble metadata is uniformly out of
+         * range would log this per file, so only the first is a warning */
+        if (db->cnid_sqlite_flags & CNID_SQLITE_FLAG_HINT_RANGE_LOGGED) {
+            LOG(log_debug, logtype_cnid,
+                "cnid_sqlite_add: not inserting out-of-range CNID hint %" PRIu32
+                " for name: \"%s\"", ntohl(hint), name);
+        } else {
+            db->cnid_sqlite_flags |= CNID_SQLITE_FLAG_HINT_RANGE_LOGGED;
+            LOG(log_warning, logtype_cnid,
+                "cnid_sqlite_add: not inserting out-of-range CNID hint %" PRIu32
+                " for name: \"%s\" (further occurrences logged at debug level)",
+                ntohl(hint), name);
+        }
     }
 
     db->cnid_sqlite_hint = hint;
@@ -1053,10 +1103,11 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
              * (CNID_SQLITE_FLAG_DEPLETED flag) ignore the CNID "hint"
              * read from AppleDouble or Extended Attributes.
              */
-            if (!db->cnid_sqlite_hint
+            if (!hint_insertable
                     || (db->cnid_sqlite_flags & CNID_SQLITE_FLAG_DEPLETED)) {
                 LOG(log_debug, logtype_cnid,
-                    "cnid_sqlite_add: not using CNID hint, CNID set is depleted or hint not set");
+                    "cnid_sqlite_add: not inserting the CNID hint: out of range, "
+                    "depleted set, or not set");
                 sqlite3_reset(db->cnid_add_stmt);
                 sqlite3_clear_bindings(db->cnid_add_stmt);
                 sqlite3_bind_text(db->cnid_add_stmt, 1, name, (int)len,
@@ -1101,6 +1152,7 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
                         PRIu32 ") or (dev=%" PRIu64 ", ino=%" PRIu64 ")", name, ntohl(did),
                         dev, ino);
                     db->cnid_sqlite_hint = CNID_INVALID;
+                    hint_insertable = false;
                     continue;
                 } else {
                     LOG(log_error, logtype_cnid,
@@ -1113,7 +1165,18 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
 
             lastid = sqlite3_last_insert_rowid(db->cnid_sqlite_con);
 
-            if ((uint32_t) lastid > UINT32_MAX) {
+            if (lastid >= (uint64_t) CNID_SQLITE_MAX_HINT
+                    && !(db->cnid_sqlite_flags & CNID_SQLITE_FLAG_NEAR_DEPLETION)) {
+                db->cnid_sqlite_flags |= CNID_SQLITE_FLAG_NEAR_DEPLETION;
+                LOG(log_warning, logtype_cnid,
+                    "cnid_sqlite_add: volume '%s' has reached CNID %" PRIu64
+                    " of %" PRIu32 "; when the ceiling is reached the CNID table "
+                    "is emptied and every session on the volume is "
+                    "disconnected. Rebuild with dbd to reclaim the range gracefully.",
+                    cdb->cnid_db_vol->v_localname, lastid, UINT32_MAX);
+            }
+
+            if (lastid >= (uint64_t) UINT32_MAX) {
                 /* CNID set is depleted, restart from scratch */
                 LOG(log_warning, logtype_cnid,
                     "cnid_sqlite_add: CNID set is depleted, emptying the CNID "
@@ -1139,33 +1202,19 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
 
                 free(sql);
                 sql = NULL;
-                EC_NEG1(asprintf(&sql,
-                                 "UPDATE sqlite_sequence SET seq = 16 WHERE name = '%s';",
-                                 db->cnid_sqlite_voluuid_str));
 
-                if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
+                if (cnid_sqlite_seed_sequence(db) < 0) {
                     cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
                     EC_FAIL;
                 }
 
-                free(sql);
-                sql = NULL;
-                EC_NEG1(asprintf(&sql, "INSERT INTO sqlite_sequence (name,seq) SELECT '%s', "
-                                       "16 WHERE NOT EXISTS "
-                                       "(SELECT changes() AS change "
-                                       "FROM sqlite_sequence WHERE change <> 0);",
-                                 db->cnid_sqlite_voluuid_str));
-
-                if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-                    cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
-                    EC_FAIL;
-                }
-
-                free(sql);
-                sql = NULL;
                 EC_NEG1(cnid_sqlite_commit(db->cnid_sqlite_con, &owned));
                 db->cnid_sqlite_flags |= CNID_SQLITE_FLAG_DEPLETED;
-                continue;
+                /* CNIDs issued before the reset now name nothing, or name a
+                 * different file as the table refills. Report rather than
+                 * retry: the caller ends the session. */
+                errno = CNID_ERR_RESET;
+                EC_FAIL;
             }
 
             /* Finally assign our result */
@@ -1192,22 +1241,30 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
         EC_FAIL;
     }
 
-EC_CLEANUP:
+EC_CLEANUP: {
+        /* Callers read errno to tell a table reset from an ordinary failure */
+        const int saved_errno = errno;
 
-    if (db) {
-        LOG(log_maxdebug, logtype_cnid,
-            "cnid_sqlite_add(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\", hint: %"
-            PRIu32 "): END",
-            ntohl(id), ntohl(did), name, ntohl(hint));
-        cnid_sqlite_stmt_reset(db->cnid_add_stmt);
-        cnid_sqlite_stmt_reset(db->cnid_put_stmt);
-        cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
+        if (db) {
+            LOG(log_maxdebug, logtype_cnid,
+                "cnid_sqlite_add(id: %" PRIu32 ", did: %" PRIu32 ", name: \"%s\", hint: %"
+                PRIu32 "): END",
+                ntohl(id), ntohl(did), name, ntohl(hint));
+            cnid_sqlite_stmt_reset(db->cnid_add_stmt);
+            cnid_sqlite_stmt_reset(db->cnid_put_stmt);
+            cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
+            /* The hint channel spans only this add: a later direct lookup acting
+             * on a stale hint would rewrite an unrelated row's identity in the
+             * server-side-move branch */
+            db->cnid_sqlite_hint = CNID_INVALID;
+        }
+
+        if (sql) {
+            free(sql);
+        }
+
+        errno = saved_errno;
     }
-
-    if (sql) {
-        free(sql);
-    }
-
     return id;
 }
 
@@ -1692,29 +1749,19 @@ int cnid_sqlite_wipe(struct _cnid_db *cdb)
 
     free(sql);
     sql = NULL;
-    EC_NEG1(asprintf(&sql,
-                     "UPDATE sqlite_sequence SET seq = 16 WHERE name = '%s';",
-                     db->cnid_sqlite_voluuid_str));
 
-    if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
+    if (cnid_sqlite_seed_sequence(db) < 0) {
         cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
         EC_FAIL;
     }
 
-    free(sql);
-    sql = NULL;
-    EC_NEG1(asprintf(&sql,
-                     "INSERT INTO sqlite_sequence (name,seq) SELECT '%s', 16 WHERE NOT EXISTS (SELECT changes() AS change FROM sqlite_sequence WHERE change <> 0);",
-                     db->cnid_sqlite_voluuid_str));
-
-    if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-        cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
-        EC_FAIL;
-    }
-
-    free(sql);
-    sql = NULL;
     EC_NEG1(cnid_sqlite_commit(db->cnid_sqlite_con, &owned));
+    /* The Depleted column is cleared above, but this connection latched the
+     * flag at open. Leaving it set would make the rest of a dbd rebuild
+     * silently discard every AppleDouble CNID hint it is trying to restore,
+     * renumbering the volume from scratch. */
+    db->cnid_sqlite_flags &= ~(CNID_SQLITE_FLAG_DEPLETED
+                               | CNID_SQLITE_FLAG_NEAR_DEPLETION);
 
     if (init_prepared_stmt(db) != 0) {
         /* The wipe is committed and the handles past the failure are NULL.
@@ -2202,30 +2249,12 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
         /* Seeding is one unit: a partly seeded sequence would hand out CNIDs
          * from the range AFP reserves */
         EC_NEG1(cnid_sqlite_begin(db->cnid_sqlite_con, &owned));
-        EC_NEG1(asprintf(&sql,
-                         "UPDATE sqlite_sequence SET seq = 16 WHERE name = '%s';",
-                         db->cnid_sqlite_voluuid_str));
 
-        if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
+        if (cnid_sqlite_seed_sequence(db) < 0) {
             cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
             EC_FAIL;
         }
 
-        free(sql);
-        sql = NULL;
-        EC_NEG1(asprintf(&sql, "INSERT INTO sqlite_sequence (name,seq) SELECT '%s',"
-                               "16 WHERE NOT EXISTS "
-                               "(SELECT changes() AS change "
-                               "FROM sqlite_sequence WHERE change <> 0);",
-                         db->cnid_sqlite_voluuid_str));
-
-        if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
-            cnid_sqlite_rollback(db->cnid_sqlite_con, &owned);
-            EC_FAIL;
-        }
-
-        free(sql);
-        sql = NULL;
         EC_NEG1(cnid_sqlite_commit(db->cnid_sqlite_con, &owned));
         /* Verify the sequence was set correctly */
         sqlite3_stmt *verify_stmt = NULL;

--- a/libatalk/util/cnid.c
+++ b/libatalk/util/cnid.c
@@ -160,12 +160,19 @@ EC_CLEANUP:
  * path MUST be pointing inside vol, this is usually the case as vol has been build from
  * path using loadvolinfo and friends.
  *
+ * Allocates, not just resolves: any path component missing from the database is
+ * inserted by cnid_add(). A caller that only reads, such as Spotlight result
+ * resolution, can therefore consume CNIDs and reach the 32-bit ceiling.
+ *
  * @param[in] cdb       CNID db handle
  * @param[in] volpath   UNIX path of volume
  * @param[in] path      path, see above
  * @param[out] did      parent CNID of returned CNID
  *
- * @returns CNID of path
+ * @returns CNID of path, or CNID_INVALID with errno set by the backend.
+ *          errno is preserved across cleanup so callers can act on it; in
+ *          particular CNID_ERR_RESET means the volume's CNID table was emptied
+ *          during this call and every session on it now holds stale CNIDs.
  */
 cnid_t cnid_for_path(struct _cnid_db *cdb,
                      const char *volpath,
@@ -201,10 +208,15 @@ cnid_t cnid_for_path(struct _cnid_db *cdb,
         EC_ZERO(bcatcstr(statpath, "/"));
     }
 
-EC_CLEANUP:
-    bdestroy(rpath);
-    bstrListDestroy(l);
-    bdestroy(statpath);
+EC_CLEANUP: {
+        /* The backend's classification is the only way a caller can tell a
+         * missing entry from a CNID table that was just reset under it */
+        int saved_errno = errno;
+        bdestroy(rpath);
+        bstrListDestroy(l);
+        bdestroy(statpath);
+        errno = saved_errno;
+    }
 
     if (ret != 0) {
         return CNID_INVALID;

--- a/libatalk/util/server_ipc.c
+++ b/libatalk/util/server_ipc.c
@@ -14,6 +14,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -69,6 +70,22 @@ static char *ipc_cmd_str[] = { "IPC_DISCOLDSESSION",
 
 #define HINT_RATE_LIMIT        1000  /* Max hints/second per child (attack guard) */
 
+/* Resets skip the drop paths, so they need their own ceiling. A child raises
+ * SIGTERM right after resetting, so it sends at most one. */
+#define HINT_RESET_RATE_LIMIT  8
+
+/* Volumes whose reset can be deduped at once — more than a handful resetting
+ * inside one second is not a case worth holding memory for */
+#define RESET_SEEN_SIZE        8
+
+/* Waiting for pipe space stalls the master, so each flush gets a fixed wait
+ * budget regardless of how many siblings are backed up */
+#define HINT_RESET_WAIT_BUDGET 4
+
+/* One wait for IPC space when a reset cannot be written at once. The child is
+ * the only sender, so a lost write costs every sibling the notification. */
+#define HINT_RESET_WAIT_MS     20
+
 /* Per-child rate tracking — fixed array indexed by PID % RATE_TRACK_SIZE.
  * Hash collisions are benign — worst case a child gets a slightly wrong
  * rate count from sharing a slot with another child. */
@@ -93,6 +110,9 @@ static struct {
     pid_t  pid;
     time_t window_start;
     int    count_in_window;
+    /* Counted apart from the hints above: a reset shares no budget with the
+     * best-effort traffic, which a working session emits far faster */
+    int    resets_in_window;
 } rate_track[RATE_TRACK_SIZE];
 
 /* Parent-side statistics */
@@ -100,9 +120,9 @@ static unsigned long long hints_batched = 0;
 static unsigned long long hints_rate_dropped = 0;
 static unsigned long long flush_count = 0;
 
-/* Returns current hint count for this child in the current 1-second window.
- * Resets window if second has changed. Called from main thread only. */
-static int check_and_increment_rate(pid_t child_pid)
+/* Start this child's window, or reuse the one already open. Called from main
+ * thread only. */
+static int rate_slot(pid_t child_pid)
 {
     int idx = child_pid % RATE_TRACK_SIZE;
     time_t now = time(NULL);
@@ -110,11 +130,133 @@ static int check_and_increment_rate(pid_t child_pid)
     if (rate_track[idx].pid != child_pid || rate_track[idx].window_start != now) {
         rate_track[idx].pid = child_pid;
         rate_track[idx].window_start = now;
-        rate_track[idx].count_in_window = 1;
-        return 1;
+        rate_track[idx].count_in_window = 0;
+        rate_track[idx].resets_in_window = 0;
     }
 
-    return ++rate_track[idx].count_in_window;
+    return idx;
+}
+
+/* Returns current hint count for this child in the current 1-second window. */
+static int check_and_increment_rate(pid_t child_pid)
+{
+    return ++rate_track[rate_slot(child_pid)].count_in_window;
+}
+
+static int check_and_increment_reset_rate(pid_t child_pid)
+{
+    return ++rate_track[rate_slot(child_pid)].resets_in_window;
+}
+
+/* Volume tags whose reset was broadcast, and when */
+static struct {
+    uint32_t tag;
+    time_t   when;
+} reset_seen[RESET_SEEN_SIZE];
+
+/*!
+ * @brief Whether this volume's reset has just been broadcast
+ *
+ * One notification per volume is all a sibling needs, and each one costs a
+ * forced flush to every session, so a repeat inside the same second is
+ * dropped. Records the tag when it is new.
+ *
+ * @param[in] tag  cnid_volume_tag() of the reset volume, network byte order
+ */
+static int reset_already_broadcast(uint32_t tag)
+{
+    const time_t now = time(NULL);
+    int oldest = 0;
+
+    for (int i = 0; i < RESET_SEEN_SIZE; i++) {
+        if (reset_seen[i].tag == tag && reset_seen[i].when == now) {
+            return 1;
+        }
+
+        if (reset_seen[i].when < reset_seen[oldest].when) {
+            oldest = i;
+        }
+    }
+
+    reset_seen[oldest].tag = tag;
+    reset_seen[oldest].when = now;
+    return 0;
+}
+
+/*!
+ * @brief Make a volume's reset broadcastable again
+ *
+ * A sibling that missed a reset batch has no other redelivery path, so a
+ * delivery failure must not leave the tag deduped against the next duplicate.
+ *
+ * @param[in] tag  cnid_volume_tag() of the reset volume, network byte order
+ */
+static void reset_broadcast_forget(uint32_t tag)
+{
+    for (int i = 0; i < RESET_SEEN_SIZE; i++) {
+        if (reset_seen[i].tag == tag) {
+            reset_seen[i].tag = 0;
+            reset_seen[i].when = 0;
+        }
+    }
+}
+
+/*!
+ * @brief Write a sibling's hint batch, waiting once if it carries a reset
+ *
+ * A full sibling pipe drops a best-effort batch: those hints only cost a
+ * lookup. A batch carrying a reset waits briefly for pipe space instead, since
+ * the sibling would otherwise keep resolving recycled CNIDs. Waits are budgeted
+ * per second across flushes so backed-up siblings cannot stall the master.
+ *
+ * @param[in]     fd          sibling's hint pipe
+ * @param[in]     buf         serialized batch
+ * @param[in]     len         bytes to write
+ * @param[in]     has_reset   batch contains a CACHE_HINT_VOLUME_RESET
+ * @param[in,out] waits_left  this second's remaining waits, spent here
+ * @returns 0 on success, -1 if the batch was not delivered
+ */
+static int hint_write_batch(int fd, const char *buf, int len, int has_reset,
+                            int *waits_left)
+{
+    ssize_t ret = write(fd, buf, len);
+    int write_errno = errno;
+
+    if (ret == len) {
+        return 0;
+    }
+
+    if (has_reset && ret == -1 && *waits_left > 0
+            && (write_errno == EAGAIN || write_errno == EWOULDBLOCK)) {
+        struct pollfd pfd = { .fd = fd, .events = POLLOUT };
+        int pret;
+        (*waits_left)--;
+
+        do {
+            pret = poll(&pfd, 1, HINT_RESET_WAIT_MS);
+        } while (pret < 0 && errno == EINTR);
+
+        if (pret > 0 && (pfd.revents & POLLOUT)) {
+            ret = write(fd, buf, len);
+            write_errno = errno;
+        }
+
+        if (ret == len) {
+            return 0;
+        }
+    }
+
+    /* Classified on the write's own errno: poll() has since overwritten it */
+    if (ret == -1 && write_errno != EAGAIN && write_errno != EWOULDBLOCK) {
+        LOG(log_debug, logtype_afpd, "hint_flush: write failed fd=%d: %s",
+            fd, strerror(write_errno));
+    } else if (has_reset) {
+        LOG(log_warning, logtype_afpd,
+            "hint_flush: could not deliver a volume reset to fd=%d; that "
+            "session may serve stale CNIDs until it reconnects", fd);
+    }
+
+    return -1;
 }
 
 /*!
@@ -152,6 +294,7 @@ static int serialize_hint(char *buf, const struct hint_entry *e)
     memcpy(p, &payload, sizeof(payload));
     return IPC_HEADERLEN + sizeof(struct ipc_cache_hint_payload);
 }
+
 
 /*!
  * @brief Pass afp_socket to old disconnected session if one has a matching token
@@ -299,15 +442,40 @@ static int ipc_relay_cache_hint(struct ipc_header *ipc,
     }
 
     /* Validate event type */
-    if (hint.event > CACHE_HINT_DELETE_CHILDREN) {
+    if (hint.event >= CACHE_HINT_COUNT) {
         LOG(log_warning, logtype_afpd,
             "ipc_relay_cache_hint: invalid event %u from pid %u, dropped",
             hint.event, ipc->child_pid);
         return 0;
     }
 
+    /* Losing a reset leaves siblings resolving recycled CNIDs, so it skips the
+     * drop paths below — but not the guard itself, or one child could force
+     * unmetered disconnection of every session on the volume. */
+    const int is_reset = (hint.event == CACHE_HINT_VOLUME_RESET);
+
+    if (is_reset) {
+        if (check_and_increment_reset_rate(ipc->child_pid)
+                > HINT_RESET_RATE_LIMIT) {
+            hints_rate_dropped++;
+            LOG(log_warning, logtype_afpd,
+                "ipc_relay_cache_hint: pid %u exceeded the reset limit, dropped",
+                ipc->child_pid);
+            return 0;
+        }
+
+        /* Siblings need to hear a volume was reset, not how often. Deduped
+         * against what was already broadcast, not against hint_buf: each reset
+         * forces a flush below, so the buffer never holds one by the time the
+         * next arrives. Keyed on the tag alone — vid is per-process, so two
+         * children reporting one volume disagree on it. */
+        if (reset_already_broadcast(hint.cnid)) {
+            return 0;
+        }
+    }
+
     /* Rate-limit check (attack guard) */
-    if (check_and_increment_rate(ipc->child_pid) > HINT_RATE_LIMIT) {
+    if (!is_reset && check_and_increment_rate(ipc->child_pid) > HINT_RATE_LIMIT) {
         hints_rate_dropped++;
 
         if (rate_track[ipc->child_pid % RATE_TRACK_SIZE].count_in_window
@@ -322,10 +490,16 @@ static int ipc_relay_cache_hint(struct ipc_header *ipc,
 
     /* Buffer full — drop hint. Caller will flush after ipc_server_read returns. */
     if (hint_buf.count >= HINT_BUF_SIZE) {
-        LOG(log_debug, logtype_afpd,
-            "ipc_relay_cache_hint: buffer full, hint dropped from pid %u",
-            ipc->child_pid);
-        return 0;
+        if (!is_reset) {
+            LOG(log_debug, logtype_afpd,
+                "ipc_relay_cache_hint: buffer full, hint dropped from pid %u",
+                ipc->child_pid);
+            return 0;
+        }
+
+        /* A best-effort hint yields its slot: flushing first would send the
+         * batch the reset has to precede */
+        hint_buf.count--;
     }
 
     hint_buf.entries[hint_buf.count] = (struct hint_entry) {
@@ -335,6 +509,12 @@ static int ipc_relay_cache_hint(struct ipc_header *ipc,
         .source_pid = ipc->child_pid,
     };
     hint_buf.count++;
+
+    if (is_reset) {
+        /* A busy master can starve the batching trigger indefinitely */
+        hint_flush_pending(children);
+    }
+
     return 0;
 }
 
@@ -584,24 +764,49 @@ void hint_flush_pending(server_child_t *children)
     }
 
     int local_count = hint_buf.count;
+    /* Shared across flushes: each reset forces one, and a per-flush budget
+     * would let a burst of distinct-volume resets stall the single-threaded
+     * master for its multiple. */
+    static time_t wait_window;
+    static int waits_left;
+    const time_t now = time(NULL);
+
+    if (now != wait_window) {
+        wait_window = now;
+        waits_left = HINT_RESET_WAIT_BUDGET;
+    }
+
+    int reset_lost = 0;
     struct hint_entry local_buf[HINT_BUF_SIZE];
     memcpy(local_buf, hint_buf.entries,
            local_count * sizeof(struct hint_entry));
     hint_buf.count = 0;
-    /* Sort by priority: REFRESH(0) first, DELETE(1), DELETE_CHILDREN(2) last.
-     * O(n) counting + scatter pass — no allocations. */
+    /* Sort by delivery priority. VOLUME_RESET ends the receiving session, so it
+     * precedes the cache-mend events that a reset makes moot; those keep their
+     * REFRESH, DELETE, DELETE_CHILDREN order. O(n) counting + scatter pass —
+     * no allocations. Events are validated against CACHE_HINT_COUNT before
+     * being buffered, so they are safe to use as indices here. */
+    static const int priority[CACHE_HINT_COUNT] = {
+        [CACHE_HINT_VOLUME_RESET]    = 0,
+        [CACHE_HINT_REFRESH]         = 1,
+        [CACHE_HINT_DELETE]          = 2,
+        [CACHE_HINT_DELETE_CHILDREN] = 3,
+    };
     struct hint_entry sorted[HINT_BUF_SIZE] = {0};
-    int counts[3] = {0};
+    int counts[CACHE_HINT_COUNT] = {0};
 
     for (int h = 0; h < local_count; h++) {
-        counts[local_buf[h].event]++;
+        counts[priority[local_buf[h].event]]++;
     }
 
-    int offsets[3] = {0, counts[0], counts[0] + counts[1]};
+    int offsets[CACHE_HINT_COUNT] = {0};
+
+    for (int p = 1; p < CACHE_HINT_COUNT; p++) {
+        offsets[p] = offsets[p - 1] + counts[p - 1];
+    }
 
     for (int h = 0; h < local_count; h++) {
-        int e = local_buf[h].event;
-        sorted[offsets[e]++] = local_buf[h];
+        sorted[offsets[priority[local_buf[h].event]]++] = local_buf[h];
     }
 
     /* Build and send per-sibling batch in PIPE_BUF-safe chunks */
@@ -620,51 +825,53 @@ void hint_flush_pending(server_child_t *children)
             }
 
             int write_len = 0;
+            int chunk_has_reset = 0;
 
             for (int h = 0; h < local_count; h++) {
                 if (child->afpch_pid == sorted[h].source_pid) {
-                    /* Skip source child */
                     continue;
                 }
 
                 write_len += serialize_hint(write_buf + write_len,
                                             &sorted[h]);
 
+                if (sorted[h].event == CACHE_HINT_VOLUME_RESET) {
+                    chunk_has_reset = 1;
+                }
+
                 /* Flush chunk when it reaches PIPE_BUF-safe limit */
                 if ((size_t)write_len >= chunk_limit) {
-                    ssize_t ret = write(child->afpch_hint_fd,
-                                        write_buf, write_len);
-
-                    if (ret < 0) {
-                        if (errno != EAGAIN && errno != EWOULDBLOCK) {
-                            LOG(log_debug, logtype_afpd,
-                                "hint_flush: write failed fd=%d pid=%d: %s",
-                                child->afpch_hint_fd,
-                                child->afpch_pid,
-                                strerror(errno));
-                        }
-
+                    if (hint_write_batch(child->afpch_hint_fd, write_buf,
+                                         write_len, chunk_has_reset,
+                                         &waits_left) != 0) {
+                        reset_lost |= chunk_has_reset;
                         write_len = 0;
                         /* Pipe full or error — next sibling */
                         break;
                     }
 
                     write_len = 0;
+                    chunk_has_reset = 0;
                 }
             }
 
             /* Flush any remaining partial chunk */
-            if (write_len > 0) {
-                ssize_t ret = write(child->afpch_hint_fd,
-                                    write_buf, write_len);
+            if (write_len > 0
+                    && hint_write_batch(child->afpch_hint_fd, write_buf,
+                                        write_len, chunk_has_reset,
+                                        &waits_left) != 0) {
+                reset_lost |= chunk_has_reset;
+            }
+        }
+    }
 
-                if (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-                    LOG(log_debug, logtype_afpd,
-                        "hint_flush: write failed fd=%d pid=%d: %s",
-                        child->afpch_hint_fd,
-                        child->afpch_pid,
-                        strerror(errno));
-                }
+    if (reset_lost) {
+        /* At least one sibling missed a reset it can only hear again through
+         * a duplicate; siblings that did hear it end their sessions either
+         * way, so the re-broadcast is idempotent. */
+        for (int h = 0; h < local_count; h++) {
+            if (local_buf[h].event == CACHE_HINT_VOLUME_RESET) {
+                reset_broadcast_forget(local_buf[h].cnid);
             }
         }
     }
@@ -691,6 +898,26 @@ unsigned long long ipc_get_hints_dropped(void)
     return hints_dropped;
 }
 
+static const char *cache_hint_name(uint8_t event)
+{
+    switch (event) {
+    case CACHE_HINT_REFRESH:
+        return "REFRESH";
+
+    case CACHE_HINT_DELETE:
+        return "DELETE";
+
+    case CACHE_HINT_DELETE_CHILDREN:
+        return "DELETE_CHILDREN";
+
+    case CACHE_HINT_VOLUME_RESET:
+        return "VOLUME_RESET";
+
+    default:
+        return "?";
+    }
+}
+
 /*!
  * @brief Send a dircache invalidation hint from child to parent
  *
@@ -704,6 +931,10 @@ unsigned long long ipc_get_hints_dropped(void)
  * Hints are best-effort optimizations, and the dircache validation mechanism
  * & graceful fail-on-use detection makes drops safe.
  *
+ * CACHE_HINT_VOLUME_RESET is the exception: a sibling that misses it keeps
+ * resolving CNIDs that the wipe has recycled onto other files, so it waits
+ * briefly for pipe space and reports failure to the caller.
+ *
  * The 22-byte message (14-byte IPC header + 8-byte payload) is well under
  * the kernel socket buffer size, so partial writes cannot occur when space
  * is available.
@@ -711,15 +942,17 @@ unsigned long long ipc_get_hints_dropped(void)
  * @param[in] obj    AFPObj with ipc_fd
  * @param[in] vid    Volume ID (network byte order, matches vol->v_vid)
  * @param[in] cnid   CNID of affected file/dir (network byte order)
- * @param[in] event  Hint type: CACHE_HINT_REFRESH, CACHE_HINT_DELETE,
- *                   or CACHE_HINT_DELETE_CHILDREN
- * @returns 0 on success (or graceful drop), -1 on fatal error
+ * @param[in] event  Hint type: one of the CACHE_HINT_* values
+ * @returns 0 on success (or graceful drop), -1 on fatal error or an
+ *          undeliverable CACHE_HINT_VOLUME_RESET
  */
 int ipc_send_cache_hint(const AFPObj *obj, uint16_t vid, cnid_t cnid,
                         uint8_t event)
 {
     if (obj->ipc_fd < 0) {
-        return 0;    /* No IPC channel */
+        /* A reset nobody can be told about is a failure; a cache-mend hint
+         * is best-effort */
+        return event == CACHE_HINT_VOLUME_RESET ? -1 : 0;
     }
 
     /* Both vid and cnid are already network byte order in the codebase */
@@ -754,23 +987,36 @@ int ipc_send_cache_hint(const AFPObj *obj, uint16_t vid, cnid_t cnid,
         hints_sent++;
         LOG(log_debug, logtype_afpd,
             "ipc_send_cache_hint: sent %s for vid:%u did:%u",
-            event == CACHE_HINT_REFRESH ? "REFRESH" :
-            event == CACHE_HINT_DELETE ? "DELETE" :
-            event == CACHE_HINT_DELETE_CHILDREN ? "DELETE_CHILDREN" : "?",
-            ntohs(vid), ntohl(cnid));
+            cache_hint_name(event), ntohs(vid), ntohl(cnid));
         return 0;
     }
 
     if (ret == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
-        hints_dropped++;
-        LOG(log_debug, logtype_afpd,
-            "ipc_send_cache_hint: dropped (buffer full) %s for vid:%u did:%u "
-            "(total dropped: %llu)",
-            event == CACHE_HINT_REFRESH ? "REFRESH" :
-            event == CACHE_HINT_DELETE ? "DELETE" :
-            event == CACHE_HINT_DELETE_CHILDREN ? "DELETE_CHILDREN" : "?",
-            ntohs(vid), ntohl(cnid), hints_dropped);
-        return 0;  /* Graceful drop — not a fatal error */
+        if (event != CACHE_HINT_VOLUME_RESET) {
+            /* Best-effort: a lost cache-mend hint costs a lookup */
+            hints_dropped++;
+            LOG(log_debug, logtype_afpd,
+                "ipc_send_cache_hint: buffer full, %s dropped",
+                cache_hint_name(event));
+            return 0;
+        }
+
+        /* A lost reset costs every sibling the notification */
+        struct pollfd pfd = { .fd = obj->ipc_fd, .events = POLLOUT };
+        int pret;
+
+        do {
+            pret = poll(&pfd, 1, HINT_RESET_WAIT_MS);
+        } while (pret < 0 && errno == EINTR);
+
+        if (pret > 0 && (pfd.revents & POLLOUT)) {
+            ret = write(obj->ipc_fd, block, total);
+        }
+
+        if (ret == total) {
+            hints_sent++;
+            return 0;
+        }
     }
 
     /* Unexpected error (not EAGAIN) or partial write */

--- a/test/afpd/subtests_cnid.c
+++ b/test/afpd/subtests_cnid.c
@@ -37,6 +37,69 @@
 
 #include "subtests_cnid.h"
 #include "test.h"
+#include "volume.h"
+
+/*!
+ * @brief cnid_volume_tag() names the CNID table, not the session's volume slot
+ *
+ * v_vid is a counter each child assigns in its own volume-load order, so the
+ * same vid names different volumes in different children. The tag is derived
+ * from the volume UUID, which every child that opens the volume agrees on.
+ */
+int utest_cnid_volume_tag_identity(void)
+{
+    struct vol vol_a;
+    struct vol vol_b;
+    char uuid_a[] = "8A1B2C3D-4E5F-6071-8293-A4B5C6D7E8F9";
+    char uuid_same[] = "8A1B2C3D-4E5F-6071-8293-A4B5C6D7E8F9";
+    char uuid_b[] = "8A1B2C3D-4E5F-6071-8293-A4B5C6D7E8FA";
+    memset(&vol_a, 0, sizeof(vol_a));
+    memset(&vol_b, 0, sizeof(vol_b));
+
+    /* A volume with no UUID cannot be named, and must say so rather than
+     * returning a tag that could collide with a real one */
+    if (cnid_volume_tag(NULL) != 0) {
+        return 1;
+    }
+
+    vol_a.v_uuid = NULL;
+
+    if (cnid_volume_tag(&vol_a) != 0) {
+        return 2;
+    }
+
+    /* Same UUID in two separate volume structs — the cross-process case, where
+     * the sender and receiver have different v_vid but the same table */
+    vol_a.v_uuid = uuid_a;
+    vol_b.v_uuid = uuid_same;
+    vol_a.v_vid = 1;
+    vol_b.v_vid = 7;
+
+    if (cnid_volume_tag(&vol_a) != cnid_volume_tag(&vol_b)) {
+        return 3;
+    }
+
+    /* v_vid must not contribute: it is exactly the field that is unreliable */
+    vol_b.v_vid = 99;
+
+    if (cnid_volume_tag(&vol_a) != cnid_volume_tag(&vol_b)) {
+        return 4;
+    }
+
+    /* A one-character UUID difference must not alias */
+    vol_b.v_uuid = uuid_b;
+
+    if (cnid_volume_tag(&vol_a) == cnid_volume_tag(&vol_b)) {
+        return 5;
+    }
+
+    /* 0 is reserved for "no tag", so a real volume never yields it */
+    if (cnid_volume_tag(&vol_a) == 0 || cnid_volume_tag(&vol_b) == 0) {
+        return 6;
+    }
+
+    return 0;
+}
 
 #ifdef CNID_BACKEND_SQLITE
 /*!
@@ -134,6 +197,37 @@ static void cnid_peer_set_seq(sqlite3 *peer, const char *uuid, long long seq)
         sqlite3_exec(peer, sql, NULL, NULL, NULL);
         free(sql);
     }
+}
+
+/*!
+ * @brief Read the volume's Depleted mark
+ *
+ * Set when the CNID space is exhausted; while it stands, the backend discards
+ * every AppleDouble CNID hint offered to it.
+ *
+ * @returns the mark, or -1 when it cannot be read
+ */
+static int cnid_peer_get_depleted(sqlite3 *peer, const char *uuid)
+{
+    sqlite3_stmt *stmt = NULL;
+    int depleted = -1;
+    char *sql = NULL;
+
+    if (asprintf(&sql, "SELECT Depleted FROM volumes WHERE VolUUID = '%s'",
+                 uuid) == -1) {
+        return -1;
+    }
+
+    if (sqlite3_prepare_v2(peer, sql, -1, &stmt, NULL) == SQLITE_OK) {
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            depleted = sqlite3_column_int(stmt, 0);
+        }
+
+        sqlite3_finalize(stmt);
+    }
+
+    free(sql);
+    return depleted;
 }
 #endif /* CNID_BACKEND_SQLITE */
 
@@ -304,6 +398,113 @@ exit:
 }
 
 /*!
+ * @brief Exhausting the CNID space reports CNID_ERR_RESET, not a recycled id
+ *
+ * The 32-bit ceiling empties the table, so every CNID any session holds now
+ * names nothing or, as the table refills, another file. Returning a fresh id
+ * as though nothing happened is what the classification exists to prevent.
+ */
+int utest_cnid_add_depletion_resets(struct vol *vol)
+{
+#ifndef CNID_BACKEND_SQLITE
+    (void) vol;
+    return TEST_SKIP;
+#else
+    sqlite3 *peer;
+    char *uuid = NULL;
+    char probe[MAXPATHLEN];
+    const char *name;
+    struct stat st;
+    long long saved_seq;
+    cnid_t id;
+    int fd;
+    int result = 0;
+    int depleted = 0;
+
+    if ((peer = cnid_peer_open(vol)) == NULL) {
+        return TEST_SKIP;
+    }
+
+    if ((uuid = uuid_strip_dashes(vol->v_uuid)) == NULL) {
+        sqlite3_close(peer);
+        return 1;
+    }
+
+    if ((saved_seq = cnid_peer_get_seq(peer, uuid)) < 0) {
+        /* Without the mark there is no way to put the sequence back */
+        result = TEST_SKIP;
+        goto exit;
+    }
+
+    snprintf(probe, sizeof(probe), "%s/cnid_depleted_XXXXXX", vol->v_path);
+
+    if ((fd = mkstemp(probe)) < 0) {
+        result = 1;
+        goto exit;
+    }
+
+    if (fstat(fd, &st) != 0) {
+        result = 2;
+        goto close_probe;
+    }
+
+    name = strrchr(probe, '/') + 1;
+    /* The next AUTOINCREMENT rowid is the last CNID the space can hold */
+    cnid_peer_set_seq(peer, uuid, (long long) UINT32_MAX - 1);
+    errno = 0;
+    /* Past here the add may have emptied the table and marked the volume,
+     * whatever it returns, so the cleanup below has to undo that */
+    depleted = 1;
+    id = cnid_add(vol->v_cdb, &st, htonl(2), name, strlen(name), CNID_INVALID);
+
+    if (id != CNID_INVALID) {
+        cnid_delete(vol->v_cdb, id);
+        result = 3;
+        goto close_probe;
+    }
+
+    if (CNID_ERRNO() != CNID_ERR_RESET) {
+        result = 4;
+    }
+
+close_probe:
+    close(fd);
+    unlink(probe);
+exit:
+
+    /* Reaching the ceiling marked the volume depleted, on disk and latched in
+     * this connection — left set, every later test and run would have its
+     * AppleDouble CNID hints discarded. cnid_wipe() is the path that clears
+     * both; it reseeds the sequence, so the saved mark goes back after it. */
+    if (depleted && cnid_wipe(vol->v_cdb) != 0) {
+        fprintf(stderr, "# utest_cnid_add_depletion_resets: cnid_wipe failed, "
+                "volume '%s' left marked depleted\n", vol->v_localname);
+
+        if (result == 0) {
+            result = 5;
+        }
+    }
+
+    cnid_peer_set_seq(peer, uuid, saved_seq);
+
+    /* An unreadable mark says nothing about the cleanup, so only a mark still
+     * standing fails */
+    if (depleted && cnid_peer_get_depleted(peer, uuid) > 0) {
+        fprintf(stderr, "# utest_cnid_add_depletion_resets: volume '%s' still "
+                "marked depleted after cleanup\n", vol->v_localname);
+
+        if (result == 0) {
+            result = 6;
+        }
+    }
+
+    free(uuid);
+    sqlite3_close(peer);
+    return result;
+#endif /* CNID_BACKEND_SQLITE */
+}
+
+/*!
  * @brief The CNID error codes stay distinct and out of the errno range
  *
  * The codes travel in errno and are compared against it, so each must be
@@ -315,7 +516,7 @@ int utest_cnid_error_codes_distinct(void)
 {
     static const int codes[] = {
         CNID_ERR_PARAM, CNID_ERR_PATH, CNID_ERR_DB, CNID_ERR_MAX,
-        CNID_ERR_CLOSE, CNID_ERR_BUSY, CNID_ERR_CORRUPT,
+        CNID_ERR_CLOSE, CNID_ERR_RESET, CNID_ERR_BUSY, CNID_ERR_CORRUPT,
         CNID_ERR_NOTFOUND,
     };
     const int count = (int)(sizeof(codes) / sizeof(codes[0]));

--- a/test/afpd/subtests_cnid.h
+++ b/test/afpd/subtests_cnid.h
@@ -3,11 +3,13 @@
 
 struct vol;
 
+extern int utest_cnid_volume_tag_identity(void);
 extern int utest_cnid_wrapper_sets_errno(void);
 extern int utest_cnid_error_codes_distinct(void);
 extern int utest_cnid_valide_byteorder(void);
 extern int utest_cnid_resolve_dotdot_rejected(void);
 extern int utest_cnid_add_busy_not_fatal(struct vol *vol);
+extern int utest_cnid_add_depletion_resets(struct vol *vol);
 extern int utest_cnid_resolve_notfound_errno(struct vol *vol);
 extern int utest_cnid_corrupt_row_classified(struct vol *vol);
 extern int utest_cnid_find_no_truncated_id(struct vol *vol);

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -521,6 +521,8 @@ int main(int argc, char *argv[])
              "CNID wrapper rejection sets its own errno, not a stale one");
     TEST_int(utest_cnid_error_codes_distinct(), 0,
              "CNID error codes are distinct and clear of the errno range");
+    TEST_int(utest_cnid_volume_tag_identity(), 0,
+             "volume tag names the CNID table, independent of v_vid");
     TEST_int(utest_cnid_valide_byteorder(), 0,
              "CNID wrapper validates returned ids in host byte order");
     TEST_int(utest_cnid_resolve_dotdot_rejected(), 0,
@@ -594,6 +596,10 @@ int main(int argc, char *argv[])
                      "cnid_find: search results never carry a truncated id");
     TEST_int_or_skip(utest_cnid_dup_row_no_truncated_delete(vol), 0,
                      "cnid_lookup: duplicate cleanup never deletes through a truncated id");
+    /* Last of the CNID group: recovering from the reset empties the volume's
+     * table, so anything expecting a CNID minted earlier must run before it */
+    TEST_int_or_skip(utest_cnid_add_depletion_resets(vol), 0,
+                     "cnid_add: exhausting the CNID space reports CNID_ERR_RESET");
     /* test directory.c stuff */
     TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT_PARENT), retdir != NULL,
               "dirlookup: root parent directory");


### PR DESCRIPTION
A volume's CNID space is 32 bits. When it runs out the sqlite backend is meant to empty the table and start again, but the guard that detects exhaustion reads `if ((uint32_t) lastid > UINT32_MAX)` — a comparison the cast makes always false. The recovery has never run. Past the ceiling `htonl((uint32_t) lastid)` truncates instead, so rowid 2³²+17 becomes CNID 17 and two files answer to one ID.

Reaching the reset is only half of it. Emptying the table invalidates every CNID held by **every session on the volume**: each one now names nothing, or — once the table refills from 17 — a different file. So this PR does two things. It makes the recovery reachable, and it makes the recovery tell (reset) every affected session, because recycling IDs silently under live clients is worse than the exhaustion it fixes.

Both SQL backends are in scope. The unreachable guard is sqlite's, but mysql does the same wipe-and-reseed, so once a reset became a reportable condition mysql had to answer for it too — which meant first making its `errno` mean something.

## Root cause

Three layers, each locally reasonable:

1. **The comparison.** `lastid` is a `uint64_t` from `sqlite3_last_insert_rowid()`, and `(uint32_t) lastid` cannot exceed `UINT32_MAX`. The branch is unreachable, and the compiler is right not to warn: the cast is well defined, just always false.
2. **The recovery assumed one writer.** Emptying and reseeding is correct for a single process. With one afpd child per session sharing the table it is a global event with purely local effect — the child that wipes carries on, and its siblings never learn.
3. **Nothing above the backend could hear it.** The backend's only channel to afpd is `errno`, and no code for a table reset existed, so even a correct guard had nothing to report with.

mysql failed the same way from the other side: one classification for everything, `CNID_ERR_DB`, which afpd answers with `exit(EXITERR_SYS)`. InnoDB reports a deadlock immediately rather than waiting, and sessions inserting into one volume's table hit deadlocks and lock-wait timeouts routinely — so a condition that deserved a retry ended the session instead.

## How the guard got here

- **`f254fd61` — Ralph Boehme, 2013.** The MySQL backend introduces depletion: a `Depleted` column, a table wipe, an `AUTO_INCREMENT` reseed. Sound for a backend whose one writer is a remote server. `CNID_ERR_DB` was the only classification available, and the codes that tell a lock from a crash were never consulted.
- **`68efab70` — Daniel Markstedt, 2025.** The SQLite backend inherits that shape, truncating comparison included. Because the branch never fires, no test and no deployment ever exercised it.
- **sqlite becomes the default (2025–2026).** The unreachable recovery is now on every install's default path, and the process model has changed underneath it: one connection per session, all on one file.

## What each caller did with exhaustion, before and after

Five call paths reach `cnid_add()`. Because the guard never fired, **none** of them had ever met this condition.

| caller | before | after |
|---|---|---|
| `get_id()` (create/lookup, the main path) | recycled CNID returned as success | `CNID_ERR_RESET` → announce → session ends |
| `reenumerate_loop()` (directory resync) | kept walking, numbering entries out of the reseeded table | stops, returns −1 |
| `afp_resolveid()` | retried `cnid_resolve()` on the pre-wipe CNID, answering **AFP_OK with another file's metadata** | honours the walk's −1, returns `AFPERR_NOID` |
| `crit_check()` (FPCatSearch) | took the reset for "no match" and packed reseeded CNIDs into the reply | ends the walk, `AFPERR_MISC` |
| Spotlight (`cnid`, `localsearch`, `xapian`) | `cnid_for_path()` allocates, so a search could trip the wipe; one reported no results, two skipped the row and returned pre-wipe rows as a *resumable* success | all three end the query |
| `dbd` scanvol | skipped the entry and **kept scanning**, renumbering every remaining file against the emptied table and rewriting their AppleDouble IDs, then exiting 0 | stops, and fails its exit status so the rerun it advises is not optional |
| `nad`, `megatron` (no session to end) | generic "Error resolving CNID"; the wipe reported nowhere | every call site names the reset behind the failure |

## The notification

Siblings hear about it over the existing dircache-hint pipe. A cache-mend hint may be dropped; this one ends the receiving session, so it cannot be. It survives a full buffer, where a best-effort hint yields its slot, but it is metered against its own per-child budget so a session's cache-mend chatter cannot consume it — and it leaves with the call that buffered it, because the batching trigger, an idle poll or a full buffer, can be starved indefinitely on a busy master.

Beyond that it rides the ordinary batch writer: no retry ladder, no separate delivery path. A 22-byte message into a 64 KB pipe fails only for a child already wedged and about to be reaped, and a once-in-years event does not justify machinery in the master's single-threaded loop. The child keeps one `poll`-then-retry on its own IPC write, the one place where a lost write costs *every* sibling the notification.

Two details keep that safe under a burst. The dedupe records a volume's tag when the hint is relayed, before delivery is known, so a batch that fails with a reset in it releases the tag again — a sibling whose pipe stayed full has no other way to hear, and re-broadcasting is harmless because anyone who already heard is ending their session anyway. And the waits are budgeted per second rather than per flush, since every reset forces a flush and a per-flush budget would multiply the stall.

**The hint cannot be keyed on `v_vid`**, a per-process counter assigned in each child's own volume-load order: with `valid users` filters or `[Homes]`, the same vid names different volumes in different children, so acting on it would end a session whose CNIDs are fine and leave the affected one stale. `cnid_volume_tag()` is an FNV-1a of `v_uuid`, which every child that opens the volume agrees on.

**No AFP attention is sent.** The protocol guarantees an ID is never reused for another object for the volume's lifetime, so "the ID space was recycled" has no representation. The nearest candidate, `AFPATTN_VOLCHANGED`, only means "call FPGetVolParms" — it invalidates no cached ID and costs a round trip to say nothing useful. The disconnect is the signal, and the die path already sends `AFPATTN_SHUTDOWN`.

## The mysql error contract

The table below lists the mysql defects one by one. Two are worth drawing out, because this change is what made them dangerous.

A stale errno: both INSERT chokepoints failed without setting `errno` at all, so the caller read whatever an earlier operation had left there. That was merely wrong before. With `CNID_ERR_RESET` now in the vocabulary, a leftover one turns a single deadlock into a disconnect of every session on the volume.

An undetected wipe: `cnid_mysql_execute()` returned `mysql_query()`'s non-zero while its two `EC_NEG1()` call sites tested for `-1`, so a failed multi-statement wipe read as success — announcing a reset of a table that was never emptied, then doing it again on the next insert.

## Defect → fix

| # | Defect | Closed by |
|---|---|---|
| 1 | depletion guard unreachable; rowids past 2³² truncate into live CNIDs | 64-bit compare, `lastid >= (uint64_t) UINT32_MAX` |
| 2 | recovery invisible to siblings | `CACHE_HINT_VOLUME_RESET` over the hint pipe, keyed on `cnid_volume_tag()` |
| 3 | `CNID_ERR_RESET` had no producer or consumer | raised by both backends; handled in `get_id()`, both Spotlight paths, and the hint receiver |
| 4 | five walks would serve reseeded CNIDs in a reply sent before the session ends | each stops its own walk (table above) |
| 5 | a wipe from `dbd`/`nad` announced nothing | `dbd` stops and fails its exit status; every `nad`/`megatron` call site names the reset |
| 6 | `dbd -f` discarded the AppleDouble hints it was restoring | both backends' `wipe()` clear the latched depleted flag |
| 7 | a planted hint could bring the wipe within reach of ordinary file creation | 2²⁸ reserve on both backends, gating *insertion* only, so legacy rows keep their identity |
| 8 | a stale hint let a later direct lookup rewrite an unrelated row's identity | both backends clear the hint at the end of the add that carried it |
| 9 | no warning before the cliff | one-shot near-depletion warning naming `dbd` as the remedy |
| 10 | the condition travels in errno, which the IPC send and the backends' cleanup clobbered — and mysql's new insert gate turns a clobbered errno into a total allocation stop | every path on both backends saves and restores it |
| 11 | a reset to a busy sibling was dropped outright, and a failed delivery still counted as broadcast, so the next duplicate was deduped away | the master waits once for pipe space; a failed batch releases the tag for re-broadcast |
| 12 | resets were exempt from the attack guard, and the wait budget was per flush while every reset forces its own | a dedicated per-child reset budget, and one wait budget shared across flushes each second |
| 13 | mysql reseeded and continued, returning an id from the emptied space | raises `CNID_ERR_RESET` like sqlite |
| 14 | mysql read lock waits, deadlocks and contended reads as a dead backend or a missing id — the latter a permanent `AFPERR_NOID` | `cnid_mysql_set_errno()` classifies them; `_lookup`, `_get` and `_resolve` classify their statement, `store_result`, `bind_result` and `fetch` failures |
| 15 | mysql's two INSERT chokepoints set no errno, so the caller read a stale one — including a stale `CNID_ERR_RESET` | both classify before failing |
| 16 | mysql carried not-found as `CNID_DBD_RES_NOTFOUND`, numerically `EPERM` | `CNID_ERR_NOTFOUND`, and the post-lookup insert gate tests for it exactly |
| 17 | a later statement of a multi-statement wipe could fail unnoticed: `mysql_next_result()` signals it with a value a `== 0` drain loop reads as end-of-batch | one helper that separates error from end-of-batch, checked before the reset is announced and before the latch is cleared; it also owns the result pointer, so the double-free path is gone |
| 18 | the exec wrapper's failure return could not satisfy its two `EC_NEG1()` call sites | normalised to `-1` |
| 19 | mysql's add and update retry loops were unbounded, and `CR_SERVER_LOST` recovery re-armed its own | all three bounded |
| 20 | `cnid_mysql_getstamp()` returned `CNID_INVALID` (0) on parameter failure, which its int-returning callers read as success | returns `-1` |

## Behaviour changes

- A volume that reaches the ceiling now recovers instead of handing out colliding IDs, and every session on it is disconnected so clients reconnect against the rebuilt table.
- A search, an `FPCatSearch` or a directory resync that trips the wipe stops, rather than completing with recycled IDs in a successful reply.
- `dbd` stops at a reset and fails its exit status, where it used to carry on and leave the volume half renumbered while exiting 0. `nad` and `megatron` report a wipe they performed in silence. Note that `dbd` now exits non-zero for any scanvol failure, not only a reset.
- On mysql, lock contention no longer disconnects the client: a deadlock or lock-wait timeout is a retryable `AFPERR_MISC` instead of `exit(EXITERR_SYS)`, and a contended read is no longer a permanent "not found".
- `dir_modify()` evicts a dircache entry whose inode changed when the backend cannot answer, so the next access re-stats. Keeping it would serve the pre-change stat indefinitely, since enumerate's cache-hit path rebuilds `struct stat` from the cached fields and never re-stats. `curdir` cannot be evicted, so it keeps its old inode instead, leaving the trigger that brings us back here.

## Testing

**Unit tests.** afpd suite: 3/3 meson tests, 102 subtests, 0 failures, no compiler warnings, built with the full CNID backend set including mysql.

`utest_cnid_add_depletion_resets` covers the headline path. A peer sqlite connection moves the volume's `AUTOINCREMENT` mark to the ceiling, so a real `cnid_add()` empties the table and has to answer `CNID_ERR_RESET` rather than a recycled id. It then restores the volume — `cnid_wipe()` to clear the depleted mark on disk and in the connection, then the saved sequence — and asserts the mark is clear, because left set it would quietly discard every AppleDouble hint in later tests and later runs. Proven RED/GREEN: remove the wipe and the test reports the volume still depleted.

`utest_cnid_volume_tag_identity` pins the tag's cross-process property: the same UUID in two volume structs with different vids must agree, a one-character UUID change must not alias, and a volume with no UUID yields the reserved 0.

**Spectests** (sqlite, single-container loopback): 292 passed / 0 failed with ea = sys, and the same with ea = ad (`AFP_ADOUBLE=1`).

## Scope

Verified by review rather than by test:

- The relay-side guards — the reset's rate budget, the dedupe and its release on a failed delivery, the per-second wait budget — are parent-side and static in `ipc_relay_cache_hint()`/`hint_flush_pending()`, and no harness drives the master's IPC loop.
- Nothing exercises the mysql changes: the depletion test drives a peer *sqlite* connection, and there is no mysql equivalent nor anything that induces a deadlock. A mysql leg for that test, and a lock-contention test pinning `CNID_ERR_BUSY`, are the natural follow-ups.

Left open deliberately:

- **A reset during a primary reconnect is swallowed.** `afp_dsi_die()` returns without exiting while `DSI_RECONINPROG` is set, so the `raise(SIGTERM)` this design depends on can leave that session alive holding stale CNIDs. #3285 carries the `process_deferred_signals()` fix with the fuller teardown that path needs; duplicating it here would collide.
- **A reset ends sessions parked in `DSI_DISCONNECTED`**, destroying the reconnect window and the user's open forks — on a session serving CNIDs to nobody. Telling "end this session" from "refuse its reclaim" is a decision beyond this change.
- **A reset tripped by `dbd` or `nad` reaches no running session.** Those tools have no IPC channel to the master, and an afpd connection reads the `Depleted` column only at open. Closing it needs a generation check on the backend, or a signal path from the tools.
- **The hint's identity range.** Outside the insertable band a hint still acts as lookup's identity token, where `hint == retid` selects update-in-place. Narrowing identity to `[CNID_START, UINT32_MAX]` is the likely fix; the legacy-rows rationale justifies only that range, not the full 32 bits.
- **The volume tag is 32-bit**, and the master's dedupe is keyed on it alone, so two volumes colliding under FNV-1a would cross-disconnect. The hint payload is a fixed 8-byte packed struct with a `_Static_assert`, so widening it means changing the shared wire format.
- **`cnid_volume_tag()` is a fourth open-coded FNV-1a** (`libatalk/acl/cache.c`, `sl_xapian.c`, `dircache.c`), and `vol->v_stamp` — which comes *from* the backend — may be a better identity source than the optional `v_uuid`.

---

The diagram is the mechanism: who detects exhaustion, how the one process that wipes reaches every other, and where each walk stops so no reply carries a recycled ID.

```mermaid
%%{init: {'flowchart': {'curve': 'basis'}, 'themeVariables': {'edgeLabelBackground': '#e5e7eb'}}}%%
flowchart LR
    classDef be   fill:#0f766e,stroke:#0d9488,color:#f0fdfa,stroke-width:1px;
    classDef walk fill:#5b21b6,stroke:#6d28d9,color:#f5f3ff,stroke-width:1px;
    classDef ipc  fill:#b45309,stroke:#d97706,color:#fffbeb,stroke-width:1px;
    classDef end1 fill:#9f1239,stroke:#be123c,color:#fff1f2,stroke-width:1px;
    classDef tool fill:#374151,stroke:#4b5563,color:#f9fafb,stroke-width:1px;

    subgraph CHILD["afpd child that reaches the ceiling"]
        direction TB
        ADD("cnid_sqlite_add() · cnid_mysql_add()<br/>lastid at the 32-bit ceiling<br/><i>empty table, reseed to CNID_START-1</i>"):::be
        ERR("errno = CNID_ERR_RESET<br/><i>distinct from BUSY · CORRUPT · NOTFOUND · DB</i>"):::be
        WALKS("the five walks that mint CNIDs<br/>get_id · reenumerate_loop<br/>afp_resolveid · crit_check · Spotlight×3<br/><i>each stops its own walk</i>"):::walk
        RESET("cnid_volume_reset()<br/><i>tag = FNV-1a(v_uuid)</i>"):::ipc
        DIE1("deferred die<br/><i>between requests</i>"):::end1
    end

    subgraph MASTER["netatalk master"]
        direction TB
        RELAY("ipc_relay_cache_hint()<br/><i>own rate budget, deduped per volume,<br/>survives a full buffer,<br/>flushes with this call</i>"):::ipc
        SORT("hint_flush_pending()<br/><i>reset sorts ahead of the cache-mend batch,<br/>waits budgeted per second,<br/>undelivered reset is re-broadcastable</i>"):::ipc
    end

    subgraph SIBS["sibling sessions"]
        direction TB
        RECV("process_cache_hints()<br/><i>resolve volume by tag, not vid</i>"):::ipc
        DIE2("deferred die<br/><i>stop draining hints</i>"):::end1
    end

    subgraph TOOLS["dbd · nad — no session to end"]
        REPORT("end the scan, fail the exit status<br/><i>a rebuild's gap is visible</i>"):::tool
    end

    ADD --> ERR
    ERR --> WALKS
    WALKS -->|"one announces"| RESET
    ERR -.->|"tool context"| REPORT
    RESET --> RELAY
    RESET --> DIE1
    RELAY --> SORT
    SORT -->|"one write per sibling"| RECV
    RECV --> DIE2
```


