### PR TITLE
spotlight: avoid lossy string length conversion

### DIFF
--- a/etc/afpd/spotlight_marshalling.c
+++ b/etc/afpd/spotlight_marshalling.c
@@ -438,7 +438,7 @@ static int sl_pack_string(char *s, char *buf, int offset, char *toc_buf,
     }
 
     octets = (int)((len / 8) + (len & 7 ? 1 : 0));
-    used_in_last_octet = 8 - (octets * 8 - len);
+    used_in_last_octet = len % 8 ? (int)(len % 8) : 8;
     EC_ZERO(slvalc(toc_buf, *toc_idx * 8, MAX_SLQ_TOC,
                    sl_pack_tag(SQ_CPX_TYPE_STRING, (offset + SL_OFFSET_DELTA) / 8,
                                used_in_last_octet)));


### PR DESCRIPTION
sl_pack_string() calculated the byte count used in the final octet by subtracting size_t len from an int expression. Although the resulting count is only one to eight, the mixed-width calculation triggers a narrowing-conversion warning and octets * 8 can overflow before the buffer-size check for very large strings.

Derive the value directly from len % 8 and cast only the proven bounded remainder.