### PR TITLE
spotlight: reject empty CNID arrays

### DIFF
--- a/etc/afpd/spotlight_marshalling.c
+++ b/etc/afpd/spotlight_marshalling.c
@@ -736,6 +736,10 @@ static int sl_unpack_CNID(DALLOC_CTX *query, const char *buf, int offset,
 
     count = query_data64 & 0xffff;
 
+    if (count == 0) {
+        EC_FAIL;
+    }
+
     if (count > (length - 2 * (int)sizeof(uint64_t)) / (int)sizeof(uint64_t)) {
         EC_FAIL;
     }

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -35,6 +35,13 @@
 #include <atalk/util.h>
 #include <atalk/volume.h>
 
+#ifdef WITH_SPOTLIGHT
+#include <talloc.h>
+
+#include <atalk/dalloc.h>
+#include <atalk/spotlight.h>
+#endif
+
 #include "afp_config.h"
 #include "afpfunc_helpers.h"
 #include "dircache.h"
@@ -64,6 +71,76 @@ static char *args[] = {"test", "-F", confpath};
 int test_output_tap = 0;
 int test_case_num = 0;
 FILE *test_report_stream = NULL;
+
+#ifdef WITH_SPOTLIGHT
+static uint64_t spotlight_test_get_le64(const char *buf, size_t offset)
+{
+    const uint8_t *p = (const uint8_t *)buf + offset;
+    return (uint64_t)p[0]
+           | ((uint64_t)p[1] << 8)
+           | ((uint64_t)p[2] << 16)
+           | ((uint64_t)p[3] << 24)
+           | ((uint64_t)p[4] << 32)
+           | ((uint64_t)p[5] << 40)
+           | ((uint64_t)p[6] << 48)
+           | ((uint64_t)p[7] << 56);
+}
+
+static int utest_spotlight_rejects_empty_long_cnids(void)
+{
+    char rpcbuf[DSI_DATASIZ - 64];
+    TALLOC_CTX *tmp = talloc_new(NULL);
+    DALLOC_CTX *packed = talloc_zero(tmp, DALLOC_CTX);
+    DALLOC_CTX *unpacked = talloc_zero(tmp, DALLOC_CTX);
+    sl_cnids_t *cnids = talloc_zero(packed, sl_cnids_t);
+    const uint16_t ca_unkn1 = 0x0fec;
+    const uint32_t ca_context = 0x5a17c0de;
+    uint64_t cnid = 0x1122334455667788;
+    uint64_t cnid_header;
+    int rpclen;
+    int result = 0;
+
+    if (tmp == NULL || packed == NULL || unpacked == NULL || cnids == NULL) {
+        goto cleanup;
+    }
+
+    cnids->ca_cnids = talloc_zero(cnids, DALLOC_CTX);
+
+    if (cnids->ca_cnids == NULL) {
+        goto cleanup;
+    }
+
+    cnids->ca_unkn1 = ca_unkn1;
+    cnids->ca_context = ca_context;
+    dalloc_add_copy(cnids->ca_cnids, &cnid, uint64_t);
+    dalloc_add(packed, cnids, sl_cnids_t);
+    rpclen = sl_pack(packed, rpcbuf);
+
+    if (rpclen < 0) {
+        goto cleanup;
+    }
+
+    cnid_header = ((uint64_t)ca_context << 32)
+                  | ((uint64_t)ca_unkn1 << 16) | 1;
+
+    for (size_t offset = 16;
+            offset + sizeof(uint64_t) <= (size_t)rpclen;
+            offset += sizeof(uint64_t)) {
+        if (spotlight_test_get_le64(rpcbuf, offset) != cnid_header) {
+            continue;
+        }
+
+        rpcbuf[offset] = 0;
+        rpcbuf[offset + 1] = 0;
+        result = sl_unpack_len(unpacked, rpcbuf, (size_t)rpclen);
+        break;
+    }
+
+cleanup:
+    talloc_free(tmp);
+    return result == -1 ? 0 : -1;
+}
+#endif
 
 static void dsi_test_header(uint8_t *block, uint8_t command,
                             uint16_t request_id,
@@ -479,6 +556,10 @@ int main(int argc, char *argv[])
              "DSI receive rejects payload larger than server quantum");
     TEST_int(utest_dsi_receive_rejects_write_offset_past_payload(), 0,
              "DSI receive rejects DSIWrite offset beyond payload");
+#ifdef WITH_SPOTLIGHT
+    TEST_int(utest_spotlight_rejects_empty_long_cnids(), 0,
+             "Spotlight rejects long-form empty CNID array");
+#endif
     TEST_int(utest_dsi_receive_rejects_zero_length_cmd(), 0,
              "DSI receive rejects a command frame with no AFP function byte");
 #ifndef NO_DDP

--- a/test/testsuite/FPSpotlightRPC.c
+++ b/test/testsuite/FPSpotlightRPC.c
@@ -875,6 +875,52 @@ test_exit:
     exit_test("FPSpotlightRPC:test633: folder-scoped filename search");
 }
 
+STATIC void test634()
+{
+    const char *testname = "test634";
+    uint16_t vol = VolID;
+    unsigned int ret;
+    ENTER_TEST
+
+    if (Conn->afp_version < 32) {
+        test_skipped(T_AFP32);
+        goto test_exit;
+    }
+
+    if (!pag_spotlight_open(vol, testname)) {
+        goto test_exit;
+    }
+
+    ret = FPSpotlightFetchAttributeNamesWithEmptyCNIDArray(Conn, vol);
+
+    if (ret != htonl(AFPERR_MISC)) {
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED: empty CNID array returned "
+                            "%" PRIu32 " (%s), expected AFPERR_MISC\n",
+                    ntohl(ret), afp_error(ret));
+        }
+
+        test_failed();
+        goto test_exit;
+    }
+
+    ret = FPSpotlightOpen(Conn, vol, NULL, 0);
+
+    if (ret != AFP_OK) {
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED: empty CNID array left "
+                            "Spotlight RPC unusable: FPSpotlightOpen returned "
+                            "%" PRIu32 " (%s), raw=0x%08x\n",
+                    ntohl(ret), afp_error(ret), ret);
+        }
+
+        test_failed();
+    }
+
+test_exit:
+    exit_test("FPSpotlightRPC:test634: reject empty CNID array");
+}
+
 void FPSpotlightRPC_test()
 {
     ENTER_TESTSET
@@ -886,4 +932,5 @@ void FPSpotlightRPC_test()
     test563();
     test632();
     test633();
+    test634();
 }

--- a/test/testsuite/afpcmd.h
+++ b/test/testsuite/afpcmd.h
@@ -27,6 +27,8 @@ extern unsigned int FPSpotlightFetchPropertiesWithLargeTOCIndex(CONN *conn,
         uint16_t vid);
 extern unsigned int FPSpotlightRPCWithLargeInt64Count(CONN *conn,
                                                       uint16_t vid);
+extern unsigned int FPSpotlightFetchAttributeNamesWithEmptyCNIDArray(
+    CONN *conn, uint16_t vid);
 extern unsigned int FPSpotlightPackFilemetaOverflowProbe(void);
 
 extern unsigned int FPopenLogin(CONN *conn, char *vers, char *uam, char *usr,

--- a/test/testsuite/afpcmd_spotlight.c
+++ b/test/testsuite/afpcmd_spotlight.c
@@ -85,6 +85,12 @@ static uint32_t spotlight_test_get_le32(const char *buf, size_t offset)
            | ((uint32_t)p[3] << 24);
 }
 
+static uint64_t spotlight_test_get_le64(const char *buf, size_t offset)
+{
+    return (uint64_t)spotlight_test_get_le32(buf, offset)
+           | ((uint64_t)spotlight_test_get_le32(buf, offset + 4) << 32);
+}
+
 static void spotlight_test_put_le32(uint8_t *buf, size_t offset, uint32_t val)
 {
     buf[offset] = (uint8_t)val;
@@ -257,6 +263,76 @@ unsigned int FPSpotlightRPCWithLargeInt64Count(CONN *conn, uint16_t vid)
     spotlight_test_put_le64(rpcbuf, 32,
                             spotlight_test_pack_tag(TEST_SQ_TYPE_TOC, 1, 0));
     return spotlight_send(conn, vid, SPOTLIGHT_CMD_RPC, rpcbuf, sizeof(rpcbuf));
+}
+
+/*!
+ * @brief Send a fetchAttributeNamesForOIDArray request whose CNIDS value uses
+ *        the long form but declares zero elements
+ */
+unsigned int FPSpotlightFetchAttributeNamesWithEmptyCNIDArray(
+    CONN *conn, uint16_t vid)
+{
+    char         rpcbuf[SL_PACK_BUFLEN];
+    int          rpclen;
+    TALLOC_CTX  *tmp = talloc_new(NULL);
+    DALLOC_CTX  *outer = talloc_zero(tmp, DALLOC_CTX);
+    sl_array_t  *outer_array = talloc_zero(outer, sl_array_t);
+    sl_array_t  *args = talloc_zero(outer_array, sl_array_t);
+    sl_cnids_t  *cnids = talloc_zero(outer_array, sl_cnids_t);
+    uint64_t     cnid = 0x1122334455667788;
+    const uint16_t ca_unkn1 = 0x0fec;
+    const uint32_t ca_context = 0x5a17c0de;
+    uint64_t     cnid_header;
+    bool         patched = false;
+    unsigned int ret = htonl(AFPERR_PARAM);
+
+    if (tmp == NULL || outer == NULL || outer_array == NULL || args == NULL
+            || cnids == NULL) {
+        goto cleanup;
+    }
+
+    cnids->ca_cnids = talloc_zero(cnids, DALLOC_CTX);
+
+    if (cnids->ca_cnids == NULL) {
+        goto cleanup;
+    }
+
+    dalloc_add(args,
+               dalloc_strdup(args, "fetchAttributeNamesForOIDArray:context:"),
+               "char *");
+    dalloc_add(outer_array, args, sl_array_t);
+    cnids->ca_unkn1 = ca_unkn1;
+    cnids->ca_context = ca_context;
+    dalloc_add_copy(cnids->ca_cnids, &cnid, uint64_t);
+    dalloc_add(outer_array, cnids, sl_cnids_t);
+    dalloc_add(outer, outer_array, sl_array_t);
+    rpclen = sl_pack(outer, rpcbuf);
+
+    if (rpclen < 0) {
+        goto cleanup;
+    }
+
+    cnid_header = spotlight_test_pack_tag(ca_unkn1, 1, ca_context);
+
+    for (size_t offset = 16; offset + sizeof(uint64_t) <= (size_t)rpclen;
+            offset += sizeof(uint64_t)) {
+        if (spotlight_test_get_le64(rpcbuf, offset) == cnid_header) {
+            rpcbuf[offset] = 0;
+            rpcbuf[offset + 1] = 0;
+            patched = true;
+            break;
+        }
+    }
+
+    if (!patched) {
+        goto cleanup;
+    }
+
+    ret = spotlight_send(conn, vid, SPOTLIGHT_CMD_RPC,
+                         (const uint8_t *)rpcbuf, (size_t)rpclen);
+cleanup:
+    talloc_free(tmp);
+    return ret;
 }
 
 /*!


### PR DESCRIPTION
Reported-by: Elias Hasas (@zer0d4y5)

Reviewed-by: Andy Lemin (@andylemin)