### PR TITLE
doc: remove obsolete configuration from Doxyfile

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2871,15 +2871,6 @@ DOT_GRAPH_MAX_NODES    = 50
 
 MAX_DOT_GRAPH_DEPTH    = 0
 
-# Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
-# files in one run (i.e. multiple -o and -T options on the command line). This
-# makes dot run faster, but since only newer versions of dot (>1.8.10) support
-# this, this feature is disabled by default.
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_MULTI_TARGETS      = NO
-
 # If the GENERATE_LEGEND tag is set to YES Doxygen will generate a legend page
 # explaining the meaning of the various boxes and arrows in the dot generated
 # graphs.


### PR DESCRIPTION
removed the DOT_MULTI_TARGETS setting which is valid for doxygen v1.14.0 but obsolete in v1.18.0

its presence fails the build when in strict mode with the later doxygent version