### PR TITLE
testsuite: document FPEnumerate reply buffer and remove stale FIXMEs

### DIFF
--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -822,7 +822,6 @@ static void cname_test(char *name)
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FAIL(FPEnumerate(Conn, vol, DIRDID_ROOT, "", 0, bitmap))
 
     if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, 0, bitmap)) {
@@ -1034,7 +1033,6 @@ STATIC void test100()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, DIRDID_ROOT, name1,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -1134,7 +1132,6 @@ STATIC void test101()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, DIRDID_ROOT, name1,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -1254,8 +1251,6 @@ STATIC void test102()
     if (not_valid(ret, /* MAC */0, AFPERR_ACCESS)) {
         test_failed();
     }
-
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
 
     if (ntohl(AFPERR_ACCESS) != FPEnumerate(Conn, vol, DIRDID_ROOT, name1,
                                             (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
@@ -1389,7 +1384,6 @@ STATIC void test103()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, dir, "",
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -1555,8 +1549,6 @@ STATIC void test105()
     if (dir || err != dsi->header.dsi_code) {
         test_failed();
     }
-
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
 
     if (err  != FPEnumerate(Conn, vol, dir, name1,
                             (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
@@ -1737,7 +1729,6 @@ STATIC void test170()
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (ntohl(AFPERR_NOOBJ) != FPEnumerate(Conn, vol, DIRDID_ROOT_PARENT, "",
                                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                                            (1 << FILPBIT_FINFO) |
@@ -1892,7 +1883,6 @@ STATIC void test171()
             tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, tdir, tname,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -2058,7 +2048,6 @@ STATIC void test173()
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (ntohl(AFPERR_PARAM) != FPEnumerate(Conn, vol, tdir, tname,
                                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                                            (1 << FILPBIT_FINFO) |
@@ -2258,7 +2247,6 @@ STATIC void test174()
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (ntohl(AFPERR_NODIR) != FPEnumerate(Conn, vol, tdir, tname,
                                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                                            (1 << FILPBIT_FINFO) |

--- a/test/testsuite/FPAddAPPL.c
+++ b/test/testsuite/FPAddAPPL.c
@@ -97,7 +97,6 @@ STATIC void test301()
 
         test_failed();
         ret = FPCreateFile(Conn, vol, 0, dir, file);
-        /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
         FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR),
                     (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |

--- a/test/testsuite/FPCreateDir.c
+++ b/test/testsuite/FPCreateDir.c
@@ -53,7 +53,6 @@ STATIC void test26()
         goto fin;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM),
                 (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |

--- a/test/testsuite/FPCreateFile.c
+++ b/test/testsuite/FPCreateFile.c
@@ -135,7 +135,6 @@ STATIC void test393()
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, DIRDID_ROOT, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -249,7 +249,6 @@ STATIC void test172()
             tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, tdir, tname,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -766,7 +766,6 @@ STATIC void test535()
     FAIL(FPGetFileDirParams(Conn, vol, dir, file1, bitmap, 0))
     FAIL(FPGetFileDirParams(Conn, vol, dir, file2, bitmap, 0))
     FAIL(FPGetFileDirParams(Conn, vol, dir, file3, bitmap, 0))
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FAIL(FPEnumerate(Conn, vol, dir, "", bitmap, bitmap))
 
     if (!Quiet && Verbose) {

--- a/test/testsuite/FPEnumerate.c
+++ b/test/testsuite/FPEnumerate.c
@@ -46,7 +46,6 @@ STATIC void test28()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir1, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -106,7 +105,6 @@ STATIC void test34()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM),
                 (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
@@ -154,7 +152,6 @@ STATIC void test38()
 
     memcpy(&did, dsi->data + 3 * sizeof(uint16_t), sizeof(did));
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, DIRDID_ROOT, name,
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -228,7 +225,6 @@ STATIC void test40()
 
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -293,7 +289,6 @@ STATIC void test41()
         goto fin;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -392,7 +387,6 @@ STATIC void test93()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, DIRDID_ROOT, name,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -451,7 +445,6 @@ STATIC void test218()
 
     bitmap = (1 << FILPBIT_LNAME);
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (htonl(AFPERR_NOOBJ) != FPEnumerateFull(Conn, vol, 1, 1, 800,  bdir, "",
             bitmap, bitmap)) {
         test_nottested();
@@ -584,7 +577,6 @@ STATIC void test300(void)
             goto test_exit;
         }
 
-        /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
         while (!(ret = FPEnumerateFull(Conn, vol, i, 150, 8000,  dir, "", f_bitmap,
                                        d_bitmap))) {
             /* FPResolveID will trash dsi->data */
@@ -719,7 +711,6 @@ STATIC void test533()
         fprintf(stdout, "\t  Step 2: Client 1 starts enumerate (first batch)\n");
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerateFull(Conn, vol, 1, 20, 8000, dir, "", f_bitmap, d_bitmap);
 
     if (ret) {

--- a/test/testsuite/FPEnumerateExt.c
+++ b/test/testsuite/FPEnumerateExt.c
@@ -20,7 +20,6 @@ STATIC void test23()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (Conn->afp_version < 30) {
         if (ntohl(AFPERR_NOOP) != FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)

--- a/test/testsuite/FPEnumerateExt2.c
+++ b/test/testsuite/FPEnumerateExt2.c
@@ -26,7 +26,6 @@ STATIC void test25()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate_ext2(Conn, vol, DIRDID_ROOT, "",
                      (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                      | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN),
@@ -83,7 +82,6 @@ STATIC void test211()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (Conn->afp_version < 31) {
         if (ntohl(AFPERR_NOOP) != FPEnumerate_ext2(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)

--- a/test/testsuite/FPGetSessionToken.c
+++ b/test/testsuite/FPGetSessionToken.c
@@ -40,7 +40,6 @@ STATIC void test220()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (Conn->afp_version < 30) {
         if (ntohl(AFPERR_NOOP) != FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)

--- a/test/testsuite/FPReadExt.c
+++ b/test/testsuite/FPReadExt.c
@@ -29,7 +29,6 @@ STATIC void test22()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                         (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                         | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0)) {

--- a/test/testsuite/FPRename.c
+++ b/test/testsuite/FPRename.c
@@ -337,7 +337,6 @@ STATIC void test219()
         goto fin;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     bitmap = (1 << FILPBIT_LNAME);
     FAIL(FPEnumerate(Conn, vol, DIRDID_ROOT, "", bitmap, bitmap))
     FAIL(FPEnumerate(Conn2, vol2,  DIRDID_ROOT, "", bitmap, bitmap))

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -964,7 +964,6 @@ STATIC void test358()
     FAIL(FPSetFilDirParam(Conn, vol, dir, "", bitmap, &filedir))
     FAIL(FPGetFileDirParams(Conn2, vol2, dir, "", bitmap, bitmap))
     bitmap = (1 << FILPBIT_LNAME);
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FAIL(FPEnumerateFull(Conn, vol, 1, 5, 800,  dir, "", bitmap, bitmap))
     FAIL(htonl(AFPERR_ACCESS) != FPEnumerateFull(Conn2, vol2, 1, 5, 800,  dir, "",
             bitmap, bitmap))

--- a/test/testsuite/FPWriteExt.c
+++ b/test/testsuite/FPWriteExt.c
@@ -37,7 +37,6 @@ STATIC void test148()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                         (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                         | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0)) {
@@ -154,7 +153,6 @@ STATIC void test207()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                         (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                         | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN),

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -62,7 +62,6 @@ STATIC void test146()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FAIL(FPEnumerate(Conn2, vol2,  DIRDID_ROOT, "", 0, bitmap))
     FAIL(ntohl(AFPERR_ACCESS) != FPDelete(Conn2, vol2,  dir, name))
     fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, dir, name,

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -39,7 +39,6 @@ STATIC void test32()
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -157,7 +156,6 @@ STATIC void test33()
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, DIRDID_ROOT, name,
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -275,7 +273,6 @@ STATIC void test42()
         goto fin;
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (ntohl(AFPERR_NOOBJ) != FPEnumerate(Conn, vol, dir, "",
                                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                                            (1 << FILPBIT_FINFO) |
@@ -627,7 +624,6 @@ STATIC void test182()
 
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -914,7 +910,6 @@ STATIC void test340()
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |

--- a/test/testsuite/T2_FPGetVolParms.c
+++ b/test/testsuite/T2_FPGetVolParms.c
@@ -176,7 +176,6 @@ STATIC void test532()
         fprintf(stdout, "\t  Step 6: Verify enumeration still works correctly\n");
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, DIRDID_ROOT, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM),
                     (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_DID))) {

--- a/test/testsuite/T2_FPOpenFork.c
+++ b/test/testsuite/T2_FPOpenFork.c
@@ -1633,9 +1633,7 @@ STATIC void test431()
         }
     }
 
-    /* Enumerate triggers v2→EA conversion (if 'convert appledouble = yes').
-     * NB: FPEnumerate* uses dsi_data_receive (should be normalised).
-     * See afphelper.c:delete_directory_tree() */
+    /* Enumerate triggers v2→EA conversion (if 'convert appledouble = yes'). */
     if (FPEnumerate_ext2(Conn, vol, DIRDID_ROOT, "",
                          (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN),
                          (1 << DIRPBIT_PDINFO) | (1 << DIRPBIT_OFFCNT))) {

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -619,7 +619,6 @@ STATIC void test412()
 
     FPResolveID(Conn, vol, fid, bitmap);
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir2, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -89,7 +89,6 @@ STATIC void test166()
         }
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                     (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                     | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0);
@@ -150,7 +149,6 @@ STATIC void test167()
         }
     }
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                     (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                     | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0);
@@ -201,7 +199,6 @@ STATIC void test181()
     FAIL(FPCloseVol(Conn, vol))
     vol = VolID = FPOpenVol(Conn, Vol);
 
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir1, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |

--- a/test/testsuite/afparg_FPfuncs.c
+++ b/test/testsuite/afparg_FPfuncs.c
@@ -237,8 +237,6 @@ void FPEnumerate_arg(char **argv)
             goto fin;
         }
 
-        /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
-
         while (!(ret = FPEnumerateFull(Conn, vol, i, 150, 8000,  dir, "", f_bitmap,
                                        d_bitmap))) {
             /* FPResolveID will trash dsi->data */

--- a/test/testsuite/afpcmd.c
+++ b/test/testsuite/afpcmd.c
@@ -1185,8 +1185,10 @@ unsigned int FPCloseDir(CONN *conn, uint16_t vol, int did)
 }
 
 /* -------------------------------
-* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
-*/
+ * FPEnumerate* replies are stored in conn->dsi.data; conn->dsi.cmdlen is
+ * their length. Copy a reply before issuing another command that receives
+ * into dsi.data.
+ */
 unsigned int FPEnumerate(CONN *conn,
                          uint16_t vol,
                          int did,
@@ -1248,8 +1250,10 @@ unsigned int FPEnumerate(CONN *conn,
 
 
 /* -------------------------------
-* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
-*/
+ * FPEnumerate* replies are stored in conn->dsi.data; conn->dsi.cmdlen is
+ * their length. Copy a reply before issuing another command that receives
+ * into dsi.data.
+ */
 unsigned int FPEnumerateFull(CONN *conn,
                              uint16_t vol,
                              uint16_t sindex,
@@ -1465,8 +1469,10 @@ unsigned int FPResolveID(CONN *conn, uint16_t vol, int did, uint16_t bitmap)
     return dsi->header.dsi_code;
 }
 /* -------------------------------
-* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
-*/
+ * FPEnumerate* replies are stored in conn->dsi.data; conn->dsi.cmdlen is
+ * their length. Copy a reply before issuing another command that receives
+ * into dsi.data.
+ */
 unsigned int FPEnumerate_ext(CONN *conn, uint16_t vol, int did, char *name,
                              uint16_t f_bitmap, uint16_t d_bitmap)
 {
@@ -1530,8 +1536,10 @@ unsigned int FPEnumerate_ext(CONN *conn, uint16_t vol, int did, char *name,
 }
 
 /* -------------------------------
-* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
-*/
+ * FPEnumerate* replies are stored in conn->dsi.data; conn->dsi.cmdlen is
+ * their length. Copy a reply before issuing another command that receives
+ * into dsi.data.
+ */
 unsigned int FPEnumerate_ext2(CONN *conn, uint16_t vol, int did, char *name,
                               uint16_t f_bitmap, uint16_t d_bitmap)
 {
@@ -1596,8 +1604,10 @@ unsigned int FPEnumerate_ext2(CONN *conn, uint16_t vol, int did, char *name,
 }
 
 /* -------------------------------
-* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
-*/
+ * FPEnumerate* replies are stored in conn->dsi.data; conn->dsi.cmdlen is
+ * their length. Copy a reply before issuing another command that receives
+ * into dsi.data.
+ */
 unsigned int FPEnumerateExt2Full(CONN *conn,
                                  uint16_t vol,
                                  uint32_t did,

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -309,7 +309,6 @@ int no_access_folder(uint16_t vol, int did, char *name)
         /* Mac OSX here does strange things
          * for when things go wrong */
         test_nottested();
-        /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
         FPEnumerate(Conn2, vol2,  DIRDID_ROOT, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR),
                     (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |
@@ -1096,17 +1095,8 @@ int delete_directory_tree_by_did(CONN *conn, uint16_t volume, uint32_t dir_id)
             break;
         }
 
-        /* Process batch */
-        /* WARN: FPEnumerate and FPEnumerate* use dsi_data_receive, other commands use dsi_cmd_receive.
-         dsi_data_receive stores data length in 'cmdlen', not 'datalen'?
-         dsi_cmd_receive (line 321) - receives data into DSI_CMDSIZ buffer (x->commands)
-         dsi_data_receive (line 327) - receives data into DSI_DATASIZ buffer (x->data)
-         So dsi_data_receive data is received into dsi->data buffer, not dsi->commands.
-         &conn->dsi->cmdlen = datalen
-         &conn->dsi->data + 0 = fbitmap
-         &conn->dsi->data + 2 = dbitmap
-         &conn->dsi->data + 4 = count
-         &conn->dsi->data + 6 = data */
+        /* Process the FPEnumerate reply in dsi->data. dsi->cmdlen is the
+         * received length; dsi->datalen still describes the request. */
         if (dsi_ptr->cmdlen < 6) {
             fprintf(stderr,
                     "[delete_directory_tree_by_did] Response too small (%lu bytes)\n",

--- a/test/testsuite/rotest.c
+++ b/test/testsuite/rotest.c
@@ -67,7 +67,6 @@ STATIC void test510()
     }
 
     /* get a directory */
-    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     bitmap = (1 << DIRPBIT_LNAME);
     ret = FPEnumerateFull(Conn, VolID, 1, 1, 800,  DIRDID_ROOT, "", 0, bitmap);
 


### PR DESCRIPTION
Remove stale call-site FIXMEs and replace them with the FPEnumerate reply-buffer contract. Clarify that replies are received in dsi->data, bounded by cmdlen, while datalen remains the request length.