### PR TITLE
dircache: remove entries by stored node; fix duplicate-key creation, curdir loss, missing volume purge, and dead asserts

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -92,6 +92,46 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           tags: ${{ steps.metadata.outputs.tags }}
 
+  build-container-testsuite-perf:
+    name: Build Alpine testsuite container (release, for perf)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Gated like its only consumers (latencygraph-lantest, perfgraph-speedtest),
+    # so pushes and dependabot PRs do not build an image nothing pulls
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && !github.event.pull_request.head.repo.fork
+      }}
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Create image name
+        run: |
+          echo "IMAGE_NAME=${REPO,,}-testsuite-perf" >> ${GITHUB_ENV}
+      - name: Login to container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=raw,value=${{ github.sha }}
+      # As the correctness image but release, so the numbers exclude the asserts
+      - name: Build and push container image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: distrib/docker/testsuite_alp.Dockerfile
+          push: true
+          build-args: |
+            BUILDTYPE=release
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
+
   build-container-webmin:
     name: Build Netatalk Webmin Module container
     runs-on: ubuntu-latest
@@ -1917,7 +1957,7 @@ jobs:
 
   latencygraph-lantest:
     name: Lantest (AFP 3.4) - LatencyGraph
-    needs: build-container-testsuite
+    needs: build-container-testsuite-perf
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
@@ -1966,7 +2006,7 @@ jobs:
             -e AFP_DIRCACHE_RFORK_MAXSIZE="${{ env.AFP_DIRCACHE_RFORK_MAXSIZE }}" \
             -e AFP_TEST_ITERATIONS="${{ env.AFP_TEST_ITERATIONS }}" \
             -e TEST_FLAGS="-c" \
-            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }} \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-perf:${{ github.sha }} \
             > lantest.csv 2> lantest.log
       - name: Show lantest log
         if: always()
@@ -2098,7 +2138,7 @@ jobs:
 
   perfgraph-speedtest:
     name: Speedtest (AFP 3.4) - PerfGraph
-    needs: build-container-testsuite
+    needs: build-container-testsuite-perf
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
@@ -2148,7 +2188,7 @@ jobs:
             -e AFP_DIRCACHE_RFORK_MAXSIZE="${{ env.AFP_DIRCACHE_RFORK_MAXSIZE }}" \
             -e AFP_TEST_ITERATIONS="${{ env.AFP_TEST_ITERATIONS }}" \
             -e TEST_FLAGS="-c -z 0.00390625,0.0078125,0.015625,0.03125,0.0625,0.125,0.25,0.5,1,2,4,8,16,32,64,128,256" \
-            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }} \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-perf:${{ github.sha }} \
             > speedtest.csv 2> speedtest.log
       - name: Show speedtest log
         if: always()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,6 +81,7 @@ required at the bare minimum.
 | libldap                    | LDAP support |
 | libpam                     | PAM support |
 | libtirpc **OR** libquota   | Quota support |
+| libunwind                  | symbolized backtraces when a daemon crashes |
 | Perl                       | admin scripts |
 | po4a                       | localization of documentation |
 | stuffit-ffi                | StuffIt support in `nad` |

--- a/bin/nad/ftw.c
+++ b/bin/nad/ftw.c
@@ -49,7 +49,6 @@
 #define mempcpy(D, S, N) ((void *) ((char *) memcpy (D, S, N) + (N)))
 #endif
 
-#define NDEBUG 1
 #include <assert.h>
 
 #ifndef _LIBC

--- a/distrib/docker/debug_alp.Dockerfile
+++ b/distrib/docker/debug_alp.Dockerfile
@@ -1,5 +1,5 @@
 # Debug / profiling Alpine Dockerfile for Netatalk
-# Builds with -Dbuildtype=debugoptimized (-O2 -g) and includes perf + FlameGraph tools
+# Builds with -Dbuildtype=release plus explicit -g, and includes perf + FlameGraph tools
 # See doc/developer/profiling.md for usage guidance
 
 ARG RUN_DEPS="\
@@ -91,11 +91,11 @@ COPY meson_options.txt .
 COPY meson.build .
 RUN rm -rf build
 
-# Build with debugoptimized: -O2 optimization + debug symbols (-g)
-# Also preserve frame pointers for accurate perf stack unwinding
+# Release, so the profile is not dominated by assertions. -g is explicit because
+# release omits it and perf needs symbols; frame pointers for stack unwinding.
 RUN meson setup build \
-    -Dbuildtype=debugoptimized \
-    -Dc_args=-fno-omit-frame-pointer \
+    -Dbuildtype=release \
+    -Dc_args="-fno-omit-frame-pointer -g" \
     -Dwith-appletalk=true \
     -Dwith-dbus-daemon-path=/usr/bin/dbus-daemon \
     -Dwith-docs= \

--- a/distrib/docker/netatalk.Dockerfile
+++ b/distrib/docker/netatalk.Dockerfile
@@ -8,6 +8,7 @@ ARG RUN_DEPS="\
     krb5 \
     libevent \
     libgcrypt \
+    libunwind \
     linux-pam \
     mariadb-client \
     mariadb-connector-c \
@@ -27,6 +28,7 @@ ARG BUILD_DEPS="\
     krb5-dev \
     libevent-dev \
     libgcrypt-dev \
+    libunwind-dev \
     linux-pam-dev \
     mariadb-dev \
     meson \

--- a/distrib/docker/testsuite_alp.Dockerfile
+++ b/distrib/docker/testsuite_alp.Dockerfile
@@ -12,6 +12,7 @@ ARG RUN_DEPS="\
     libedit \
     libevent \
     libgcrypt \
+    libunwind \
     linux-pam \
     localsearch \
     mariadb \
@@ -40,6 +41,7 @@ ARG BUILD_DEPS="\
     libedit-dev \
     libevent-dev \
     libgcrypt-dev \
+    libunwind-dev \
     linux-pam-dev \
     mariadb-dev \
     meson \
@@ -58,6 +60,9 @@ ARG RUN_DEPS
 ARG BUILD_DEPS
 ENV RUN_DEPS=$RUN_DEPS
 ENV BUILD_DEPS=$BUILD_DEPS
+
+# Perf jobs pass release, so their numbers do not include the asserts
+ARG BUILDTYPE=debugoptimized
 
 RUN apk update \
 &&  apk add --no-cache \
@@ -113,7 +118,7 @@ COPY meson.build .
 RUN rm -rf build
 
 RUN meson setup build \
-    -Dbuildtype=debugoptimized \
+    -Dbuildtype=$BUILDTYPE \
     -Dwith-appletalk=true \
     -Dwith-dbus-daemon-path=/usr/bin/dbus-daemon \
     -Dwith-docs= \

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -157,6 +157,13 @@ functionality.
     library, netatalk can produce the GSS UAM library for authentication
     with existing Kerberos infrastructure.
 
+- libunwind
+
+    When a daemon hits a fatal fault, netatalk logs a backtrace of the
+    faulting thread, and libunwind names the functions in it. Builds
+    without it fall back to `backtrace_symbols()`, or to bare addresses
+    on C libraries that lack it, such as musl.
+
 - PAM
 
     PAM provides a flexible mechanism for authenticating users. PAM was

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -504,7 +504,14 @@ static int process_deferred_signals(AFPObj *obj)
         int sig = die_pending;
         die_pending = 0;
         afp_dsi_die(sig);
-        /* afp_dsi_die calls exit() — should not return */
+        /* Reached only with DSI_RECONINPROG set: the handoff failed
+         * (auth.c leaves the flag set) and this child still owns the client
+         * socket, so run the full teardown like the afp_over_dsi() backstop,
+         * keeping afp_dsi_die()'s diagnostic exit mapping. */
+        LOG(log_note, logtype_afpd, "Reconnect-state session terminating");
+        iw_shutdown();
+        afp_dsi_close(obj);
+        exit((sig == SIGTERM || sig == SIGALRM) ? 0 : sig);
     }
 
     /* Primary reconnect (SIGURG) */

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -122,6 +123,10 @@
 
 static hash_t       *dircache;
 static unsigned int dircache_maxsize;
+
+/* Cached entries per volume id, maintained in dircache_add()/dircache_remove(),
+ * so closing a volume with nothing cached costs one read, not a table scan */
+static uint32_t     vid_entry_count[UINT16_MAX + 1];
 
 /* Accessor for chain-level iteration — used by dircache_process_deferred_chain()
  * and dircache_flush_deferred_for_vol() */
@@ -329,6 +334,9 @@ static struct {
  * No separate ghost_entry_t type or pool is needed.
  */
 
+/* Ghost mid-promotion: arc_replace() can trim the very list it is leaving */
+static const struct dir *arc_promoting_ghost = NULL;
+
 /* FNV 1a - inline for performance */
 static inline hash_val_t hash_vid_did(const void *key)
 {
@@ -443,24 +451,85 @@ static void arc_verify_invariants(void)
 {
 #ifdef DEBUG
     AFP_ASSERT(arc_cache.enabled);
+    /* A ghost mid-promotion is not trimmed, so B1+B2 may sit one over c */
+    size_t slack = arc_promoting_ghost ? 1 : 0;
     /* Invariant 1: Total cached entries = c */
     AFP_ASSERT(arc_cache.t1_size + arc_cache.t2_size <= arc_cache.c);
     /* Invariant 2: Total ghost entries ≤ c */
-    AFP_ASSERT(arc_cache.b1_size + arc_cache.b2_size <= arc_cache.c);
+    AFP_ASSERT(arc_cache.b1_size + arc_cache.b2_size <= arc_cache.c + slack);
     /* Invariant 3: p within bounds */
     AFP_ASSERT(arc_cache.p <= arc_cache.c);
-    /* Invariant 4: Total directory size ≤ 2c */
+    /* Invariant 4: cached entries plus ghosts ≤ 2c */
     size_t l1 = arc_cache.t1_size + arc_cache.b1_size;
     size_t l2 = arc_cache.t2_size + arc_cache.b2_size;
-    AFP_ASSERT(l1 + l2 <= 2 * arc_cache.c);
+    AFP_ASSERT(l1 + l2 <= 2 * arc_cache.c + slack);
 
-    /* Once directory is full, maintain exact sizes */
-    if (l1 + l2 == 2 * arc_cache.c) {
+    /* Once the dircache is full, maintain exact sizes */
+    if (slack == 0 && l1 + l2 == 2 * arc_cache.c) {
         AFP_ASSERT(arc_cache.t1_size + arc_cache.t2_size == arc_cache.c);
         AFP_ASSERT(arc_cache.b1_size + arc_cache.b2_size == arc_cache.c);
     }
 
 #endif
+}
+
+static void dircache_defer_free(struct dir *dir);
+
+/*!
+ * @brief Release every cache entry belonging to a closing volume
+ *
+ * Nothing else reclaims by volume, so entries left behind are found as valid
+ * when the vid is reused. DIRCACHE_NOSHRINK keeps the scan valid: each entry
+ * deletes only its own just-returned node and the table never rehashes
+ * mid-scan.
+ *
+ * Nothing is exempt: closevol() frees v_root next, so an entry kept back
+ * would outlive its volume under a reusable vid. A curdir still inside the
+ * volume is dropped to rootParent rather than left cached.
+ *
+ * @param[in] vol  Volume being closed (required)
+ */
+void dircache_purge_vol(const struct vol *vol)
+{
+    unsigned int removed = 0;
+    hscan_t scan;
+    hnode_t *node;
+
+    if (dircache == NULL || vol == NULL) {
+        return;
+    }
+
+    const uint16_t vid = vol->v_vid;
+    uint32_t remaining = vid_entry_count[vid];
+
+    if (remaining == 0) {
+        return;
+    }
+
+    hash_scan_begin(&scan, dircache);
+
+    while (remaining > 0 && (node = hash_scan_next(&scan)) != NULL) {
+        struct dir *e = hnode_get(node);
+
+        if (e == NULL || e->d_vid != vid) {
+            continue;
+        }
+
+        remaining--;
+
+        /* v_root is freed next, so it cannot serve as the fallback */
+        if (e == curdir) {
+            curdir = &rootParent;
+        }
+
+        dircache_remove(vol, e, DIRCACHE_ALL | DIRCACHE_NOSHRINK);
+        /* Deferred: callers hold entries across a close */
+        dircache_defer_free(e);
+        removed++;
+    }
+
+    LOG(removed ? log_info : log_debug, logtype_afpd,
+        "dircache_purge_vol: vid:%u released %u entries", vid, removed);
 }
 
 /*!
@@ -488,17 +557,51 @@ static void dircache_defer_free(struct dir *dir)
 }
 
 /*!
- * @brief Ensure ghost directory has room for one more entry
+ * @brief Pick the ghost to release from a list at capacity
+ *
+ * LRU first, skipping the excluded entry; a single-node list is both MRU and
+ * LRU, so MRU ordering alone cannot exclude it.
+ *
+ * @param[in] q     Ghost queue (B1 or B2)
+ * @param[in] skip  Entry that must not be selected (ghost mid-promotion),
+ *                  or NULL
+ *
+ * @returns node to release, or NULL to leave the list alone
+ */
+qnode_t *arc_ghost_trim_candidate(q_t *q, const struct dir *skip)
+{
+    if (q == NULL || q->next == q) {
+        return NULL;
+    }
+
+    qnode_t *node = q->next;
+
+    if ((const struct dir *)node->data == skip) {
+        node = node->next;
+    }
+
+    if (node == q || node->data == NULL) {
+        return NULL;
+    }
+
+    return node;
+}
+
+/*!
+ * @brief Ensure the ghost lists have room for one more entry
  *
  * Maintains the ARC invariant: B1 + B2 ≤ c
  *
  * Called before operations that will add a ghost entry to B1 or B2.
- * If ghost directory is at or over capacity, deletes the LRU ghost
+ * If the ghost lists are at or over capacity, deletes the LRU ghost
  * from the specified target list to make room.
  *
  * This handles the edge case where entries are removed from the cache
  * via dircache_remove() (bypassing ghost lists), causing the ghost
- * directory to stay at capacity while the cache shrinks.
+ * lists to stay at capacity while the cache shrinks.
+ *
+ * A ghost mid-promotion is skipped, leaving the ghost lists one over
+ * capacity until that promotion moves it out.
  *
  * @param[in] target_list  Which ghost list will receive new entry (ARC_B1 or ARC_B2)
  */
@@ -511,29 +614,37 @@ static void arc_ensure_ghost_capacity(arc_list_t target_list)
         return;
     }
 
-    /* Ghost directory at or over capacity - must delete LRU from target list
+    /* Ghost lists at or over capacity - must delete LRU from target list
      * to maintain invariant B1+B2 <= c */
     q_t *target_queue = (target_list == ARC_B1) ? arc_cache.b1 : arc_cache.b2;
     size_t *target_size = (target_list == ARC_B1) ? &arc_cache.b1_size :
                           &arc_cache.b2_size;
+    qnode_t *victim_node = arc_ghost_trim_candidate(target_queue,
+                           arc_promoting_ghost);
 
-    /* Dequeue LRU ghost from target list */
-    if (*target_size > 0) {
-        struct dir *ghost = (struct dir *)dequeue(target_queue);
-
-        if (ghost) {
-            (*target_size)--;
-            ghost->qidx_node = NULL;  /* Clear queue pointer */
-            LOG(log_debug, logtype_afpd,
-                "arc_ensure_ghost_capacity: deleted %s ghost (did:%u) to maintain invariant (B1=%zu, B2=%zu)",
-                target_list == ARC_B1 ? "B1" : "B2",
-                ntohl(ghost->d_did),
-                arc_cache.b1_size,
-                arc_cache.b2_size);
-            dircache_remove(NULL, ghost, DIRCACHE | DIDNAME_INDEX);
-            dircache_defer_free(ghost);
-        }
+    if (victim_node == NULL) {
+        return;
     }
+
+    struct dir *ghost = (struct dir *)victim_node->data;
+
+    queue_remove(victim_node);
+
+    /* Guarded: a counter below the queue length would wrap to SIZE_MAX and
+     * disable trimming for the rest of the session */
+    if (*target_size > 0) {
+        (*target_size)--;
+    }
+
+    ghost->qidx_node = NULL;
+    LOG(log_debug, logtype_afpd,
+        "arc_ensure_ghost_capacity: deleted %s ghost (did:%u) to maintain invariant (B1=%zu, B2=%zu)",
+        target_list == ARC_B1 ? "B1" : "B2",
+        ntohl(ghost->d_did),
+        arc_cache.b1_size,
+        arc_cache.b2_size);
+    dircache_remove(NULL, ghost, DIRCACHE | DIDNAME_INDEX);
+    dircache_defer_free(ghost);
 }
 
 /*!
@@ -806,17 +917,16 @@ static void arc_case_ii_adapt_and_replace(struct dir *ghost)
         AFP_PANIC("arc_case_ii NULL qidx_node");
     }
 
-    /* Protect ghost from arc_ensure_ghost_capacity() eviction:
-     * Move ghost to MRU of B1 so it won't be the LRU victim when
-     * arc_replace() → arc_evict_to_ghost() → arc_ensure_ghost_capacity()
-     * needs to shrink B1 to maintain B1+B2 ≤ c. */
-    queue_move_to_tail(arc_cache.b1, ghost->qidx_node);
+    /* REPLACE can trim B1, and this ghost is leaving it */
+    arc_promoting_ghost = ghost;
 
-    /* Call REPLACE to make room in cache (ghost is safe at MRU of B1) */
+    /* Call REPLACE to make room in cache */
     if (arc_replace(0) != 0) {
         LOG(log_warning, logtype_afpd,
             "arc_case_ii: arc_replace failed, cache temporarily over capacity");
     }
+
+    arc_promoting_ghost = NULL;
 
     /* Promote ghost node from B1 to T2 */
     if (queue_move_to_tail_of(arc_cache.b1, arc_cache.t2,
@@ -884,17 +994,16 @@ static void arc_case_iii_adapt_and_replace(struct dir *ghost)
         AFP_PANIC("arc_case_iii NULL qidx_node");
     }
 
-    /* Protect ghost from arc_ensure_ghost_capacity() eviction:
-     * Move ghost to MRU of B2 so it won't be the LRU victim when
-     * arc_replace() → arc_evict_to_ghost() → arc_ensure_ghost_capacity()
-     * needs to shrink B2 to maintain B1+B2 ≤ c. */
-    queue_move_to_tail(arc_cache.b2, ghost->qidx_node);
+    /* REPLACE can trim B2, and this ghost is leaving it */
+    arc_promoting_ghost = ghost;
 
-    /* Call REPLACE to make room in cache (ghost is safe at MRU of B2) */
+    /* Call REPLACE to make room in cache */
     if (arc_replace(1) != 0) {  /* in_b2 = 1 */
         LOG(log_warning, logtype_afpd,
             "arc_case_iii: arc_replace failed, cache temporarily over capacity");
     }
+
+    arc_promoting_ghost = NULL;
 
     /* Move ghost node from B2 to T2 */
     if (queue_move_to_tail_of(arc_cache.b2, arc_cache.t2,
@@ -916,7 +1025,7 @@ static void arc_case_iii_adapt_and_replace(struct dir *ghost)
 }
 
 /*!
- * @brief ARC Case IV: Complete miss (not in any list)
+ * @brief ARC Case IV, eviction half: make room for a complete miss
  *
  * From paper:
  * "case (i): |L1| = c
@@ -924,16 +1033,14 @@ static void arc_case_iii_adapt_and_replace(struct dir *ghost)
  *      else delete LRU of T1, remove from cache
  *  case (ii): |L1| < c and |L1| + |L2| ≥ c
  *      if |L1| + |L2| = 2c then delete LRU of B2
- *      REPLACE(p)
- *  Put x at MRU of T1, load into cache"
+ *      REPLACE(p)"
  *
- * Adds new entry to T1 (recency list).
- *
- * @param[in] dir  New directory entry to insert
+ * Runs before the new entry's hash inserts: whenever the dircache holds 2c
+ * entries this deletes one from the hash, so hash_insert() never sees a full
+ * table (its nodecount < maxcount assert holds).
  */
-static void arc_case_iv(struct dir *dir)
+static void arc_case_iv_make_room(void)
 {
-    AFP_ASSERT(dir);
     size_t l1_size = arc_cache.t1_size + arc_cache.b1_size;
     size_t l2_size = arc_cache.t2_size + arc_cache.b2_size;
 
@@ -945,8 +1052,7 @@ static void arc_case_iv(struct dir *dir)
 
             if (ghost) {
                 arc_cache.b1_size--;
-                ghost->qidx_node = NULL;  /* Clear queue pointer after dequeue */
-                /* Ghost is a full struct dir - remove from hash, defer free */
+                ghost->qidx_node = NULL;
                 dircache_remove(NULL, ghost, DIRCACHE | DIDNAME_INDEX);
                 dircache_defer_free(ghost);
             }
@@ -967,11 +1073,8 @@ static void arc_case_iv(struct dir *dir)
             }
 
             if (victim) {
-                /* Unlink victim's node from its queue (circular doubly-linked list) */
-                qnode_t *node = victim->qidx_node;
-                node->prev->next = node->next;
-                node->next->prev = node->prev;
-                free(node);
+                queue_remove(victim->qidx_node);
+                victim->qidx_node = NULL;
 
                 if (victim->arc_list == ARC_T1) {
                     arc_cache.t1_size--;
@@ -979,7 +1082,6 @@ static void arc_case_iv(struct dir *dir)
                     arc_cache.t2_size--;
                 }
 
-                victim->qidx_node = NULL;
                 dircache_remove(NULL, victim, DIRCACHE | DIDNAME_INDEX);
                 dircache_defer_free(victim);
             } else {
@@ -991,14 +1093,13 @@ static void arc_case_iv(struct dir *dir)
     }
     /* Case (ii): |L1| < c and |L1| + |L2| ≥ c */
     else if (l1_size < arc_cache.c && (l1_size + l2_size) >= arc_cache.c) {
-        /* If directory is full (2c), delete LRU of B2 (ghost) */
+        /* If the dircache is full (2c), delete LRU of B2 (ghost) */
         if ((l1_size + l2_size) == 2 * arc_cache.c) {
             struct dir *ghost = (struct dir *)dequeue(arc_cache.b2);
 
             if (ghost) {
                 arc_cache.b2_size--;
-                ghost->qidx_node = NULL;  /* Clear queue pointer after dequeue */
-                /* Ghost is a full struct dir - remove from hash, defer free */
+                ghost->qidx_node = NULL;
                 dircache_remove(NULL, ghost, DIRCACHE | DIDNAME_INDEX);
                 dircache_defer_free(ghost);
             }
@@ -1011,16 +1112,25 @@ static void arc_case_iv(struct dir *dir)
         }
     }
 
-    /* Case (iii): Cache not full yet, just add */
+    /* Case (iii): Cache not full yet, nothing to evict */
+}
 
-    /* Add new entry to MRU (tail) of T1 */
+/*!
+ * @brief ARC Case IV, insertion half: "Put x at MRU of T1, load into cache"
+ *
+ * @param[in] dir  New directory entry, already in both hash indexes
+ */
+static void arc_case_iv_insert(struct dir *dir)
+{
+    AFP_ASSERT(dir);
+
     if ((dir->qidx_node = enqueue(arc_cache.t1, dir)) == NULL) {
         LOG(log_error, logtype_afpd, "arc_case_iv: T1 enqueue failed");
         AFP_PANIC("arc_case_iv T1 enqueue");
     }
 
     arc_cache.t1_size++;
-    dir->arc_list = ARC_T1;  /* Mark as being in T1 */
+    dir->arc_list = ARC_T1;
     /* Track peak cached entries (parallel to LRU's queue_count_max tracking) */
     size_t total_cached = arc_cache.t1_size + arc_cache.t2_size;
 
@@ -1180,8 +1290,8 @@ static void dircache_evict(void)
             continue;
         }
 
-        dircache_remove(NULL, dir, DIRCACHE | DIDNAME_INDEX); /* 3 */
-        dircache_defer_free(dir);                             /* 4 */
+        dircache_remove(NULL, dir, DIRCACHE | DIDNAME_INDEX);   /* 3 */
+        dircache_defer_free(dir);                               /* 4 */
     }
 
     AFP_ASSERT(queue_count == dircache->hash_nodecount);
@@ -1590,6 +1700,36 @@ struct dir *dircache_search_by_name(const struct vol *vol,
 }
 
 /*!
+ * @brief Retire a cached entry that a pending insert is about to supersede
+ *
+ * Not dir_remove(): its curdir recovery calls dirlookup(), which re-enters
+ * dircache_add() and re-publishes the key the caller is clearing. curdir is
+ * handed back instead, for the caller to re-point once its entry is published.
+ *
+ * @param[in]  vol         Volume the entry belongs to
+ * @param[in]  dup         Entry to retire
+ * @param[out] took_curdir set if the retired entry was curdir
+ */
+static void dircache_expunge_duplicate(const struct vol *vol, struct dir *dup,
+                                       int *took_curdir)
+{
+    /* Reserved ids are never hashed: dircache_add() asserts did >= CNID_START
+     * and invalidated entries leave the indexes before d_did is cleared */
+    AFP_ASSERT(dup->d_did != DIRDID_ROOT_PARENT && dup->d_did != DIRDID_ROOT
+               && dup->d_did != CNID_INVALID);
+
+    if ((curdir == dup) && !(dup->d_flags & DIRF_ISFILE)) {
+        curdir = NULL;
+        *took_curdir = 1;
+    }
+
+    dircache_remove(vol, dup, DIRCACHE | DIDNAME_INDEX | QUEUE_INDEX);
+    /* Deferred: pointers handed out earlier this request stay readable */
+    dircache_defer_free(dup);
+    dircache_stat.expunged++;
+}
+
+/*!
  * @brief create struct dir from struct path
  *
  * Add a struct dir to the cache and its indexes.
@@ -1598,13 +1738,15 @@ struct dir *dircache_search_by_name(const struct vol *vol,
  * @param[in] vol   pointer to volume
  * @param[in] dir   pointer to parent directory
  *
- * @returns 0 on success, -1 on error which should result in an abort
+ * @returns 0; a failed hash insert aborts the process
  */
 int dircache_add(const struct vol *vol,
                  struct dir *dir)
 {
     struct dir key;
     hnode_t *hn;
+    /* An expunged curdir is taken over by this entry, describing the same dir */
+    int took_curdir = 0;
     AFP_ASSERT(dir);
     AFP_ASSERT(ntohl(dir->d_pdid) >= 2);
 
@@ -1637,40 +1779,34 @@ int dircache_add(const struct vol *vol,
     key.d_did = dir->d_did;
 
     if ((hn = hash_lookup(dircache, &key))) {
-        /* Found an entry with the same CNID, delete it */
-        struct dir *duplicate = hnode_get(hn);
-        LOG(log_debug, logtype_afpd,
-            "dircache_add: found duplicate CNID entry: did:%u, removing",
-            ntohl(duplicate->d_did));
-        dir_remove(vol, duplicate, 0);  /* Proactive duplicate cleanup */
-        dircache_stat.expunged++;
+        dircache_expunge_duplicate(vol, hnode_get(hn), &took_curdir);
     }
 
-    key.d_vid = vol->v_vid;
+    /* Keyed on the entry, exactly as both inserts below are */
+    key.d_vid = dir->d_vid;
     key.d_pdid = dir->d_pdid;
     key.d_u_name = dir->d_u_name;
 
     if ((hn = hash_lookup(index_didname, &key))) {
-        /* Found an entry with the same DID/name, delete it */
-        struct dir *duplicate = hnode_get(hn);
-        LOG(log_debug, logtype_afpd,
-            "dircache_add: found duplicate DID/name entry: pdid:%u name:'%s', removing",
-            ntohl(duplicate->d_pdid),
-            duplicate->d_u_name ? cfrombstr(duplicate->d_u_name) : "(null)");
-        dir_remove(vol, duplicate, 0);  /* Proactive duplicate cleanup */
-        dircache_stat.expunged++;
+        dircache_expunge_duplicate(vol, hnode_get(hn), &took_curdir);
     }
 
-    /* LRU mode: Check cache fullness and evict BEFORE adding to hash tables */
-    if (!arc_cache.enabled && dircache->hash_nodecount >= dircache_maxsize) {
+    /* Make room BEFORE the hash inserts: hash_insert() asserts
+     * nodecount < maxcount, and a full dircache (2c in ARC, c in LRU)
+     * is this cache's steady state */
+    if (arc_cache.enabled) {
+        arc_case_iv_make_room();
+    } else if (dircache->hash_nodecount >= dircache_maxsize) {
         LOG(log_debug, logtype_afpd,
             "dircache_add: cache full, evicting before adding did:%u",
             ntohl(dir->d_did));
         dircache_evict();
     }
 
-    /* Add it to the main dircache hash table (both modes) */
-    if (hash_alloc_insert(dircache, dir, dir) == 0) {
+    /* Add it to the main dircache hash table (both modes), keeping the node
+     * so removal can delete it without a keyed lookup */
+    if ((dir->d_index_node = hash_alloc_insert_node(dircache, dir,
+                             dir)) == NULL) {
         LOG(log_error, logtype_afpd,
             "dircache_add: main hash insert failed for did:%u",
             ntohl(dir->d_did));
@@ -1678,26 +1814,37 @@ int dircache_add(const struct vol *vol,
         exit(EXITERR_SYS);
     }
 
+    vid_entry_count[dir->d_vid]++;
+
     /* Add it to the did/name index (both modes) */
-    if (hash_alloc_insert(index_didname, dir, dir) == 0) {
+    if ((dir->d_didname_node = hash_alloc_insert_node(index_didname, dir,
+                               dir)) == NULL) {
         /* insert failed; Rollback main hash to keep counts consistent */
         LOG(log_error, logtype_afpd,
             "dircache_add: didname hash insert failed for did:%u, rolling back",
             ntohl(dir->d_did));
-        hn = hash_lookup(dircache, dir);
-
-        if (hn) {
-            hash_delete_free(dircache, hn);
-        }
-
+        hash_delete_free(dircache, dir->d_index_node);
+        dir->d_index_node = NULL;
         dircache_dump();
         exit(EXITERR_SYS);
     }
 
+    /* Set before the queue insert below, whose eviction can reach this entry:
+     * dir_free() refuses only entries marked indexed */
+    dir->d_flags |= DIRF_INDEXED;
+
+    /* A file cannot be curdir, so an expunged curdir falls back to the
+     * volume root, which is not yet built during volume setup */
+    if (took_curdir) {
+        curdir = (dir->d_flags & DIRF_ISFILE)
+                 ? (vol->v_root ? vol->v_root : &rootParent)
+                 : dir;
+    }
+
     /* Add to queue index - dispatch based on mode */
     if (arc_cache.enabled) {
-        /* ARC mode: Use Case IV (complete miss) */
-        arc_case_iv(dir);
+        /* ARC mode: Case IV (complete miss); room was made above */
+        arc_case_iv_insert(dir);
     } else {
         /* LRU mode: Enqueue the new entry */
         if ((dir->qidx_node = enqueue(index_queue, dir)) == NULL) {
@@ -1726,26 +1873,77 @@ int dircache_add(const struct vol *vol,
 }
 
 /*!
+ * @brief A stored index node does not name its entry: unrecoverable
+ *
+ * Every node is created with its entry as data and freed only through the
+ * entry's own removal, so a mismatch means memory corruption or a foreign
+ * delete. Freeing what a table still points at cannot be survived.
+ */
+static void dircache_mismatch_panic(const char *index_name,
+                                    const struct dir *dir, const void *node,
+                                    const struct dir *found)
+{
+    LOG(log_severe, logtype_afpd,
+        "dircache_remove: entry %p did:%u pdid:%u name:\"%s\" flags:0x%x "
+        "arc_list:%u — %s node %p carries %p did:%u",
+        (const void *)dir, ntohl(dir->d_did), ntohl(dir->d_pdid),
+        dir->d_u_name ? cfrombstr(dir->d_u_name) : "(null)",
+        (unsigned)dir->d_flags, (unsigned)dir->arc_list,
+        index_name, node, (const void *)found,
+        found ? ntohl(found->d_did) : 0u);
+    dircache_dump();
+    AFP_PANIC("dircache index node mismatch");
+}
+
+/*!
   * @brief Remove an entry from the dircache
+  *
+  * Deletes the entry's own stored nodes, so removal can never cost another
+  * entry its node. A NULL node means the entry is not in that index and it
+  * is skipped; a node naming a different entry panics before anything is
+  * mutated or followed.
   *
   * Callers outside of dircache.c should call this with
   * flags = QUEUE_INDEX | DIDNAME_INDEX | DIRCACHE.
   */
 void dircache_remove(const struct vol *vol _U_, struct dir *dir, int flags)
 {
-    hnode_t *hn;
     AFP_ASSERT(dir);
     AFP_ASSERT((flags & ~(QUEUE_INDEX | DIDNAME_INDEX | DIRCACHE |
                           DIRCACHE_NOSHRINK)) == 0);
     AFP_ASSERT(!(flags & DIRCACHE_NOSHRINK)
                || (flags & (DIRCACHE | DIDNAME_INDEX)));
 
+    if (dir->d_didname_node && hnode_get(dir->d_didname_node) != dir) {
+        dircache_mismatch_panic("didname index", dir, dir->d_didname_node,
+                                hnode_get(dir->d_didname_node));
+    }
+
+    if (dir->d_index_node && hnode_get(dir->d_index_node) != dir) {
+        dircache_mismatch_panic("dircache", dir, dir->d_index_node,
+                                hnode_get(dir->d_index_node));
+    }
+
+    /* Marked as indexed but holding no node: some table may still point
+     * at this entry, so freeing it is not safe */
+    if ((flags & DIRCACHE) && dir->d_index_node == NULL
+            && (dir->d_flags & DIRF_INDEXED)) {
+        dircache_mismatch_panic("dircache", dir, NULL, NULL);
+    }
+
+    /* Unlinking dereferences qidx_node->prev; the node names its owner, so a
+     * mismatch catches a stale pointer before it is followed */
+    if (dir->qidx_node && dir->qidx_node->data != dir) {
+        dircache_mismatch_panic("queue", dir, dir->qidx_node,
+                                dir->qidx_node->data);
+    }
+
     if (flags & QUEUE_INDEX) {
         /* Remove from queue - dispatch based on mode */
         if (arc_cache.enabled) {
             /* ARC mode: Remove from appropriate ARC list */
             if (dir->qidx_node) {
-                dequeue(dir->qidx_node->prev);
+                queue_remove(dir->qidx_node);
 
                 /* Update list size based on which list it was in */
                 switch (dir->arc_list) {
@@ -1786,40 +1984,34 @@ void dircache_remove(const struct vol *vol _U_, struct dir *dir, int flags)
                     "dircache_remove: NULL qidx_node for did:%u (orphan entry!)",
                     ntohl(dir->d_did));
             } else {
-                dequeue(dir->qidx_node->prev);
-                /* Clear queue pointer after dequeue */
+                queue_remove(dir->qidx_node);
                 dir->qidx_node = NULL;
                 queue_count--;
             }
         }
     }
 
-    if (flags & DIDNAME_INDEX) {
-        if ((hn = hash_lookup(index_didname, dir)) == NULL) {
-            LOG(log_error, logtype_afpd,
-                "dircache_remove: Cache entry not in didname index: did:%u",
-                ntohl(dir->d_did));
+    if ((flags & DIDNAME_INDEX) && dir->d_didname_node) {
+        if (flags & DIRCACHE_NOSHRINK) {
+            hash_scan_delfree(index_didname, dir->d_didname_node);
         } else {
-            if (flags & DIRCACHE_NOSHRINK) {
-                hash_scan_delfree(index_didname, hn);
-            } else {
-                hash_delete_free(index_didname, hn);
-            }
+            hash_delete_free(index_didname, dir->d_didname_node);
         }
+
+        dir->d_didname_node = NULL;
     }
 
-    if (flags & DIRCACHE) {
-        if ((hn = hash_lookup(dircache, dir)) == NULL) {
-            LOG(log_error, logtype_afpd,
-                "dircache_remove: Cache entry not in dircache: did:%u",
-                ntohl(dir->d_did));
+    if ((flags & DIRCACHE) && dir->d_index_node) {
+        if (flags & DIRCACHE_NOSHRINK) {
+            hash_scan_delfree(dircache, dir->d_index_node);
         } else {
-            if (flags & DIRCACHE_NOSHRINK) {
-                hash_scan_delfree(dircache, hn);
-            } else {
-                hash_delete_free(dircache, hn);
-            }
+            hash_delete_free(dircache, dir->d_index_node);
         }
+
+        dir->d_index_node = NULL;
+        dir->d_flags &= ~DIRF_INDEXED;
+        AFP_ASSERT(vid_entry_count[dir->d_vid] > 0);
+        vid_entry_count[dir->d_vid]--;
     }
 
     /* Unpublish is the one choke point every removal funnels through
@@ -1845,117 +2037,92 @@ void dircache_remove(const struct vol *vol _U_, struct dir *dir, int flags)
  * CNID entries use parent DIDs and name, and requre recursion to get
  * the full path, therefore parent changes do not invalidate the CNIDs.
  *
+ * Removes as it scans: DIRCACHE_NOSHRINK deletes the entry's own
+ * just-returned node without rehashing the table, and the free is deferred,
+ * so nothing the scan is walking moves. dir_remove() cannot be used here —
+ * its curdir recovery calls dirlookup(), and an insert mid-scan can grow the
+ * table. A removed curdir is re-resolved once the scan is over instead: a
+ * rename keeps the CNID, so the lookup rebuilds the entry on the new path.
+ *
  * @param[in] vol  volume
  * @param[in] dir  parent directory whose children should be removed
- * @returns 0 on success, -1 if curdir was removed and recovery failed
+ * @returns 0 on success, -1 if a removed curdir could not be re-resolved
  */
 int dircache_remove_children(const struct vol *vol, struct dir *dir)
 {
     struct dir *entry;
     hnode_t *hn;
     hscan_t hs;
-    /* Store dir pointers */
-    struct dir **to_remove = NULL;
-    int remove_count = 0;
-    int remove_capacity = 0;
+    unsigned int removed = 0;
+    int recovery_status = 0;
 
     if (!dir || !dir->d_fullpath) {
         return 0;
     }
 
+    const char *parent_path = cfrombstr(dir->d_fullpath);
+    size_t parent_len = blength(dir->d_fullpath);
+
+    if (parent_path == NULL || parent_len == 0) {
+        return 0;
+    }
+
     LOG(log_debug, logtype_afpd,
         "dircache_remove_children: removing children of \"%s\" (did:%u)",
-        cfrombstr(dir->d_fullpath), ntohl(dir->d_did));
-    /* Two stages to avoid modifying the hash during iteration */
-    /* First pass: collect entries to remove */
+        parent_path, ntohl(dir->d_did));
+    cnid_t saved_curdir_did = curdir ? curdir->d_did : CNID_INVALID;
     hash_scan_begin(&hs, dircache);
 
     while ((hn = hash_scan_next(&hs))) {
         entry = hnode_get(hn);
 
         /* Skip the parent directory itself */
-        if (entry == dir) {
+        if (entry == dir || entry->d_fullpath == NULL) {
             continue;
         }
 
-        /* Check if entry is a decendant by comparing parent path */
-        if (entry->d_fullpath && dir->d_fullpath) {
-            const char *entry_path = cfrombstr(entry->d_fullpath);
-            const char *parent_path = cfrombstr(dir->d_fullpath);
-            size_t parent_len = blength(dir->d_fullpath);
+        /* A descendant's path is the parent's, then '/', then more */
+        const char *entry_path = cfrombstr(entry->d_fullpath);
 
-            /* Check if entry's path starts with parent's path followed by '/' */
-            if (parent_path && entry_path && parent_len > 0 &&
-                    (size_t)blength(entry->d_fullpath) > parent_len &&
-                    memcmp(entry_path, parent_path, parent_len) == 0 &&
-                    entry_path[parent_len] == '/') {
-                /* Expand to_remove array */
-                if (remove_count >= remove_capacity) {
-                    remove_capacity = remove_capacity ? remove_capacity * 2 : 16;
-                    struct dir **tmp = realloc(to_remove, remove_capacity * sizeof(struct dir*));
-
-                    if (!tmp) {
-                        LOG(log_error, logtype_afpd,
-                            "dircache_remove_children: out of memory");
-                        free(to_remove);
-                        return -1;
-                    }
-
-                    to_remove = tmp;
-                }
-
-                /* Store the dir pointer for removal */
-                to_remove[remove_count] = entry;
-                remove_count++;
-                LOG(log_debug, logtype_afpd,
-                    "dircache_remove_children: marking child \"%s\" (did:%u) for removal",
-                    entry->d_u_name ? cfrombstr(entry->d_u_name) : "(null)", ntohl(entry->d_did));
-            }
+        if (entry_path == NULL
+                || (size_t)blength(entry->d_fullpath) <= parent_len
+                || memcmp(entry_path, parent_path, parent_len) != 0
+                || entry_path[parent_len] != '/') {
+            continue;
         }
-    }
 
-    /* Save curdir DID before loop in case dir_remove recovery fails */
-    cnid_t saved_curdir_did = curdir ? curdir->d_did : CNID_INVALID;
-    int recovery_status = 0;
-
-    /* Second pass: remove collected entries from dircache */
-    for (int i = 0; i < remove_count; i++) {
-        entry = to_remove[i];
         LOG(log_debug, logtype_afpd,
             "dircache_remove_children: removing stale \"%s\" (did:%u) from dircache",
-            entry->d_u_name ? cfrombstr(entry->d_u_name) : "(null)", ntohl(entry->d_did));
+            entry->d_u_name ? cfrombstr(entry->d_u_name) : "(null)",
+            ntohl(entry->d_did));
 
-        /* dir_remove returns -1 if it removed curdir and recovery failed */
-        if (dir_remove(vol, entry, 0) != 0) {
-            /* Proactive cleanup of children after rename */
-            recovery_status = -1;
+        if (entry == curdir) {
+            curdir = NULL;
         }
+
+        dircache_remove(vol, entry, DIRCACHE_ALL | DIRCACHE_NOSHRINK);
+        dircache_defer_free(entry);
+        removed++;
     }
 
-    /* Defensive check: If curdir is NULL, dir_remove failed to recover */
+    /* Safe now the scan is over: this re-enters dircache_add() */
+    if (!curdir && saved_curdir_did != CNID_INVALID) {
+        curdir = dirlookup(vol, saved_curdir_did);
+    }
+
     if (!curdir) {
         curdir = vol->v_root ? vol->v_root : &rootParent;
         LOG(log_debug, logtype_afpd,
-            "dircache_remove_children: DEFENSIVE: curdir is NULL (was did:%u), fallback to %s",
+            "dircache_remove_children: curdir (was did:%u) not resolvable, "
+            "fallback to %s",
             ntohl(saved_curdir_did), vol->v_root ? "volume root" : "rootParent");
         recovery_status = -1;
     }
 
-    if (to_remove) {
-        free(to_remove);
-    }
-
-    if (remove_count) {
-        const char *status = recovery_status ? " (curdir recovery failed)" : "";
-        LOG(log_debug, logtype_afpd,
-            "dircache_remove_children: removed %d dircache entries of \"%s\"%s",
-            remove_count, cfrombstr(dir->d_fullpath), status);
-    } else {
-        LOG(log_debug, logtype_afpd,
-            "dircache_remove_children: removed %d dircache entries of \"%s\"",
-            remove_count, cfrombstr(dir->d_fullpath));
-    }
-
+    LOG(log_debug, logtype_afpd,
+        "dircache_remove_children: removed %u dircache entries of \"%s\"%s",
+        removed, parent_path,
+        recovery_status ? " (curdir recovery failed)" : "");
     return recovery_status;
 }
 
@@ -1971,13 +2138,29 @@ int dircache_remove_children(const struct vol *vol, struct dir *dir)
  *
  * @returns 0 on success, -1 on hash insert failure
  */
-int dircache_reindex_didname(const struct vol *vol _U_, struct dir *dir)
+int dircache_reindex_didname(const struct vol *vol, struct dir *dir)
 {
+    hnode_t *hn;
     AFP_ASSERT(dir);
+
+    /* A stale entry may still hold the new key (destination deleted outside
+     * this session); retire it like dircache_add() does, or the insert below
+     * would publish a second node under one key */
+    if ((hn = hash_lookup(index_didname, dir)) != NULL) {
+        int took_curdir = 0;
+        dircache_expunge_duplicate(vol, hnode_get(hn), &took_curdir);
+
+        if (took_curdir) {
+            curdir = (dir->d_flags & DIRF_ISFILE)
+                     ? (vol->v_root ? vol->v_root : &rootParent)
+                     : dir;
+        }
+    }
 
     /* Caller has already called dircache_remove(vol, dir, DIDNAME_INDEX)
      * and updated dir->d_pdid / dir->d_u_name. Re-insert with new key. */
-    if (hash_alloc_insert(index_didname, dir, dir) == 0) {
+    if ((dir->d_didname_node = hash_alloc_insert_node(index_didname, dir,
+                               dir)) == NULL) {
         LOG(log_error, logtype_afpd,
             "dircache_reindex_didname: re-insert failed for did:%u",
             ntohl(dir->d_did));
@@ -3013,30 +3196,27 @@ void dircache_flush_deferred_for_vol(uint16_t vid)
                 const struct vol *vol = getvolbyvid(vid);
 
                 if (vol) {
-                    hashcount_t nchains = hash_size(dircache);
+                    hscan_t hs;
+                    hnode_t *hn;
+                    hash_scan_begin(&hs, dircache);
 
-                    for (hashcount_t ci = 0; ci < nchains; ci++) {
-                        hnode_t *node = hash_chain_head(dircache, ci);
+                    while ((hn = hash_scan_next(&hs)) != NULL) {
+                        struct dir *entry = hnode_get(hn);
 
-                        while (node) {
-                            hnode_t *next = node->hash_next;
-                            struct dir *entry = hnode_get(node);
+                        if (entry == curdir || entry->d_did == CNID_INVALID
+                                || entry->d_fullpath == NULL) {
+                            continue;
+                        }
 
-                            if (entry != curdir &&
-                                    entry->d_did != CNID_INVALID &&
-                                    entry->d_fullpath) {
-                                const char *ep = cfrombstr(entry->d_fullpath);
+                        const char *ep = cfrombstr(entry->d_fullpath);
 
-                                if (ep &&
-                                        (size_t)blength(entry->d_fullpath) > deferred_queue[idx].parent_len &&
-                                        memcmp(ep, deferred_queue[idx].parent_path,
-                                               deferred_queue[idx].parent_len) == 0 &&
-                                        ep[deferred_queue[idx].parent_len] == '/') {
-                                    dir_remove_and_free(vol, entry);
-                                }
-                            }
-
-                            node = next;
+                        if (ep != NULL
+                                && (size_t)blength(entry->d_fullpath) > deferred_queue[idx].parent_len
+                                && memcmp(ep, deferred_queue[idx].parent_path,
+                                          deferred_queue[idx].parent_len) == 0
+                                && ep[deferred_queue[idx].parent_len] == '/') {
+                            /* NOSHRINK inside dir_remove_and_free keeps the scan valid */
+                            dir_remove_and_free(vol, entry);
                         }
                     }
                 }

--- a/etc/afpd/dircache.h
+++ b/etc/afpd/dircache.h
@@ -38,6 +38,9 @@
 #define DIRCACHE_NOSHRINK (1 << 3)  /* Skip hash table shrink */
 #define DIRCACHE_ALL  (DIRCACHE|DIDNAME_INDEX|QUEUE_INDEX)
 
+/*! Non-static so the unit tests can drive selection directly */
+extern qnode_t    *arc_ghost_trim_candidate(q_t *q, const struct dir *skip);
+extern void       dircache_purge_vol(const struct vol *vol);
 extern int        dircache_init(int reqsize);
 extern int        dircache_add(const struct vol *, struct dir *);
 extern void       dircache_remove(const struct vol *, struct dir *, int flag);

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -744,6 +744,9 @@ static struct dir *dirlookup_internal(const struct vol *vol, cnid_t did,
         goto exit;
     }
 
+    /* dir_new took ownership; dir_free(ret) is the sole owner of it now */
+    fullpath = NULL;
+
     /* Add new struct to the cache */
     if (dircache_add(vol, ret) != 0) { /* 7 */
         afp_errno = AFPERR_MISC;
@@ -754,7 +757,7 @@ static struct dir *dirlookup_internal(const struct vol *vol, cnid_t did,
 exit:
 
     /* Log result and cleanup */
-    if (ret) {
+    if (ret && !err) {
         LOG(log_debug, logtype_afpd,
             DIRLOOKUP_LOG_FMT ": SUCCESS - pdid: %u, path: \"%s\"",
             ntohl(ret->d_did), ntohl(ret->d_pdid), cfrombstr(ret->d_fullpath));
@@ -765,7 +768,7 @@ exit:
     }
 
     if (err) {
-        /* If dir_new failed, fullpath ownership not transferred to ret - free resources */
+        /* Non-NULL only before dir_new took ownership */
         if (fullpath) {
             bdestroy(fullpath);
         }
@@ -1008,6 +1011,19 @@ bstring fullpath_join(const bstring parent, const char *name)
  */
 void dir_free(struct dir *dir)
 {
+    /* A still-linked entry would leave the hash pointing at freed memory */
+    if ((dir->d_flags & DIRF_INDEXED) || dir->d_index_node
+            || dir->d_didname_node) {
+        LOG(log_error, logtype_afpd,
+            "dir_free: did:%u pdid:%u name:\"%s\" path:\"%s\" flags:0x%x "
+            "is still indexed",
+            ntohl(dir->d_did), ntohl(dir->d_pdid),
+            dir->d_u_name ? cfrombstr(dir->d_u_name) : "(null)",
+            dir->d_fullpath ? cfrombstr(dir->d_fullpath) : "(null)",
+            (unsigned)dir->d_flags);
+        AFP_PANIC("dir_free on an indexed dircache entry");
+    }
+
     /* Free Tier 2 rfork buffer before deallocating the entry.
      * rfork_cache_free() handles budget accounting and LRU removal. */
     if (dir->dcache_rfork_buf) {
@@ -1145,7 +1161,8 @@ int dir_modify(const struct vol *vol, struct dir *dir,
             }
         }
 
-        /* Remove from DID/name index if key is changing */
+        /* Re-keying while still indexed under the old key would leave two
+         * nodes for this entry */
         if (needs_reindex) {
             dircache_remove(vol, dir, DIDNAME_INDEX);
         }
@@ -1449,15 +1466,7 @@ struct dir *dir_add(struct vol *vol, const struct dir *dir, struct path *path,
             "dir_add(did:%u,'%s/%s'): {stray cache entry: did:%u,'%s', removing}",
             ntohl(dir->d_did), cfrombstr(dir->d_fullpath), path->u_name,
             ntohl(cdir->d_did), cfrombstr(dir->d_fullpath));
-        int remove_result = dir_remove(vol, cdir, 0);  /* Proactive cleanup of stray */
-
-        if (remove_result != 0) {
-            LOG(log_error, logtype_afpd,
-                "dir_add: CRITICAL dir_remove failed (returned -1), curdir recovery failed but curdir fallback successful");
-            dircache_dump();
-            AFP_PANIC("dir_add");
-        }
-
+        (void)dir_remove(vol, cdir, 0);  /* Proactive cleanup of stray */
         /* dir_remove() queued the stray on invalid_dircache_entries; the
          * exit block below must not free it a second time */
         cdir = NULL;
@@ -1480,6 +1489,7 @@ struct dir *dir_add(struct vol *vol, const struct dir *dir, struct path *path,
 
     if (adp) {
         ad_close(adp, ADFLAGS_HF);
+        adp = NULL;
     }
 
     /* Get macname from unixname */
@@ -1586,7 +1596,8 @@ void dir_remove_and_free(const struct vol *vol, struct dir *dir)
     }
 
     dircache_remove(vol, dir,
-                    DIRCACHE | DIDNAME_INDEX | QUEUE_INDEX | DIRCACHE_NOSHRINK);
+                    DIRCACHE | DIDNAME_INDEX | QUEUE_INDEX |
+                    DIRCACHE_NOSHRINK);
     dir->d_did = CNID_INVALID;
     dir_free(dir);
 }
@@ -1644,7 +1655,8 @@ int dir_remove(const struct vol *vol, struct dir *dir, int report_invalid)
     }
 
     /* Remove the dircache entry (also purges the entry's pfd slot) */
-    dircache_remove(vol, dir, DIRCACHE | DIDNAME_INDEX | QUEUE_INDEX); /* 2 */
+    dircache_remove(vol, dir,
+                    DIRCACHE | DIDNAME_INDEX | QUEUE_INDEX); /* 2 */
     /* Queue pruned entry for memory deallocation */
     enqueue(invalid_dircache_entries, dir); /* 3 */
     iw_note_work();

--- a/etc/afpd/hash.c
+++ b/etc/afpd/hash.c
@@ -20,13 +20,23 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#define NDEBUG
+/* assert() follows the b_ndebug build option; hash_insert() asserts key
+ * uniqueness */
 #include <assert.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #define HASH_IMPLEMENTATION
 #include "hash.h"
+
+/* hash_verify() walks every chain and node, so asserting it per mutation
+ * turns O(1) operations into O(table); confine it to debug buildtype and
+ * leave the O(chain) asserts to b_ndebug */
+#ifdef DEBUG
+#define HASH_ASSERT_VERIFY(h) assert(hash_verify(h))
+#else
+#define HASH_ASSERT_VERIFY(h) ((void)0)
+#endif
 
 #ifdef KAZLIB_RCSID
 #endif
@@ -198,7 +208,7 @@ static void grow_table(hash_t *hash)
         hash->highmark *= 2;
     }
 
-    assert(hash_verify(hash));
+    HASH_ASSERT_VERIFY(hash);
 }
 
 /*!
@@ -277,7 +287,7 @@ static void shrink_table(hash_t *hash)
     hash->nchains = nchains;
     hash->lowmark /= 2;
     hash->highmark /= 2;
-    assert(hash_verify(hash));
+    HASH_ASSERT_VERIFY(hash);
 }
 
 
@@ -347,7 +357,7 @@ hash_t *hash_create(hashcount_t maxcount, hash_comp_t compfun,
             hash->dynamic = 1;
             /* 8 */
             clear_table(hash);
-            assert(hash_verify(hash));
+            HASH_ASSERT_VERIFY(hash);
             return hash;
         }
 
@@ -538,7 +548,7 @@ void hash_insert(hash_t *hash, hnode_t *node, const void *key)
     node->next = hash->table[chain];
     hash->table[chain] = node;
     hash->nodecount++;
-    assert(hash_verify(hash));
+    HASH_ASSERT_VERIFY(hash);
 }
 
 /*!
@@ -625,7 +635,7 @@ hnode_t *hash_delete(hash_t *hash, hnode_t *node)
     }
 
     hash->nodecount--;
-    assert(hash_verify(hash));
+    HASH_ASSERT_VERIFY(hash);
     /* 6 */
     node->next = NULL;
     return node;
@@ -633,15 +643,23 @@ hnode_t *hash_delete(hash_t *hash, hnode_t *node)
 
 int hash_alloc_insert(hash_t *hash, const void *key, void *data)
 {
+    return hash_alloc_insert_node(hash, key, data) != NULL;
+}
+
+/*!
+ * Like hash_alloc_insert, but hands back the inserted node, so a caller that
+ * keeps it can delete without a lookup.
+ */
+hnode_t *hash_alloc_insert_node(hash_t *hash, const void *key, void *data)
+{
     hnode_t *node = hash->allocnode(hash->context);
 
     if (node) {
         hnode_init(node, data);
         hash_insert(hash, node, key);
-        return 1;
     }
 
-    return 0;
+    return node;
 }
 
 void hash_delete_free(hash_t *hash, hnode_t *node)
@@ -674,7 +692,7 @@ hnode_t *hash_scan_delete(hash_t *hash, hnode_t *node)
     }
 
     hash->nodecount--;
-    assert(hash_verify(hash));
+    HASH_ASSERT_VERIFY(hash);
     node->next = NULL;
     return node;
 }

--- a/etc/afpd/hash.h
+++ b/etc/afpd/hash.h
@@ -35,6 +35,7 @@ extern void hash_insert(hash_t *, hnode_t *, const void *);
 extern hnode_t *hash_lookup(hash_t *, const void *);
 extern hnode_t *hash_delete(hash_t *, hnode_t *);
 extern int hash_alloc_insert(hash_t *, const void *, void *);
+extern hnode_t *hash_alloc_insert_node(hash_t *, const void *, void *);
 extern void hash_delete_free(hash_t *, hnode_t *);
 
 extern void hnode_put(hnode_t *, void *);

--- a/etc/afpd/idle_worker.c
+++ b/etc/afpd/idle_worker.c
@@ -24,6 +24,7 @@
 #include <time.h>
 
 #include <atalk/logger.h>
+#include <atalk/util.h>
 #include <atalk/queue.h>
 
 #include "dircache.h"
@@ -162,10 +163,16 @@ static int iw_work_pending(void)
 static void *iw_main(void *arg)
 {
     (void)arg;
-    /* Block all signals — worker thread must not receive process signals */
+    /* Block the asynchronous signals: those are the main thread's to handle.
+     * The handled fault signals stay deliverable because the kernel cannot
+     * queue one to a thread that blocks it -- it forces the default action
+     * instead, turning a reportable crash into a silent kill. */
     sigset_t sigs;
     sigfillset(&sigs);
+    sigdelset(&sigs, SIGSEGV);
+    sigdelset(&sigs, SIGBUS);
     pthread_sigmask(SIG_BLOCK, &sigs, NULL);
+    fault_setup_thread();
     const struct timespec sleep_ts = {
         .tv_sec = 0,
         .tv_nsec = IW_WAKE_MS * 1000000L

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -1111,10 +1111,10 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
                 cnid_delete(ofork->of_vol->v_cdb, icon_cnid);
             }
 
-            /* Remove from dircache */
+            /* Remove from dircache and queue the entry for deallocation;
+             * skip cache refresh and hint lookup below */
             if (cached) {
-                dircache_remove(ofork->of_vol, cached, DIRCACHE | DIDNAME_INDEX | QUEUE_INDEX);
-                /* invalidated by dircache_remove; skip cache refresh and hint lookup below */
+                (void)dir_remove(ofork->of_vol, cached, 0);
                 cached = NULL;
             }
 

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -1151,6 +1151,8 @@ void closevol(const AFPObj *obj, struct vol *vol)
      * struct vol and v_vid persist across logout/re-login a surviving
      * slot would satisfy (vid, did) matches after re-open. */
     pfd_purge_vol(vol->v_vid);
+    /* Before v_root is freed, so removals still have a valid volume */
+    dircache_purge_vol(vol);
     dir_free(vol->v_root);
     vol->v_root = NULL;
 

--- a/include/atalk/directory.h
+++ b/include/atalk/directory.h
@@ -32,6 +32,7 @@
 #include <bstrlib.h>
 
 #include <atalk/cnid.h>
+#include <atalk/hash.h>
 #include <atalk/queue.h>
 #include <atalk/unicode.h>
 
@@ -52,6 +53,7 @@
 #define DIRF_OFFCNT    (1<<4) /*!< offsprings count is valid */
 #define DIRF_CNID	   (1<<5) /*!< renumerate id */
 #define DIRF_ARC_GHOST (1<<6) /*!< ARC ghost entry (in B1/B2) */
+#define DIRF_INDEXED   (1<<7) /*!< linked in the dircache hash index */
 
 /* dcache_rlen states. AD_RLEN_NO_RFORK is the floor of the positive
  * range, not a sentinel: test >= 0 for "metadata cached". */
@@ -76,6 +78,8 @@ struct dir { // NOSONAR (max 20 fields) — fields are intentionally grouped for
     bstring     d_u_name;            /*!< unix name */
     ucs2_t      *d_m_name_ucs2;      /*!< mac name as UCS2 */
     qnode_t     *qidx_node;          /*!< pointer to position in queue index */
+    hnode_t     *d_index_node;       /*!< this entry's node in the dircache */
+    hnode_t     *d_didname_node;     /*!< this entry's node in index_didname */
 
     /* Tier 2: Resource Fork data cache.
      * Dynamically allocated buffer containing dcache_rlen bytes of rfork data.

--- a/include/atalk/queue.h
+++ b/include/atalk/queue.h
@@ -39,5 +39,6 @@ extern qnode_t *prequeue(q_t *q, void *data);
 extern qnode_t *queue_move_to_tail(q_t *q, qnode_t *node);
 extern qnode_t *queue_move_to_tail_of(q_t *from_q, q_t *to_q, qnode_t *node);
 extern void *dequeue(q_t *q);
+extern void *queue_remove(qnode_t *node);
 
 #endif  /* ATALK_QUEUE_H */

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -109,6 +109,7 @@ extern pid_t server_lock(char * /*program*/, char * /*file*/, int /*debug*/);
 extern int check_lockfile(const char *program, const char *pidfile);
 extern int create_lockfile(const char *program, const char *pidfile);
 extern void fault_setup(void (*fn)(void *));
+extern void fault_setup_thread(void);
 extern void netatalk_panic(const char *why);
 #define server_unlock(x)  (unlink(x))
 

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -29,6 +29,10 @@ if have_acls
     libatalk_deps += acl_deps
 endif
 
+if libunwind.found()
+    libatalk_deps += libunwind
+endif
+
 libatalk_deps += sendfile_deps
 
 if enable_appletalk

--- a/libatalk/util/fault.c
+++ b/libatalk/util/fault.c
@@ -22,10 +22,14 @@
 #include "config.h"
 #endif
 
-#ifdef HAVE_BACKTRACE_SYMBOLS
+#ifdef HAVE_LIBUNWIND
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+#elif defined(HAVE_BACKTRACE_SYMBOLS)
 #include <execinfo.h>
 #endif
 
+#include <errno.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,6 +38,7 @@
 #include <unistd.h>
 
 #include <atalk/logger.h>
+#include <atalk/util.h>
 
 #ifndef SIGNAL_CAST
 #define SIGNAL_CAST (void (*)(int))
@@ -42,6 +47,9 @@
 #define SAFE_FREE(x) do { if ((x) != NULL) {free(x); x=NULL;} } while(0)
 #endif
 #define BACKTRACE_STACK_SIZE 64
+
+/* SIGSTKSZ is not a compile-time constant on current glibc */
+#define FAULT_ALTSTACK_SIZE (64 * 1024)
 
 static void (*cont_fn)(void *);
 
@@ -79,18 +87,61 @@ static void (*CatchSignal(int signum, void (*handler)(int)))(int)
 }
 
 /*!
- * Something really nasty happened - panic !
+ * Log a backtrace of the calling thread
+ *
+ * libunwind names frames on musl, which ships no execinfo; the execinfo path
+ * stays for platforms that do. Deep runs of one frame are the signature of
+ * runaway recursion, so log enough of them to see it.
  */
-void netatalk_panic(const char *why _U_)
+static void log_backtrace(void *uctx _U_)
 {
-#ifdef HAVE_BACKTRACE_SYMBOLS
+#ifdef HAVE_LIBUNWIND
+    unw_context_t uc;
+    unw_cursor_t cursor;
+    unsigned int frame = 0;
+    int ret;
+
+    if (uctx != NULL) {
+        /* Unwind the frame that faulted. Starting from the handler's own
+         * context instead stops at the signal trampoline, which musl does not
+         * annotate, hiding the whole call chain that matters */
+        ret = unw_init_local2(&cursor, (unw_context_t *) uctx,
+                              UNW_INIT_SIGNAL_FRAME);
+    } else if (unw_getcontext(&uc) == 0) {
+        ret = unw_init_local(&cursor, &uc);
+    } else {
+        ret = -1;
+    }
+
+    if (ret != 0) {
+        LOG(log_severe, logtype_default, "BACKTRACE: unavailable");
+        return;
+    }
+
+    LOG(log_severe, logtype_default, "BACKTRACE:");
+
+    do {
+        unw_word_t ip = 0;
+        unw_word_t off = 0;
+        char name[256];
+        unw_get_reg(&cursor, UNW_REG_IP, &ip);
+
+        if (unw_get_proc_name(&cursor, name, sizeof(name), &off) != 0) {
+            name[0] = '\0';
+        }
+
+        LOG(log_severe, logtype_default, " #%u 0x%llx %s+0x%llx",
+            frame++, (unsigned long long)ip,
+            name[0] ? name : "??", (unsigned long long)off);
+    } while (frame < BACKTRACE_STACK_SIZE && unw_step(&cursor) > 0);
+
+#elif defined(HAVE_BACKTRACE_SYMBOLS)
     void *backtrace_stack[BACKTRACE_STACK_SIZE];
     size_t backtrace_size;
     char **backtrace_strings;
     /* get the backtrace (stack frames) */
     backtrace_size = backtrace(backtrace_stack, BACKTRACE_STACK_SIZE);
     backtrace_strings = backtrace_symbols(backtrace_stack, backtrace_size);
-    LOG(log_severe, logtype_default, "PANIC: %s", why);
     LOG(log_severe, logtype_default, "BACKTRACE: %d stack frames:", backtrace_size);
 
     if (backtrace_strings) {
@@ -103,29 +154,54 @@ void netatalk_panic(const char *why _U_)
         SAFE_FREE(backtrace_strings);
     }
 
+#else
+    LOG(log_severe, logtype_default,
+        "BACKTRACE: not built with an unwinder (libunwind or execinfo)");
 #endif
+}
+
+/*!
+ * Something really nasty happened - panic !
+ */
+static void panic_report(const char *why, void *uctx)
+{
+    LOG(log_severe, logtype_default, "PANIC: %s", why);
+    log_backtrace(uctx);
+}
+
+void netatalk_panic(const char *why)
+{
+    panic_report(why, NULL);
 }
 
 
 /*!
  * report a fault
  */
-static void fault_report(int sig)
+static void fault_report(int sig, siginfo_t *info, void *uctx)
 {
+    /* Atomic: the main thread and the idle worker can fault concurrently */
     static int counter;
 
-    if (counter) {
+    if (__atomic_fetch_add(&counter, 1, __ATOMIC_SEQ_CST) > 0) {
         abort();
     }
 
-    counter++;
     LOG(log_severe, logtype_default,
         "===============================================================");
     LOG(log_severe, logtype_default, "INTERNAL ERROR: Signal %d in pid %d (%s)",
         sig, (int)getpid(), VERSION);
+
+    if (info != NULL) {
+        /* An address just past the deepest frame means the guard page, ie the
+         * stack was exhausted rather than a bad pointer dereferenced */
+        LOG(log_severe, logtype_default,
+            "faulting address %p, si_code %d", info->si_addr, info->si_code);
+    }
+
     LOG(log_severe, logtype_default,
         "===============================================================");
-    netatalk_panic("internal error");
+    panic_report("internal error", uctx);
 
     if (cont_fn) {
         cont_fn(NULL);
@@ -144,9 +220,55 @@ static void fault_report(int sig)
 /*!
  * catch serious errors
  */
-static void sig_fault(int sig)
+static void sig_fault(int sig, siginfo_t *info, void *ctx)
 {
-    fault_report(sig);
+    fault_report(sig, info, ctx);
+}
+
+/*!
+ * Install sig_fault for a fault signal, on the alternate stack
+ *
+ * SA_ONSTACK is required to report stack exhaustion: the
+ * guard page leaves no room for a signal frame, so without it the kernel
+ * cannot run the handler and kills the process with no diagnostic.
+ */
+static void catch_fault_signal(int signum)
+{
+    struct sigaction act;
+    ZERO_STRUCT(act);
+    act.sa_sigaction = sig_fault;
+    act.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&act.sa_mask);
+    sigaddset(&act.sa_mask, signum);
+    sigaction(signum, &act, NULL);
+}
+
+#ifdef HAVE_SIGALTSTACK
+static void install_altstack(char *base, size_t size)
+{
+    stack_t ss;
+    ZERO_STRUCT(ss);
+    ss.ss_sp = base;
+    ss.ss_size = size;
+
+    if (sigaltstack(&ss, NULL) != 0) {
+        LOG(log_error, logtype_default, "sigaltstack: %s", strerror(errno));
+    }
+}
+#endif
+
+/*!
+ * Give the calling thread its own alternate signal stack
+ *
+ * sigaltstack() is per-thread and survives fork() but not pthread_create(), so
+ * a thread that exhausts its stack dies unreported unless it installs one.
+ */
+void fault_setup_thread(void)
+{
+#ifdef HAVE_SIGALTSTACK
+    static _Thread_local char altstack[FAULT_ALTSTACK_SIZE];
+    install_altstack(altstack, sizeof(altstack));
+#endif
 }
 
 /*!
@@ -155,10 +277,14 @@ static void sig_fault(int sig)
 void fault_setup(void (*fn)(void *))
 {
     cont_fn = fn;
+#ifdef HAVE_SIGALTSTACK
+    static char altstack[FAULT_ALTSTACK_SIZE];
+    install_altstack(altstack, sizeof(altstack));
+#endif
 #ifdef SIGSEGV
-    CatchSignal(SIGSEGV, SIGNAL_CAST sig_fault);
+    catch_fault_signal(SIGSEGV);
 #endif
 #ifdef SIGBUS
-    CatchSignal(SIGBUS, SIGNAL_CAST sig_fault);
+    catch_fault_signal(SIGBUS);
 #endif
 }

--- a/libatalk/util/meson.build
+++ b/libatalk/util/meson.build
@@ -21,11 +21,18 @@ util_sources = [
     'unix.c',
 ]
 
+libutil_deps = [bstring, iniparser]
+
+# fault.c includes <libunwind.h> when HAVE_LIBUNWIND is set
+if libunwind.found()
+    libutil_deps += libunwind
+endif
+
 libutil = static_library(
     'util',
     util_sources,
     include_directories: root_includes,
-    dependencies: [bstring, iniparser],
+    dependencies: libutil_deps,
     c_args: [
         confdir,
         messagedir,

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -431,7 +431,7 @@ static int check_vol_acl_support(const struct vol *vol)
     }
 
 #endif /* HAVE_POSIX_ACLS */
-    LOG(log_debug, logtype_afpd, "Volume \"%s\" ACL support: %s",
+    LOG(log_info, logtype_afpd, "Volume \"%s\" ACL support: %s",
         vol->v_path, ret ? "yes" : "no");
     return ret;
 }
@@ -2066,7 +2066,7 @@ static struct vol *creatvol(AFPObj *obj,
 #ifdef HAVE_ACLS
 
     if (!check_vol_acl_support(volume)) {
-        LOG(log_debug, logtype_afpd, "creatvol(\"%s\"): disabling ACL support",
+        LOG(log_info, logtype_afpd, "creatvol(\"%s\"): disabling ACL support",
             volume->v_path);
         volume->v_flags &= ~AFPVOL_ACLS;
         obj->options.flags &= ~(OPTION_ACL2MODE | OPTION_ACL2MACCESS);

--- a/libatalk/util/queue.c
+++ b/libatalk/util/queue.c
@@ -159,6 +159,22 @@ qnode_t *prequeue(q_t *q, void *data)
     return node;
 }
 
+/*! Unlink a node from whichever queue holds it and free it */
+void *queue_remove(qnode_t *node)
+{
+    void *data;
+
+    if (node == NULL) {
+        return NULL;
+    }
+
+    data = node->data;
+    node->prev->next = node->next;
+    node->next->prev = node->prev;
+    free(node);
+    return data;
+}
+
 /*! Take from head */
 void *dequeue(q_t *q)
 {

--- a/meson.build
+++ b/meson.build
@@ -545,6 +545,7 @@ check_functions = [
     'pselect',
     'pwrite',
     'rresvport',
+    'sigaltstack',
     'splice',
     'strlcat',
     'strlcpy',
@@ -839,6 +840,13 @@ if enable_dbd_backend
 endif
 
 # Check for mysql CNID backend
+
+# Backtraces on musl, which ships no execinfo
+libunwind = dependency('libunwind', required: false)
+
+if libunwind.found()
+    cdata.set('HAVE_LIBUNWIND', 1)
+endif
 
 mysqlclient = dependency('mysqlclient', required: false)
 mariadb = dependency('libmariadb', required: false)

--- a/meson_config.h
+++ b/meson_config.h
@@ -199,6 +199,9 @@
 /* define if you have libquota */
 #mesondefine HAVE_LIBQUOTA
 
+/* Whether libunwind is available for backtraces */
+#mesondefine HAVE_LIBUNWIND
+
 /* Define to 1 if you have the `listea' function. */
 #mesondefine HAVE_LISTEA
 
@@ -282,6 +285,9 @@
 
 /* Define to 1 if you have the <sgtty.h> header file. */
 #mesondefine HAVE_SGTTY_H
+
+/* Define to 1 if you have the `sigaltstack' function. */
+#mesondefine HAVE_SIGALTSTACK
 
 /* Whether Solaris ACLs are available */
 #mesondefine HAVE_SOLARIS_ACLS

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -164,6 +164,23 @@ if build_afpd_tests
         # default is too close for a loaded runner
         timeout: 120,
     )
+    # Second leg in LRU mode: both cache modes ship, and index_queue and
+    # dircache_evict() run in that mode only
+    test(
+        'afpd tests - run (LRU dircache)',
+        afpdtest,
+        args: ['--tap'],
+        protocol: 'tap',
+        env: {
+            'LD_PRELOAD': faultinject_preload.full_path(),
+            'AFPDTEST_DIRCACHE_MODE': 'lru',
+        },
+        depends: faultinject_preload,
+        verbose: true,
+        is_parallel: false,
+        priority: 0,
+        timeout: 120,
+    )
 
 endif
 

--- a/test/afpd/subtests.c
+++ b/test/afpd/subtests.c
@@ -43,6 +43,29 @@
 #include "test.h"
 #include "volume.h"
 
+/*!
+ * @brief Plant a cache entry keyed (DIRDID_ROOT, uname)
+ *
+ * Fullpath points at the volume root so lookup validation stats successfully
+ * and returns the entry.
+ */
+static struct dir *plant_root_entry(const struct vol *vol, const char *uname,
+                                    cnid_t did, struct stat *st)
+{
+    bstring fullpath = bfromcstr(vol->v_path);
+    struct dir *entry = dir_new(uname, uname, vol, DIRDID_ROOT, did,
+                                fullpath, st);
+
+    if (entry == NULL) {
+        /* dir_new takes ownership only on success */
+        bdestroy(fullpath);
+        return NULL;
+    }
+
+    dircache_add(vol, entry);
+    return entry;
+}
+
 int test001_add_x_dirs(const struct vol *vol, cnid_t start, cnid_t end)
 {
     struct dir *dir;
@@ -87,7 +110,8 @@ int test002_rem_x_dirs(const struct vol *vol, cnid_t start, cnid_t end)
 int test003_dir_add_error_no_double_free(struct vol *vol)
 {
     const struct dir *root;
-    struct dir *stray, *ret;
+    const struct dir *stray;
+    const struct dir *ret;
     struct path path;
     struct stat st;
     struct _cnid_db *saved_cdb;
@@ -101,12 +125,10 @@ int test003_dir_add_error_no_double_free(struct vol *vol)
         return -1;
     }
 
-    /* Plant a stray entry for (root, uname).  Fullpath points at the volume
-     * root so the lookup validation stat succeeds and returns the entry. */
-    stray = dir_new(uname, uname, vol, DIRDID_ROOT, htonl(30003),
-                    bfromcstr(vol->v_path), &st);
+    /* Plant a stray entry for (root, uname) */
+    stray = plant_root_entry(vol, uname, htonl(30003), &st);
 
-    if (stray == NULL || dircache_add(vol, stray) != 0) {
+    if (stray == NULL) {
         return -1;
     }
 
@@ -514,5 +536,392 @@ out:
     }
 
     close(cwd_fd);
+    return ret;
+}
+
+/*!
+ * @brief A second entry may never be published under a key already in use
+ *
+ * A key may name only one entry. Adds over both keys — (vid, did) and
+ * (vid, pdid, uname) — with curdir on the entry being retired, the case that
+ * drives a recovery lookup back into dircache_add().
+ */
+int test007_add_over_existing_key_leaves_one(struct vol *vol)
+{
+    struct dir *first = NULL;
+    struct dir *second = NULL;
+    struct dir *saved_curdir = curdir;
+    const char *uname = "t007_dup_key";
+    const cnid_t did = htonl(30007);
+    struct stat st;
+    int ret = -1;
+
+    if (stat(vol->v_path, &st) != 0) {
+        return -1;
+    }
+
+    first = plant_root_entry(vol, uname, did, &st);
+
+    if (first == NULL) {
+        return -1;
+    }
+
+    /* Not looked up: validation would reject the root's inode under this CNID
+     * and retire the entry before the duplicate is attempted */
+    curdir = first;
+    /* Collides on both keys */
+    second = dir_new(uname, uname, vol, DIRDID_ROOT, did,
+                     bfromcstr(vol->v_path), &st);
+
+    if (second == NULL) {
+        ret = 3;
+        goto out;
+    }
+
+    if (dircache_add(vol, second) != 0) {
+        ret = 4;
+        goto out;
+    }
+
+    /* Retired, awaiting the deferred free */
+    if (first->d_did != CNID_INVALID) {
+        ret = 7;
+        goto out;
+    }
+
+    /* Taken over by the replacement, not recovered via dirlookup() */
+    if (curdir != second) {
+        ret = 8;
+        goto out;
+    }
+
+    ret = 0;
+out:
+
+    if (ret != 0) {
+        fprintf(stderr,
+                "test007: failed at step %d (first=%p did:%u, second=%p, curdir=%p)\n",
+                ret, (void *)first, first ? ntohl(first->d_did) : 0u,
+                (void *)second, (void *)curdir);
+    }
+
+    curdir = saved_curdir;
+
+    if (second != NULL && second->d_did != CNID_INVALID) {
+        dir_remove(vol, second, 0);
+    }
+
+    /* On the paths that never reached the duplicate add, the planted entry
+     * is still cached and must not outlive the test */
+    if (first != NULL && first->d_did != CNID_INVALID) {
+        dir_remove(vol, first, 0);
+    }
+
+    dir_free_invalid_q();
+    return ret;
+}
+
+/*!
+ * @brief Ghost-trim selection never yields the pinned entry
+ *
+ * Throwaway queues suffice: only the choice of node is under test.
+ *
+ * @returns 0, else the number of the case that disagreed
+ */
+int dircache_test_ghost_trim_selection(void)
+{
+    struct dir lru = {0};
+    struct dir mru = {0};
+    q_t *q = queue_init();
+    int ret = 0;
+
+    if (q == NULL) {
+        return -1;
+    }
+
+    /* 1: nothing queued, nothing to release */
+    if (arc_ghost_trim_candidate(q, NULL) != NULL) {
+        ret = 1;
+        goto out;
+    }
+
+    /* 2: a lone unpinned ghost is the candidate */
+    const qnode_t *lru_node = enqueue(q, &lru);
+
+    if (lru_node == NULL) {
+        ret = -1;
+        goto out;
+    }
+
+    if (arc_ghost_trim_candidate(q, NULL) != lru_node) {
+        ret = 2;
+        goto out;
+    }
+
+    /* 3: a lone ghost mid-promotion must be left alone */
+    if (arc_ghost_trim_candidate(q, &lru) != NULL) {
+        ret = 3;
+        goto out;
+    }
+
+    /* 4: pinned at LRU, so the next ghost along is released instead */
+    const qnode_t *mru_node = enqueue(q, &mru);
+
+    if (mru_node == NULL) {
+        ret = -1;
+        goto out;
+    }
+
+    if (arc_ghost_trim_candidate(q, &lru) != mru_node) {
+        ret = 4;
+        goto out;
+    }
+
+    /* 5: pinned away from LRU leaves the LRU the candidate */
+    if (arc_ghost_trim_candidate(q, &mru) != lru_node) {
+        ret = 5;
+        goto out;
+    }
+
+out:
+
+    while (dequeue(q) != NULL) {
+        /* nodes only; the entries are on this frame */
+    }
+
+    free(q);
+    return ret;
+}
+
+/*!
+ * @brief Re-keying onto a name a stale entry still holds retires the holder
+ *
+ * dir_modify(DCMOD_PATH) re-inserts under the destination key; a stale cache
+ * entry for that key must be expunged, or the key would name two entries.
+ *
+ * @returns 0, else the number of the step that disagreed
+ */
+int test008_reindex_over_stale_key_expunges(struct vol *vol)
+{
+    struct dir *root;
+    struct dir *stale = NULL;
+    struct dir *renamed = NULL;
+    struct stat st;
+    int ret = -1;
+
+    if ((root = dirlookup(vol, DIRDID_ROOT)) == NULL) {
+        return -1;
+    }
+
+    if (stat(vol->v_path, &st) != 0) {
+        return -1;
+    }
+
+    /* The stale holder of the destination key */
+    stale = plant_root_entry(vol, "t008_dst", htonl(30008), &st);
+
+    if (stale == NULL) {
+        return 1;
+    }
+
+    /* The entry being renamed onto that key */
+    renamed = plant_root_entry(vol, "t008_src", htonl(30018), &st);
+
+    if (renamed == NULL) {
+        ret = 2;
+        goto out;
+    }
+
+    if (dir_modify(vol, renamed, &(struct dir_modify_args) {
+    .flags = DCMOD_PATH,
+    .new_mname = "t008_dst",
+    .new_uname = "t008_dst",
+    .new_pdir_path = root->d_fullpath,
+}) != 0) {
+        ret = 3;
+        goto out;
+    }
+
+    /* The stale holder was retired, awaiting the deferred free */
+    if (stale->d_did != CNID_INVALID) {
+        ret = 4;
+        goto out;
+    }
+
+    /* The renamed entry owns the key */
+    if (renamed->d_did != htonl(30018)) {
+        ret = 5;
+        goto out;
+    }
+
+    ret = 0;
+out:
+
+    if (ret != 0) {
+        fprintf(stderr,
+                "test008: failed at step %d (stale=%p did:%u, renamed=%p did:%u)\n",
+                ret, (void *)stale, stale ? ntohl(stale->d_did) : 0u,
+                (void *)renamed, renamed ? ntohl(renamed->d_did) : 0u);
+    }
+
+    if (renamed != NULL && renamed->d_did != CNID_INVALID) {
+        dir_remove(vol, renamed, 0);
+    }
+
+    if (stale != NULL && stale->d_did != CNID_INVALID) {
+        dir_remove(vol, stale, 0);
+    }
+
+    dir_free_invalid_q();
+    return ret;
+}
+
+/*!
+ * @brief curdir survives its entry being expunged by a file
+ *
+ * A file colliding on the (vid, did) key retires the cached directory — a
+ * mid-session CNID reset can hand a file a directory's stale did. A file
+ * cannot stand in as curdir, so curdir must land on the volume root, never
+ * NULL.
+ *
+ * @returns 0, else the number of the step that disagreed
+ */
+int test009_file_add_over_curdir_did(struct vol *vol)
+{
+    struct dir *dir = NULL;
+    struct dir *file = NULL;
+    struct dir *saved_curdir = curdir;
+    const cnid_t did = htonl(30009);
+    struct stat st;
+    int ret = -1;
+
+    if (stat(vol->v_path, &st) != 0) {
+        return -1;
+    }
+
+    dir = plant_root_entry(vol, "t009_dir", did, &st);
+
+    if (dir == NULL) {
+        return 1;
+    }
+
+    curdir = dir;
+    /* Same did, different name: collides only on the (vid, did) key */
+    file = dir_new("t009_file", "t009_file", vol, DIRDID_ROOT, did,
+                   bfromcstr(vol->v_path), &st);
+
+    if (file == NULL) {
+        ret = 2;
+        goto out;
+    }
+
+    file->d_flags |= DIRF_ISFILE;
+
+    if (dircache_add(vol, file) != 0) {
+        ret = 3;
+        goto out;
+    }
+
+    /* The directory was retired... */
+    if (dir->d_did != CNID_INVALID) {
+        ret = 4;
+        goto out;
+    }
+
+    /* ...and curdir fell back to the volume root, not NULL or the file */
+    if (curdir != vol->v_root) {
+        ret = 5;
+        goto out;
+    }
+
+    ret = 0;
+out:
+
+    if (ret != 0) {
+        fprintf(stderr,
+                "test009: failed at step %d (dir=%p did:%u, file=%p, curdir=%p)\n",
+                ret, (void *)dir, dir ? ntohl(dir->d_did) : 0u,
+                (void *)file, (void *)curdir);
+    }
+
+    curdir = saved_curdir;
+
+    if (file != NULL && file->d_did != CNID_INVALID) {
+        dir_remove(vol, file, 0);
+    }
+
+    if (dir != NULL && dir->d_did != CNID_INVALID) {
+        dir_remove(vol, dir, 0);
+    }
+
+    dir_free_invalid_q();
+    return ret;
+}
+
+/*!
+ * @brief A full dircache keeps accepting inserts
+ *
+ * A cached entry and its ghost both occupy a hash slot, so once the working
+ * set exceeds the cache size the hash sits at its 2c capacity; every add past
+ * that point must release a slot before it inserts, or hash_insert()'s
+ * capacity assert aborts. Ghosts appear only where an eviction demotes a
+ * frequently-used entry, so each add is promoted at once: the entry moves to
+ * T2 and its eventual eviction lands in B2, filling the cache to 2c. The
+ * margin beyond that drives inserts against a cache pinned at capacity.
+ *
+ * Promoted rather than looked up: the planted names do not exist on disk, so
+ * a lookup that validated would stat through the parent and expunge.
+ *
+ * @param[in] vol         volume the entries are planted on
+ * @param[in] cache_size  the size dircache_init() was called with
+ *
+ * @returns 0, else the number of the step that disagreed
+ */
+int test010_full_cache_accepts_adds(struct vol *vol,
+                                    unsigned int cache_size)
+{
+    const uint32_t base = 40000;
+    const uint32_t count = cache_size * 2 + DIRCACHE_FREE_QUANTUM;
+    char uname[24];
+    struct stat st;
+    uint32_t at = 0;
+    int ret = 0;
+
+    if (stat(vol->v_path, &st) != 0) {
+        return -1;
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
+        const cnid_t did = htonl(base + i);
+        struct dir *entry;
+        at = i;
+        snprintf(uname, sizeof(uname), "t010_%06u", i);
+
+        if ((entry = plant_root_entry(vol, uname, did, &st)) == NULL) {
+            ret = 1;
+            break;
+        }
+
+        /* Published under its CNID: a plain index probe, no validation */
+        if (dircache_lookup_parent(vol, did) != entry) {
+            ret = 2;
+            break;
+        }
+
+        dircache_promote(entry);
+    }
+
+    if (ret != 0) {
+        fprintf(stderr,
+                "test010: failed at step %d on add %u of %u (cache_size=%u)\n",
+                ret, at, count, cache_size);
+    }
+
+    /* The flood evicted everything else; leave later tests a cold cache
+     * rather than one full of t010 entries. The volume root is never cached,
+     * so parking curdir there keeps it clear of the purge. */
+    curdir = vol->v_root;
+    dircache_purge_vol(vol);
+    dir_free_invalid_q();
     return ret;
 }

--- a/test/afpd/subtests.h
+++ b/test/afpd/subtests.h
@@ -44,4 +44,10 @@ extern int test003_dir_add_error_no_double_free(struct vol *vol);
 extern int test004_getmetadata_nostat_keeps_cache(struct vol *vol);
 extern int test005_getmetadata_open_fork_outlives_path(struct vol *vol);
 extern int test006_rflen_rfork_without_metadata(struct vol *vol);
+extern int test007_add_over_existing_key_leaves_one(struct vol *vol);
+extern int test008_reindex_over_stale_key_expunges(struct vol *vol);
+extern int test009_file_add_over_curdir_did(struct vol *vol);
+extern int test010_full_cache_accepts_adds(struct vol *vol,
+        unsigned int cache_size);
+extern int dircache_test_ghost_trim_selection(void);
 #endif  /* SUBTESTS_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -556,13 +556,27 @@ int main(int argc, char *argv[])
              "initialize server config state");
     TEST(cnid_init(), "initialize CNID subsystem");
     TEST(load_afp_conf_vols(&obj, LV_ALL), "load all volumes from config");
-    TEST_int(dircache_init(8192), 0, "initialize dircache (8192 entries)");
     obj.afp_version = 34;
     /* No IPC channel or dircache hint pipe in test harness */
     obj.ipc_fd = -1;
     obj.hint_fd = -1;
-    /* Set global AFPobj — normally done by afp_over_dsi() which tests bypass */
+    /* Set global AFPobj — normally done by afp_over_dsi() which tests bypass.
+     * Before dircache_init() so the cache runs in the configured (default:
+     * ARC) mode, as in production. */
     AFPobj = &obj;
+    /* Both cache modes ship, so the suite runs once under each; the LRU leg
+     * is the only cover for index_queue and dircache_evict() */
+    const char *dcmode = getenv("AFPDTEST_DIRCACHE_MODE");
+
+    if (dcmode != NULL && strcmp(dcmode, "lru") == 0) {
+        obj.options.dircache_mode = 0;
+    }
+
+    TEST_int(dircache_init(8192), 0, "initialize dircache (8192 entries)");
+    test_section(obj.options.dircache_mode ? "dircache mode: ARC"
+                 : "dircache mode: LRU", "");
+    TEST_int(dircache_test_ghost_trim_selection(), 0,
+             "ARC ghost trim never releases the ghost being promoted");
 
     if (!test_output_tap) {
         fprintf(test_stream(), "\n");
@@ -665,6 +679,14 @@ int main(int argc, char *argv[])
     TEST_int_or_skip(volsys ? test006_rflen_rfork_without_metadata(volsys)
                      : TEST_SKIP, 0,
                      "getmetadata: rfork without metadata EA reports real RFLEN");
+    TEST_int(test007_add_over_existing_key_leaves_one(vol), 0,
+             "dircache: adding over an existing key leaves exactly one entry");
+    TEST_int(test008_reindex_over_stale_key_expunges(vol), 0,
+             "dircache: re-keying onto a held name retires the stale holder");
+    TEST_int(test009_file_add_over_curdir_did(vol), 0,
+             "dircache: a file expunging curdir hands curdir to the volume root");
+    TEST_int(test010_full_cache_accepts_adds(vol, 8192), 0,
+             "dircache: a full cache keeps accepting inserts");
     /* pfd cache: strict ostat equivalence (quiescent), and the
      * divergence window — probe bound + three-way sync-check no-thrash */
     TEST_int(test_pfd_ostat_equivalence(vol), 0,


### PR DESCRIPTION
The dircache indexes every entry twice — on `(vid, did)` and on `(vid, pdid, uname)` — plus an LRU/ARC queue. Every removal used to find its nodes *by key* and free whatever the lookup returned. That is safe only while each key has one holder, and nothing enforced it: the assert that rejects a second node under an existing key had been compiled out of every build since the table was imported in 2005.

This PR makes removal work from nodes the entry stores itself, then closes each path that could mint a duplicate in the first place, and re-arms the asserts that police the whole thing. Arming them immediately caught a further defect, unrelated to duplicates, in ARC's insert ordering.

## When it actually fired

One spectest case, ever: `Dircache:test506`, *"stat subdir in poisoned path"*, from the suite written to attack this cache. It is the only case that vacates a `(vid, pdid, uname)` key in one session and re-occupies it with a different CNID from another:

1. Session A creates `t506 dir` / `t506 subdir1` / `t506 subdir2`, nested, so all three land in A's cache.
2. Session B, a second afpd child on the same volume, moves and renames `subdir1` away.
3. Session B re-creates a *new* directory under the old name `subdir1`, same parent. That is the poison — a different CNID now holds a key A still maps to the old one.
4. Session A resolves `subdir2` via `FPGetFileDirParams`, walking its cached path through the stale `subdir1`.

Both key dimensions collide at once, and `curdir` sits on the entry being retired, which is what turns the expunge into a re-publish. The panic named the child of that poisoned parent: `did:19 pdid:18 name:"t506 subdir2"`.

**Why only one test, and only one CI round in three to five.** Three samples have to line up, none under the test's control:

- Validation is sampled. At the jobs' `AFP_DIRCACHE_VALIDATION_FREQ=100`, one lookup in a hundred stat-validates, so whether the stale entry is noticed at all — and the expunge runs — depends on where the test lands in that cycle.
- Which of the two entries dies is a bucket-order accident: `hash_lookup()` returns whichever sits first in the chain.
- The orphan has to be touched again. The panicking entry was a B1 ghost (`flags:0xc0`, `arc_list:3`), so it had to age out of T1/T2 first, which depends on pressure from every earlier test at `AFP_DIRCACHESIZE=1024`.

Miss one and the round is green — which is why 16 consecutive local runs stayed clean while CI failed about one round in three.

**The duplicates were not rare.** A trap at the point of duplicate *birth* fired in ~23 legs of a single run. Only the combination above turned one into a crash, which is why this read as a flaky test rather than a systemic key collision.

## Root cause

The crash was an entry absent from both tables whose own history showed no removal had run against it. From the instrumented build used to trace it (this wording is from the hunt; the fix rewrote that reporting):

```
dircache_remove: not in didname index: did:19 pdid:18 name:"t506 subdir2"
flags:0xc0 arc_list:3 qidx:null linked(dircache):no linked(didname):no
```

With two key-equal entries, removing B frees A's node: A stays reachable with its node gone, B stays linked while its caller frees it.

The duplicates were born in the code meant to prevent them. `dircache_add()` expunged a key-holder with `dir_remove()`, whose curdir recovery re-enters the cache:

```
dircache_add(X) for did:19
 └─ expunge finds duplicate D (did:19), which is curdir
     └─ dir_remove(D) → removes D, curdir = NULL
         └─ recovery: dirlookup(19) → miss → dircache_add(D')   ← re-publishes did:19
 └─ ...inserts X for did:19  →  two live entries, one key
```

It compounds, because a single-probe expunge removes at most one holder per index: three entries for `did:19` were observed, serials 384/385/386.

**The hash itself was never at fault.** Both tables pair their hash function with a real comparator, and every survivor's stored hash matched a freshly computed one. The entries were genuinely key-equal, not misrouted.

## How the cache got here (6 commits, ~21 years)

- **`e8bbed26` — didg, 2005.** kazlib imported with `#define NDEBUG` baked into `hash.c`, killing all 25 asserts — including `hash_insert()`'s uniqueness check — in every build type from day one.
- **`6ee7ecd6` — franklahm, 2010.** The dircache rewrite: two keyed indexes, an LRU queue, and removal by `hash_lookup()` from birth. Sound while every key has one holder, which nothing enforced.
- **`1a8fee3f` — franklahm, 2010.** "Pay attention to curdir on cache eviction" — first of many scattered curdir special-cases in removal paths.
- **`4e1a09e4` — andylemin, 2025.** Validation hardening gives `dir_remove()` its `dirlookup()` → parent → volume-root curdir recovery. Valuable on its own, but it makes `dir_remove()` re-entrant into the cache.
- **`d6d88ea8` — andylemin, 2026.** ARC mode: ghosts are full `struct dir`s, so ghost trims become extra removal paths, and MRU ordering cannot protect a sole node (both MRU and LRU).
- **`a2fa3170` — andylemin, 2026.** `dir_modify()`'s re-key removes the entry's own old didname key and inserts the new one, without checking whether a stale entry holds the destination. The second duplicate factory, on the rename path.

## Coverage matrix

✓ handled · ~ detected, but by aborting the session · ✗ silent · ✗-strand actively breaks other state.

| hazard | old code (asserts dead) | old code, asserts armed | new code |
|---|---|---|---|
| duplicate born by `dircache_add()` expunge recovery | ✗ silent | ~ abort at the re-insert | ✓ expunge retires without recovery |
| duplicate born by `dir_modify()` re-key onto a held name | ✗ silent | ~ abort in `hash_insert()` | ✓ stale holder retired first |
| key-equal duplicate present at removal | ✗-strand (wrong node freed) | ✗-strand (uniqueness gone by then) | ✓ removal is by stored node |
| stored node naming another entry | ✗ frees what a table points at | ✗ same | ✓ unreachable by construction; fatal if it ever occurs |
| insert while the cache sits at capacity | ✗ silent overfill past `maxcount` | ~ abort in `hash_insert()` | ✓ room made before the inserts |
| `curdir` taken by an expunge, new entry is a file | ✗ `curdir == NULL`, later deref crashes | ✗ same | ✓ volume root, or rootParent before it exists |
| abandoned re-key after an on-disk rename | ✗ stale identity stays cached | ✗ same | ✓ entry removed outright |
| entries of a closed volume | ✗ met as live on vid reuse | ✗ same | ✓ purged at `closevol()`, nothing exempt |
| sole ghost trimmed mid-promotion | ✗ freed under the promotion | ✗ same | ✓ pinned, selection skips it |
| `fullpath` on the `dirlookup()` error path | ✗ latent double free (unreachable while adds cannot fail) | ✗ same | ✓ ownership released at `dir_new()` |
| O(table) `hash_verify()` per mutation | (dead) | ✗ every cache op O(cache) in `plain`/`debugoptimized` | ✓ confined to `debug` |

## Index layout

| structure | key | entry's back-pointer |
|---|---|---|
| `dircache` hash | `(d_vid, d_did)` | `d_index_node` *(new)* |
| `index_didname` hash | `(d_vid, d_pdid, d_u_name)` | `d_didname_node` *(new)* |
| LRU queue / ARC T1·T2·B1·B2 | — (position) | `qidx_node` *(existing)* |

Both hashes use the `struct dir` as key and store the computed `hkey` on the node, and the comparator reads the entry's current fields. Removal-by-key therefore had two ways to go wrong that back-pointers cannot: a key-equal duplicate resolves to the wrong node, and a key mutated after insert resolves to nothing. `hash_delete()` navigates by the stored `hkey` and never rehashes, and kazlib nodes never move — grow and shrink reallocate only the chain-head array — so a stored node pointer stays valid for the entry's whole indexed life.

## Defects

1. **Wrong-node unlink.** With two key-equal entries, removal frees the node the key resolves to, not the entry's own.
2. **The expunge was a duplicate factory.** `dircache_add()` → `dir_remove()` → curdir recovery → `dircache_add()` re-published the key being cleared.
3. **The re-key was a second factory.** `dircache_reindex_didname()` inserted the destination key blind; a stale holder made two nodes under one key, or an abort once the uniqueness assert is armed.
4. **Partial removal.** The queue side was drained before the hash lookups could fail, so a miss left the entry half-unlinked with `queue_count != hash_nodecount` — the state the count asserts panic on.
5. **curdir holes.** The post-expunge re-point skipped files, leaving `curdir == NULL` with dozens of unguarded dereferences downstream.
6. **No volume teardown.** `closevol()` left the closing volume's entries cached, and the persistent vid met them as live on reopen.

Arming the asserts exposed a seventh, independent of all that: **ARC inserted into a full cache.** A ghost holds a hash slot just as a cached entry does, so the table sits at its declared 2c capacity once the working set exceeds the cache size. Case IV made room *after* `dircache_add()` had inserted, so `hash_insert()` got a full table and its capacity assert killed the session child. No corruption or race needed — just a volume walked wider than twice the cache — in every build that does not define `NDEBUG`, `plain` included.

## Fix

The invariant: **an entry's index membership is recorded on the entry, and removal consumes that record.** A missing stored node means "not in that index, skip the leg". Nothing else is survivable, because freeing memory a table still points at is the one unrecoverable move.

- **`hash_alloc_insert_node()`** (`hash.c`) — `hash_alloc_insert()` that returns the inserted node; the old entry point wraps it.
- **`d_index_node` / `d_didname_node`** (`directory.h`) — the stored nodes, set on insert and cleared on removal.
- **`dircache_remove()`** — deletes by stored node, skipping indexes the entry is not in. `dir_free()`'s refuse-to-free guard now checks both stored nodes too.
- **`dircache_expunge_duplicate()`** — retires a key-holder with a plain full-index removal, no `dirlookup()` recovery, handing curdir back for the caller to re-point at the replacement entry or the volume root. `dircache_reindex_didname()` now calls it for a stale destination holder.
- **`arc_case_iv_make_room()` / `arc_case_iv_insert()`** — Case IV splits, so `dircache_add()` evicts before its inserts and queues after. LRU mode always did this; ARC was the outlier.
- **`dircache_purge_vol()`** — from `closevol()`, removes each of the volume's entries as the scan reaches it, deferred free. Nothing is exempt: `v_root` is freed next, so a kept-back entry would outlive its volume under a reusable vid. A per-vid count kept at the insert and delete funnels answers the common case, nothing cached, with one array read instead of a table scan.
- **`dircache_remove_children()`** — same remove-as-you-scan shape, dropping a capacity-doubling array, its OOM path and a second loop. It cannot use `dir_remove()`, whose curdir recovery would insert mid-scan; it re-resolves a removed curdir once the scan is over, a rename having kept the CNID that resolves it.
- **`dircache_flush_deferred_for_vol()`** — scans with `hash_scan_next()` rather than walking chain heads, so all three table walks share one shape. The two resumable per-chain scans keep chain-level access, which is their point.
- **One pin on a promoting ghost, not two** — `arc_case_ii/iii` also pushed the ghost to MRU before `arc_replace()`. The skip pointer works from any position, so that splice was dead work that made the tested mechanism look optional.
- **`arc_ghost_trim_candidate(q, skip)`** — trim selection takes the pinned entry as an argument and steps over it; a sole pinned node yields no candidate.
- **`queue_remove(node)`** (`libatalk/util/queue.c`) — unlinks a node from whichever queue holds it, replacing `dequeue(node->prev)`, which worked only by exploiting the sentinel layout.
- **`HASH_ASSERT_VERIFY`** (`hash.c`) — `#define NDEBUG` removed here and in `bin/nad/ftw.c`. The cheap O(chain) asserts go to `b_ndebug`, live in `debug`/`debugoptimized`/`plain`; the O(table) `hash_verify()` walks are confined to `debug`, so no CI or distro build pays O(cache) per operation.

### Detected corruption is fatal

`dircache_remove()` reports a stored node that does not name its entry — the entry's identity and flags, which index disagreed, what that node carries — dumps the cache and panics. It does not try to continue. That matches how the cache already treats a broken invariant (`dir_free()` on an indexed entry, `hash_insert()`'s uniqueness assert, the ARC migration failures), and it is honest about reachability: every node is created with its entry as its data and freed only through that entry's own removal, so once keyed deletion is gone, nothing can produce a mismatched node. A tripwire is the right shape for that; recovery code behind it would be untestable by construction.

Declining the removal instead — leaving the entry published — was tried and is worse. A declined entry can never be retired, so it is served stale for the rest of the session, `dir_remove()` reports success without unpublishing, `dir_modify()` strands an entry in no index and on no queue, and the ARC requeue paths break their own size invariants. Five near-identical requeue blocks went with it.

### Riding along

Found while instrumenting the hunt:

- Worker threads blocked every signal, including the synchronous fault signals. The kernel cannot queue those to a thread that blocks them and forces the default action, so a fault in the idle worker died silently. The two handled fault signals stay deliverable, each thread installs an alternate stack so stack exhaustion is reportable, `fault.c` unwinds with libunwind where available, and the handler's re-entry counter is atomic now two threads can reach it.
- libunwind's include directories reach the target that actually compiles `fault.c`. Only the shared library carried the dependency, so any platform whose `libunwind.h` sits outside the default include path failed to build.
- A session whose reconnect handoff failed carried on after being told to die. It now terminates, running `afp_dsi_close()` and keeping `afp_dsi_die()`'s exit mapping — the failed handoff leaves this child owning the client socket, so volume close, CNID close and logout still have to run.
- The `Icon\r` cleanup queues the entry it removes for deallocation instead of unlinking it from every index and leaking it.

### Defect → fix

| # | Defect | Closed by |
|---|---|---|
| 1 | wrong-node unlink | stored nodes: removal cannot resolve to a bystander |
| 2 | expunge re-published the key | `dircache_expunge_duplicate()`, no recovery re-entry |
| 3 | re-key published a second node | `dircache_reindex_didname()` retires the stale holder first |
| 4 | partial removal, skewed counts | no lookup left to fail mid-way; a mismatched node is fatal, not partial |
| 5 | curdir NULL | curdir lands on the replacement, the volume root, or rootParent |
| 6 | entries outliving their volume | `dircache_purge_vol()` in `closevol()` |
| 7 | insert into a full cache | Case IV's eviction half runs before the inserts |

## Behaviour changes

- `struct dir` grows two pointers (16 bytes per entry) so removal is by node.
- `dircache_remove()` stays `void`; a stored node naming another entry is fatal rather than silently freeing what a table points at.
- `dircache_add()` keeps its contract: returns 0, or the process exits on a hash insert failure.
- Asserts live in `debug`/`debugoptimized`/`plain`, compiled out in `release`; `hash_verify()` only in `debug`.
- The three performance-dashboard jobs build **release**, so their numbers and the flamegraph measure shipped code rather than assertions. The flamegraph keeps `-g`, which `release` omits and perf needs. The perf image builds only on the events whose jobs consume it.
- Comments call the 2c index the dircache. "Directory" is the ARC paper's word for it and reads here as a filesystem directory.

## Testing

Unit tests, each proven RED against the defect it closes:

- `test007` — adds over both keys with `curdir` on the entry being retired. RED with `dir_remove()` restored in the expunge.
- `test008` — renames onto a key a stale entry holds. RED without the reindex expunge: `SIGABRT` on the uniqueness assert.
- `test009` — a file takes over curdir's `(vid, did)` key. RED with the old file-gated re-point: returns `curdir == NULL`.
- `test010` — saturates the cache to 2c and keeps inserting. RED with the eviction half after the inserts: `Assertion failed: hash->nodecount < hash->maxcount`, `SIGABRT`. It promotes rather than looks up, because the planted names do not exist on disk and a validating lookup would stat through the parent and expunge.
- `dircache_test_ghost_trim_selection` — five selection cases including the sole-pinned-ghost regression.

The suite runs twice, since both cache modes ship: **105 subtests per leg, 0 failures, in ARC and in LRU.** The harness initialises the dircache after `AFPobj` is published so it honours the configured mode, and a second meson leg forces LRU with `AFPDTEST_DIRCACHE_MODE=lru` — `index_queue` and `dircache_evict()` are reachable in that mode only. Before this, every unit test silently ran LRU and the shipped default was never exercised.

Suites and measurements:

- Full spectest on the final tree: **292 passed, 0 failed** — ARC, `AFP_DIRCACHE_VALIDATION_FREQ=100`, sqlite CNID, the configuration the original failure lived in. `Dircache:test500`–`test509` all pass, with no panic, assert or fault in the run.
- Assert cost measured, not assumed: spectest 65s → 64s with all 25 kazlib asserts live. Stripping verified in the binary: 2 assert strings in the debug image, 0 in release.
- `closevol` leak, measured on the purge as first written: 89 of 115 volume closes left entries behind → 0 of 115.
- The original failure reproduced about one CI round in three. Two 10-round reroll campaigns ran all green on the key-uniqueness work (20 consecutive rounds); everything layered on top is covered by the RED/GREEN unit tests, the spectest above, and the CI matrix.

## Not in this PR

Three candidates were weighed and left out, each costing more than it returns:

- **`arc_promoting_ghost` stays.** Removing the pin needs one of two trades. Detaching the ghost's node before `arc_replace()` means re-enqueueing into T2 after — a `malloc`/`free` per ghost hit where the node move is currently allocation-free, plus a new enqueue-failure panic. Moving it into T2 *before* `arc_replace()` lets `arc_find_victim()` pick it, since that takes the LRU and at `t2_size == 1` the LRU is the entry about to be returned as a hit; suppressing that needs a skip inside `arc_find_victim`, which is the same pin relocated. The explicit pin is now the only mechanism, and the unit test drives it.
- **`vid_entry_count[]` stays.** It is BSS, so demand-zero: a child dirties about a page per vid in use, not 256 KiB. Moving the counter to `struct vol` needs `getvolbyvid()` inside `dircache_remove()`, because five call sites pass `vol == NULL` — three ghost trims, the Case IV victim, `dircache_evict()` — adding a volume-list walk to the eviction path to reclaim pages nothing touches.
- **The `containers.yml` matrix fold stays.** The two testsuite-image jobs differ only by suffix and `BUILDTYPE`, but folding them is CI refactoring unrelated to cache correctness, validated only by pushing it, and a mistake there breaks the CI that validates this PR.

---

The crash class lived in the red edge — resolving an entry by key at removal time — which the stored back-pointers replace.

```mermaid
%%{init: {'flowchart': {'curve': 'basis'}, 'themeVariables': {'edgeLabelBackground': '#e5e7eb'}}}%%
flowchart TD
    classDef wire   fill:#1e3a8a,stroke:#1e40af,color:#eff6ff,stroke-width:1px;
    classDef api    fill:#5b21b6,stroke:#6d28d9,color:#f5f3ff,stroke-width:1px;
    classDef struct fill:#0f766e,stroke:#0d9488,color:#f0fdfa,stroke-width:1px;
    classDef index  fill:#b45309,stroke:#d97706,color:#fffbeb,stroke-width:1px;
    classDef global fill:#9f1239,stroke:#be123c,color:#fff1f2,stroke-width:1px;

    subgraph WIRE["🌐 AFP ops that touch the cache"]
        OPS("FPEnumerate · FPCreateDir/File · FPMoveAndRename<br/>FPDelete · FPCloseVol · every dirlookup")
    end

    subgraph API["🟣 dircache API — etc/afpd/dircache.c"]
        ADD("dircache_add()<br/>expunge both keys → make room → insert both → queue")
        REM("dircache_remove()<br/>delete by stored node, skip absent indexes<br/><i>node naming another entry = panic</i>")
        REK("dircache_reindex_didname()<br/>retire stale holder → re-insert")
        PUR("dircache_purge_vol()<br/>removes each entry as the scan reaches it")
        SRCH("dircache_search_by_did / _by_name<br/>keyed lookups (unchanged — reads only)")
    end

    subgraph ENTRY["🟢 struct dir — one per cached object"]
        DIR("d_vid · d_did · d_pdid · d_u_name<br/>d_flags (DIRF_INDEXED · DIRF_ISFILE · DIRF_ARC_GHOST)")
        NODES("back-pointers, written at insert:<br/>d_index_node · d_didname_node · qidx_node")
    end

    subgraph INDEXES["🟠 the three structures an entry lives in"]
        DC("dircache hash<br/>key (vid, did) · hkey stored on node")
        DN("index_didname hash<br/>key (vid, pdid, uname)")
        Q("LRU queue / ARC T1·T2·B1·B2<br/>ghosts are full entries")
        DEFER("invalid_dircache_entries<br/>deferred free — pointers handed out<br/>this request stay readable")
    end

    CURDIR("curdir — per-session global<br/>never NULL: replacement entry,<br/>volume root, else rootParent")

    OPS --> ADD & REM & REK & SRCH
    OPS -->|"FPCloseVol / logout"| PUR
    ADD -->|"insert returns the node"| NODES
    REK -->|"insert returns the node"| NODES
    DIR --- NODES
    NODES ==>|"delete by stored node — O(1), identity-exact"| DC
    NODES ==>|"delete by stored node"| DN
    NODES ==>|"unlink by stored node"| Q
    REM -->|"consumes"| NODES
    REM -->|"on success"| DEFER
    PUR --> REM
    SRCH -.->|"read-only keyed lookup"| DC
    SRCH -.->|"read-only keyed lookup"| DN
    ADD & REM -.->|"handoff, never NULL"| CURDIR

    REMOLD("old model: hash_lookup(key) at removal<br/>→ frees whichever node the key resolves to")
    REMOLD -. "⚠ key-equal duplicate ⇒ unlinks the WRONG entry — removed by this PR" .-> DC

    class OPS wire;
    class ADD,REM,REK,PUR,SRCH api;
    class DIR,NODES struct;
    class DC,DN,Q,DEFER index;
    class CURDIR,REMOLD global;

    style WIRE   fill:#f1f5f9,stroke:#cbd5e1,color:#334155;
    style API    fill:#f8fafc,stroke:#cbd5e1,color:#334155;
    style ENTRY  fill:#eef2f6,stroke:#d1d9e0,color:#334155;
    style INDEXES fill:#eef2f6,stroke:#d1d9e0,color:#334155;

    linkStyle 18 stroke:#dc2626,stroke-width:2px;
```
