### PR TITLE
ci: hardening of workflow and job level permissions

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -222,7 +222,6 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Lower ASLR entropy for TSAN shadow-memory compatibility
         run: sudo sysctl vm.mmap_rnd_bits=28
@@ -322,7 +321,6 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: write
-      checks: write
     outputs:
       self_time: ${{ steps.flamegraph-summary.outputs.SELF_TIME }}
       self_time_warning: ${{ steps.flamegraph-summary.outputs.SELF_TIME_WARNING }}
@@ -452,7 +450,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Create Docker network
         run: |
@@ -521,7 +518,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Create container network
         run: |
@@ -603,7 +599,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Create Docker network
         run: |
@@ -670,7 +665,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Create container network
         run: |
@@ -730,7 +724,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -774,7 +767,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -840,7 +832,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -883,7 +874,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -926,7 +916,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -968,7 +957,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1014,7 +1002,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1058,7 +1045,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1101,7 +1087,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1144,7 +1129,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1186,7 +1170,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1228,7 +1211,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1270,7 +1252,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1313,7 +1294,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1356,7 +1336,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1399,7 +1378,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1442,7 +1420,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1484,7 +1461,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1526,7 +1502,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1568,7 +1543,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1612,7 +1586,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1656,7 +1629,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1694,7 +1666,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1732,7 +1703,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -1770,7 +1740,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite
         run: |
@@ -2469,7 +2438,6 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Run Netatalk testsuite with ARC stress test
         run: |

--- a/.github/workflows/spectest-macos.yml
+++ b/.github/workflows/spectest-macos.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 env:
   AFP_USER: atalk1

--- a/.github/workflows/spectest-vms.yml
+++ b/.github/workflows/spectest-vms.yml
@@ -21,6 +21,9 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+
 env:
   CMARK_TARBALL_URL: https://github.com/commonmark/cmark/archive/refs/tags/0.31.2.tar.gz
   INIPARSER_TARBALL_URL: https://gitlab.com/iniparser/iniparser/-/archive/v4.2.6/iniparser-v4.2.6.tar.gz
@@ -35,7 +38,6 @@ jobs:
     timeout-minutes: 24
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -128,7 +130,6 @@ jobs:
     timeout-minutes: 24
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -218,7 +219,6 @@ jobs:
     timeout-minutes: 24
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -316,7 +316,6 @@ jobs:
     timeout-minutes: 24
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -409,7 +408,6 @@ jobs:
     timeout-minutes: 24
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -499,7 +497,6 @@ jobs:
     timeout-minutes: 24
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -603,7 +600,6 @@ jobs:
     timeout-minutes: 24
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -701,7 +697,6 @@ jobs:
     timeout-minutes: 24
     permissions:
       contents: read
-      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
two changes to address weaknesses in the GitHub workflow permissions configuration: set a workflow level default permission in the VM spectest workflow, and remove checks write permissions from all jobs and workflows