### PR TITLE
distrib: remove default base image from perftest container

### DIFF
--- a/distrib/docker/perftest/perftest.Dockerfile
+++ b/distrib/docker/perftest/perftest.Dockerfile
@@ -6,7 +6,7 @@
 #   docker build -f distrib/docker/perftest/perftest.Dockerfile \
 #       --build-arg BASE_IMAGE=netatalk-testsuite -t netatalk-perftest .
 
-ARG BASE_IMAGE=netatalk-testsuite
+ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
having an unpinned default base image may have unexpected side effects, so removing the default and making the BASE_IMAGE env variable mandatory

this expectation is already documented and captured in the shell script harness