### PR TITLE
Follow-ups to recent hardening commits: cnid, dbd, adouble, unicode

### DIFF
--- a/bin/dbd/cmd_dbd_scanvol.c
+++ b/bin/dbd/cmd_dbd_scanvol.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <setjmp.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -231,7 +232,7 @@ static void remove_eafiles(const char *name, struct ea *ea _U_)
     addir_fd = open(ADv2_DIRNAME,
                     O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
 
-    if (addir_fd == -1) {
+    if (addir_fd < 0) {
         dbd_log(LOGSTD, "Couldn't open '%s/%s': %s",
                 cwdbuf, ADv2_DIRNAME, strerror(errno));
         return;
@@ -322,6 +323,16 @@ static int check_eafiles(const char *fname)
 }
 
 /*!
+ * @brief Whether a non-directory holds the AppleDouble dir name
+ *
+ * A regular file gives ENOTDIR, a symlink the platform's O_NOFOLLOW errno.
+ */
+static bool adouble_dir_unusable(int err)
+{
+    return err == ENOTDIR || err == OPEN_NOFOLLOW_ERRNO;
+}
+
+/*!
  * Check for .AppleDouble folder and .Parent, create if missing
  */
 static int check_addir(int volroot _U_)
@@ -342,6 +353,15 @@ static int check_addir(int volroot _U_)
                     O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
 
     if (addir_fd == -1) {
+        if (adouble_dir_unusable(errno)) {
+            /* Left by a non-AFP client: skip this directory's AppleDouble
+             * checks rather than fail the volume */
+            dbd_log(LOGSTD,
+                    "Skipping AppleDouble checks in '%s': %s is not a directory",
+                    cwdbuf, ADv2_DIRNAME);
+            return 1;
+        }
+
         if (errno != ENOENT) {
             dbd_log(LOGSTD, "Open error for directory %s/%s: %s", cwdbuf, ADv2_DIRNAME,
                     strerror(errno));
@@ -437,22 +457,16 @@ static int check_addir(int volroot _U_)
             addir_fd = open(ADv2_DIRNAME,
                             O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
 
-            if (addir_fd == -1) {
-                dbd_log(LOGSTD, "Couldn't open newly created directory \"%s\"", ADv2_DIRNAME);
-
-                if (parent_fd != -1) {
-                    close(parent_fd);
+            if (addir_fd != -1) {
+                if (fchown(addir_fd, st.st_uid, st.st_gid) < 0) {
+                    dbd_log(LOGSTD, "fchown failed on fd for \"%s\"", ADv2_DIRNAME);
                 }
-
-                return -1;
-            }
-
-            if (fchown(addir_fd, st.st_uid, st.st_gid) < 0) {
-                dbd_log(LOGSTD, "fchown failed on fd for \"%s\"", ADv2_DIRNAME);
+            } else {
+                dbd_log(LOGSTD, "Couldn't open newly created directory \"%s\"", ADv2_DIRNAME);
             }
         }
 
-        if (parent_fd == -1) {
+        if (parent_fd == -1 && addir_fd != -1) {
             parent_fd = openat(addir_fd, ".Parent",
                                O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
 
@@ -462,8 +476,6 @@ static int check_addir(int volroot _U_)
                 }
             } else {
                 dbd_log(LOGSTD, "Couldn't open newly created file \"%s\"", ad_parent_path);
-                close(addir_fd);
-                return -1;
             }
         }
     }
@@ -494,13 +506,6 @@ static int check_eafile_in_adouble(int parent_fd, int addir_fd,
 
     /* Check if this is an AFPVOL_EA_AD vol */
     if (vol->v_vfs_ea == AFPVOL_EA_AD) {
-        /* Both descriptors name the containing directories. */
-        if (parent_fd < 0 || addir_fd < 0) {
-            dbd_log(LOGSTD, "Invalid directory descriptor while checking '%s/%s'",
-                    ADv2_DIRNAME, name);
-            return -1;
-        }
-
         /* Does the filename contain "::EA" ? */
         namedup = strdup(name);
 
@@ -565,7 +570,7 @@ static int read_addir(void)
     struct stat st;
     parent_fd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
 
-    if (parent_fd == -1) {
+    if (parent_fd < 0) {
         dbd_log(LOGSTD, "Couldn't open '%s': %s", cwdbuf, strerror(errno));
         return -1;
     }
@@ -573,11 +578,18 @@ static int read_addir(void)
     addir_fd = openat(parent_fd, ADv2_DIRNAME,
                       O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
 
-    if (addir_fd == -1) {
+    if (addir_fd < 0) {
         int saved_errno = errno;
         close(parent_fd);
 
-        if (vol->v_adouble == AD_VERSION_EA && saved_errno == ENOENT) {
+        /* On an ea volume the directory is at most a v2 leftover, never a
+         * reason to stop the rebuild */
+        if (vol->v_adouble == AD_VERSION_EA) {
+            if (saved_errno != ENOENT) {
+                dbd_log(LOGSTD, "Skipping '%s/%s': %s",
+                        cwdbuf, ADv2_DIRNAME, strerror(saved_errno));
+            }
+
             return 0;
         }
 
@@ -788,9 +800,10 @@ static int dbd_readdir(int volroot, cnid_t did)
     struct dirent *ep;
     static struct stat st;      /* Save some stack space */
 
-    /* Check again for .AppleDouble folder, check_adfile also checks/creates it */
-    if ((addir_ok = check_addir(volroot)) != 0 && !(dbd_flags & DBD_FLAGS_SCAN)) {
-        /* Fatal on rebuild run, continue if only scanning ! */
+    /* Check again for .AppleDouble folder, check_adfile also checks/creates it.
+     * Positive: skip this directory's AppleDouble checks; negative: fatal on a
+     * rebuild run. */
+    if ((addir_ok = check_addir(volroot)) < 0 && !(dbd_flags & DBD_FLAGS_SCAN)) {
         return -1;
     }
 
@@ -922,8 +935,8 @@ static int dbd_readdir(int volroot, cnid_t did)
             /* Check CNIDs */
             cnid = check_cnid(name, did, &st, adfile_ok);
 
-            /* Check EA files */
-            if (vol->v_vfs_ea == AFPVOL_EA_AD) {
+            /* Check EA files, which live in the AppleDouble dir too */
+            if (ADDIR_OK && vol->v_vfs_ea == AFPVOL_EA_AD) {
                 check_eafiles(name);
             }
         }

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -2256,7 +2256,10 @@ int copyfile(struct vol *s_vol,
     if (ad_meta_open(&add)) {
         if (ad_meta_open(adp)) {
             if (ad_copy_header(&add, adp) != 0) {
-                err = EIO;
+                if (err == 0) {
+                    err = EIO;
+                }
+
                 goto error;
             }
         }
@@ -2333,6 +2336,9 @@ done:
 
     case EROFS:
         return AFPERR_VLOCK;
+
+    case EIO:
+        return AFPERR_MISC;
     }
 
     return AFPERR_PARAM;

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -35,6 +35,7 @@
 
 #include <fcntl.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -467,6 +468,7 @@ extern int ad_tmplock(struct adouble *, uint32_t eid, int type, off_t off,
 
 /* ad_open.c */
 extern void *ad_entry(const struct adouble *ad, int eid);
+extern bool ad_entry_fits(const struct adouble *ad, int eid, uint32_t len);
 extern off_t ad_getentryoff(const struct adouble *ad, int eid);
 extern const char *adflags2logstr(int adflags);
 extern int ad_setfuid(const uid_t);

--- a/libatalk/adouble/ad_flush.c
+++ b/libatalk/adouble/ad_flush.c
@@ -185,16 +185,61 @@ int ad_rebuild_adouble_header_osx(struct adouble *ad, char *adbuf)
     return AD_DATASZ_OSX;
 }
 
+/*!
+ * @brief The source entry to copy for eid, or NULL to skip it
+ *
+ * Forks and the comment are never copied; anything else must be present on
+ * both sides and valid in the source. @p len receives its source length.
+ */
+static char *ad_copy_header_entry(const struct adouble *add,
+                                  const struct adouble *ads,
+                                  uint32_t eid, uint32_t *len)
+{
+    char *src;
+    ssize_t ade_len;
+
+    switch (eid) {
+    case ADEID_COMMENT:
+    case ADEID_DFORK:
+    case ADEID_RFORK:
+        return NULL;
+
+    default:
+        break;
+    }
+
+    if (ads->ad_eid[eid].ade_off == 0 || add->ad_eid[eid].ade_off == 0) {
+        return NULL;
+    }
+
+    ade_len = ads->ad_eid[eid].ade_len;
+
+    if (ade_len <= 0) {
+        return NULL;
+    }
+
+    *len = (uint32_t) ade_len;
+
+    if ((src = ad_entry(ads, eid)) == NULL) {
+        LOG(log_debug, logtype_ad, "ad_copy_header(%s): invalid src eid[%d]",
+            ads->ad_name, eid);
+    }
+
+    return src;
+}
+
 /* -------------------
  * XXX copy only header with same size or comment
  * doesn't work well for adouble with different version.
  *
+ * Every destination entry is checked against the length to be copied before
+ * anything is written: exchangefiles runs this on live open forks, so a
+ * failure must leave the header untouched.
  */
 int ad_copy_header(struct adouble *add, struct adouble *ads)
 {
     uint32_t       eid;
     uint32_t       len;
-    ssize_t        dst_len;
     char *src = NULL;
     char *dst = NULL;
 
@@ -205,56 +250,28 @@ int ad_copy_header(struct adouble *add, struct adouble *ads)
     }
 
     for (eid = 0; eid < ADEID_MAX; eid++) {
-        src = dst = NULL;
-
-        if (ads->ad_eid[eid].ade_off == 0 || add->ad_eid[eid].ade_off == 0) {
+        if (ad_copy_header_entry(add, ads, eid, &len) == NULL) {
             continue;
         }
 
-        len = ads->ad_eid[eid].ade_len;
+        /* FinderInfo accepts any length of at least 32 bytes, so a large but
+         * source-valid entry could otherwise be copied past add->ad_data */
+        if (!ad_entry_fits(add, eid, len)) {
+            LOG(log_debug, logtype_ad, "ad_copy_header(%s): invalid dst eid[%d]",
+                add->ad_name, eid);
+            errno = EIO;
+            return -1;
+        }
+    }
 
-        if (len == 0) {
+    for (eid = 0; eid < ADEID_MAX; eid++) {
+        if ((src = ad_copy_header_entry(add, ads, eid, &len)) == NULL) {
             continue;
         }
 
-        switch (eid) {
-        case ADEID_COMMENT:
-        case ADEID_DFORK:
-        case ADEID_RFORK:
-            continue;
-
-        default:
-            if ((src = ad_entry(ads, eid)) == NULL) {
-                LOG(log_debug, logtype_ad, "ad_copy_header(%s): invalid src eid[%d]",
-                    ads->ad_name, eid);
-                continue;
-            }
-
-            /*
-             * Validate the destination against the length memcpy() will
-             * actually use.  Checking it with the old destination length is
-             * insufficient: FinderInfo accepts any length of at least 32
-             * bytes, so a large but source-valid entry could otherwise be
-             * copied past add->ad_data.
-             *
-             * Keep the old length until validation and copying succeed so an
-             * error leaves this destination entry's metadata unchanged.
-             */
-            dst_len = add->ad_eid[eid].ade_len;
-            ad_setentrylen(add, eid, len);
-            dst = ad_entry(add, eid);
-            ad_setentrylen(add, eid, dst_len);
-
-            if (dst == NULL) {
-                LOG(log_debug, logtype_ad, "ad_copy_header(%s): invalid dst eid[%d]",
-                    add->ad_name, eid);
-                errno = EIO;
-                return -1;
-            }
-
-            memcpy(dst, src, len);
-            ad_setentrylen(add, eid, len);
-        }
+        dst = add->ad_data + ad_getentryoff(add, eid);
+        memcpy(dst, src, len);
+        ad_setentrylen(add, eid, len);
     }
 
     add->ad_rlen = ads->ad_rlen;

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -1994,24 +1994,28 @@ static bool ad_entry_check_size(uint32_t eid,
     return true;
 }
 
+/*!
+ * @brief Whether an entry of @p len bytes fits at eid's offset in ad
+ *
+ * ad_entry()'s bounds check against a caller-supplied length, so a
+ * destination can be checked before its length is committed.
+ */
+bool ad_entry_fits(const struct adouble *ad, int eid, uint32_t len)
+{
+    off_t off = ad_getentryoff(ad, eid);
+    return off != 0
+           && ad_entry_check_size(eid, ad->valid_data_len, (uint32_t) off, len);
+}
+
 void *ad_entry(const struct adouble *ad, int eid)
 {
-    size_t bufsize = ad->valid_data_len;
     off_t off = ad_getentryoff(ad, eid);
-    size_t len = ad_getentrylen(ad, eid);
-    bool valid;
-    valid = ad_entry_check_size(eid, bufsize, off, len);
+    uint32_t len = (uint32_t) ad_getentrylen(ad, eid);
 
-    if (!valid) {
+    if (!ad_entry_fits(ad, eid, len)) {
         LOG(log_debug, logtype_ad,
-            "ad_entry(%s, %d): invalid off: %d, len: %llu, buf: %llu",
-            ad->ad_name, eid, off, len, bufsize);
-        return NULL;
-    }
-
-    if (off == 0) {
-        LOG(log_debug, logtype_ad, "ad_entry(%s, %d): invalid off: %d, len: %llu",
-            ad->ad_name, eid, off, len);
+            "ad_entry(%s, %d): invalid off: %lld, len: %u, buf: %zu",
+            ad->ad_name, eid, (long long) off, len, ad->valid_data_len);
         return NULL;
     }
 

--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -74,26 +74,6 @@
 static void cnid_sqlite_set_errno(int sqlite_return);
 
 /*!
- * @brief Whether a string is one of this backend's per-volume table names
- *
- * uuid_strip_dashes() yields exactly 32 hex digits, so a value in any other
- * form was not written by this backend. A table name cannot be a bound
- * parameter, so statements that name one accept only this form.
- */
-static bool cnid_sqlite_is_table_name(const char *name)
-{
-    size_t i;
-
-    for (i = 0; name[i] != '\0'; i++) {
-        if (!isxdigit((unsigned char) name[i])) {
-            return false;
-        }
-    }
-
-    return i == 32;
-}
-
-/*!
  * @brief Prepare one per-volume statement, replacing any previous handle
  *
  * @param[in,out] db      backend private data
@@ -2007,6 +1987,51 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
     }
 
     /*
+     * SQLite table names are case-insensitive while VolUUID compares bytewise,
+     * so a row for this path differing from the configured UUID only in case
+     * names this volume's live table, and the stale scan below would drop it.
+     * Adopt the spelling on disk instead.
+     */
+    if (sqlite3_prepare_v2(db->cnid_sqlite_con,
+                           "SELECT VolUUID FROM volumes WHERE VolPath = ? "
+                           "AND VolUUID != ? AND VolUUID = ? COLLATE NOCASE",
+                           -1, &transient_stmt, NULL) == SQLITE_OK) {
+        char *same_table_uuid = NULL;
+        sqlite3_bind_text(transient_stmt, 1, vol->v_path, -1, SQLITE_STATIC);
+        sqlite3_bind_text(transient_stmt, 2, db->cnid_sqlite_voluuid_str, -1,
+                          SQLITE_STATIC);
+        sqlite3_bind_text(transient_stmt, 3, db->cnid_sqlite_voluuid_str, -1,
+                          SQLITE_STATIC);
+
+        if (sqlite3_step(transient_stmt) == SQLITE_ROW) {
+            const char *on_disk = (const char *)sqlite3_column_text(transient_stmt, 0);
+
+            if (on_disk != NULL && cnid_sqlite_uuid_usable(on_disk)) {
+                same_table_uuid = strdup(on_disk);
+            }
+        }
+
+        /* The statement still reads the bound string, so it is finalized
+         * before the swap */
+        sqlite3_finalize(transient_stmt);
+        transient_stmt = NULL;
+
+        if (same_table_uuid != NULL) {
+            LOG(log_info, logtype_cnid,
+                "cnid_sqlite_open: volume '%s' UUID '%s' names the existing CNID "
+                "table '%s'; keeping that spelling",
+                vol->v_path, db->cnid_sqlite_voluuid_str, same_table_uuid);
+            free(db->cnid_sqlite_voluuid_str);
+            db->cnid_sqlite_voluuid_str = same_table_uuid;
+        }
+    } else {
+        LOG(log_error, logtype_cnid,
+            "cnid_sqlite_open: could not check the CNID table spelling for '%s': %s",
+            vol->v_path, sqlite3_errmsg(db->cnid_sqlite_con));
+        EC_FAIL;
+    }
+
+    /*
      * Clean up stale volume entries for the same path but with a different UUID.
      * This can happen when the UUID config file is rewritten without the entry
      * for this volume (e.g. [Homes] volumes not loaded during load_afp_conf_vols),
@@ -2031,17 +2056,20 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
                 && stale_count < 64) {
             const char *stale_uuid = (const char *)sqlite3_column_text(transient_stmt, 0);
 
+            if (stale_uuid == NULL) {
+                continue;
+            }
+
             /* Only names this backend created are cleaned up; a row whose
              * VolUUID is not in table-name form is left in place and logged */
-            if (stale_uuid != NULL && !cnid_sqlite_is_table_name(stale_uuid)) {
+            if (!cnid_sqlite_uuid_usable(stale_uuid)) {
                 LOG(log_warning, logtype_cnid,
                     "cnid_sqlite_open: ignoring volumes row for path '%s' whose "
                     "VolUUID is not a CNID table name", vol->v_path);
                 continue;
             }
 
-            if (stale_uuid == NULL
-                    || (stale_uuids[stale_count] = strdup(stale_uuid)) == NULL) {
+            if ((stale_uuids[stale_count] = strdup(stale_uuid)) == NULL) {
                 continue;
             }
 
@@ -2065,27 +2093,6 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
         for (int i = 0; i < stale_count; i++) {
             char *stale_sql = NULL;
             int removed;
-
-            /* A UUID that is not 32 hex digits names no table this code
-             * created, so only its row is removed. The row is what brings it
-             * back at the next open. */
-            if (!cnid_sqlite_uuid_usable(stale_uuids[i])) {
-                LOG(log_error, logtype_cnid,
-                    "cnid_sqlite_open: refusing to act on malformed stale volume "
-                    "UUID for path '%s'; removing its entry", vol->v_path);
-                removed = cnid_sqlite_delete_volumes_row(db->cnid_sqlite_con,
-                                                         stale_uuids[i]) == 0;
-
-                if (!removed) {
-                    LOG(log_warning, logtype_cnid,
-                        "cnid_sqlite_open: could not remove malformed stale volume "
-                        "entry for path '%s'", vol->v_path);
-                }
-
-                free(stale_uuids[i]);
-                continue;
-            }
-
             LOG(log_warning, logtype_cnid,
                 "cnid_sqlite_open: removing stale volume entry UUID '%s' for path '%s'",
                 stale_uuids[i], vol->v_path);

--- a/libatalk/unicode/util_unistr.c
+++ b/libatalk/unicode/util_unistr.c
@@ -623,7 +623,6 @@ size_t precompose_w(ucs2_t *name, size_t inplen, ucs2_t *comp, size_t *outlen)
                 i += 2;
 
                 if (i == inplen) {
-                    out++;
                     *out = 0;
                     return o_len - *outlen;
                 }

--- a/test/afpd/subtests_cnid.c
+++ b/test/afpd/subtests_cnid.c
@@ -16,6 +16,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <ctype.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -393,6 +394,100 @@ exit:
 
     close(fd);
     unlink(probe);
+    return result;
+#endif /* CNID_BACKEND_SQLITE */
+}
+
+/*!
+ * @brief A UUID differing only in case reuses the live table, never drops it
+ *
+ * SQLite table names are case-insensitive, but the stale-volume scan compares
+ * VolUUID bytewise. A second session under a case-flipped spelling of the same
+ * UUID must therefore find the same table, and the CNIDs in it must survive.
+ */
+int utest_cnid_uuid_case_keeps_table(struct vol *vol)
+{
+#ifndef CNID_BACKEND_SQLITE
+    (void) vol;
+    return TEST_SKIP;
+#else
+    struct vol peer_vol;
+    struct _cnid_db *peer_db;
+    char *flipped = NULL;
+    char probe[MAXPATHLEN];
+    char resolved[MAXPATHLEN];
+    const char *name;
+    struct stat st;
+    cnid_t id;
+    cnid_t did;
+    int fd;
+    int result = 0;
+
+    if (vol->v_cdb == NULL || vol->v_uuid == NULL
+            || vol->v_cnidscheme == NULL
+            || strcmp(vol->v_cnidscheme, "sqlite") != 0) {
+        return TEST_SKIP;
+    }
+
+    if ((flipped = strdup(vol->v_uuid)) == NULL) {
+        return 1;
+    }
+
+    for (char *c = flipped; *c != '\0'; c++) {
+        unsigned char ch = *c;
+        *c = (char)(isupper(ch) ? tolower(ch) : toupper(ch));
+    }
+
+    /* An all-digit UUID has nothing to flip */
+    if (strcmp(flipped, vol->v_uuid) == 0) {
+        free(flipped);
+        return TEST_SKIP;
+    }
+
+    snprintf(probe, sizeof(probe), "%s/cnid_uuidcase_XXXXXX", vol->v_path);
+
+    if ((fd = mkstemp(probe)) < 0) {
+        free(flipped);
+        return 2;
+    }
+
+    if (fstat(fd, &st) != 0) {
+        result = 3;
+        goto close_probe;
+    }
+
+    name = strrchr(probe, '/') + 1;
+    id = cnid_add(vol->v_cdb, &st, htonl(2), name, strlen(name), CNID_INVALID);
+
+    if (id == CNID_INVALID) {
+        result = 4;
+        goto close_probe;
+    }
+
+    peer_vol = *vol;
+    peer_vol.v_uuid = flipped;
+    peer_vol.v_cdb = NULL;
+    peer_db = cnid_open(&peer_vol, vol->v_cnidscheme, 0);
+
+    if (peer_db == NULL) {
+        result = 5;
+        goto delete_id;
+    }
+
+    cnid_close(peer_db);
+    did = id;
+
+    if (cnid_resolve(vol->v_cdb, &did, resolved, sizeof(resolved)) == NULL
+            || strcmp(resolved, name) != 0) {
+        result = 6;
+    }
+
+delete_id:
+    cnid_delete(vol->v_cdb, id);
+close_probe:
+    close(fd);
+    unlink(probe);
+    free(flipped);
     return result;
 #endif /* CNID_BACKEND_SQLITE */
 }

--- a/test/afpd/subtests_cnid.h
+++ b/test/afpd/subtests_cnid.h
@@ -10,6 +10,7 @@ extern int utest_cnid_valide_byteorder(void);
 extern int utest_cnid_resolve_dotdot_rejected(void);
 extern int utest_cnid_add_busy_not_fatal(struct vol *vol);
 extern int utest_cnid_add_depletion_resets(struct vol *vol);
+extern int utest_cnid_uuid_case_keeps_table(struct vol *vol);
 extern int utest_cnid_resolve_notfound_errno(struct vol *vol);
 extern int utest_cnid_corrupt_row_classified(struct vol *vol);
 extern int utest_cnid_find_no_truncated_id(struct vol *vol);

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -250,6 +250,44 @@ static int utest_ad_copy_header_bounds_finderinfo(void)
     return 0;
 }
 
+/*!
+ * @brief A rejected entry leaves every earlier entry of the destination intact
+ *
+ * ADEID_NAME precedes ADEID_FINDERI, so the name is what a per-entry copy
+ * would already have committed when the oversized FinderInfo is refused.
+ */
+static int utest_ad_copy_header_rejects_before_writing(void)
+{
+    struct adouble src;
+    struct adouble dst;
+    const char *dst_name;
+    ad_init_old(&src, AD_VERSION2, 0);
+    ad_init_old(&dst, AD_VERSION2, 0);
+
+    if (ad_init_offsets(&src) != 0 || ad_init_offsets(&dst) != 0) {
+        return 1;
+    }
+
+    ad_setentrylen(&src, ADEID_NAME, 4);
+    memcpy(ad_entry(&src, ADEID_NAME), "NAME", 4);
+    memset(ad_entry(&src, ADEID_FINDERI), 'F', ADEDLEN_FINDERI);
+    ad_setentryoff(&src, ADEID_FINDERI, 1);
+    ad_setentrylen(&src, ADEID_FINDERI, AD_DATASZ2 - 1);
+
+    if (ad_copy_header(&dst, &src) != -1) {
+        return 2;
+    }
+
+    dst_name = dst.ad_data + ad_getentryoff(&dst, ADEID_NAME);
+
+    if (ad_getentrylen(&dst, ADEID_NAME) != 0
+            || memcmp(dst_name, "\0\0\0\0", 4) != 0) {
+        return 3;
+    }
+
+    return 0;
+}
+
 static int utest_ad_copy_header_skips_dfork(void)
 {
     static const uint8_t guard_byte = 0xa5;
@@ -263,9 +301,8 @@ static int utest_ad_copy_header_skips_dfork(void)
         return 1;
     }
 
-    /* Reproduce the attacker-controlled entries from poc_dfork.py.  Each
-     * entry fits by itself, but copying the source length at the destination
-     * offset would write 739 bytes beyond valid_data_len. */
+    /* Each entry fits by itself, but copying the source length at the
+     * destination offset would write 739 bytes beyond valid_data_len. */
     memset(src.ad_data, 'D', src.valid_data_len);
     ad_setentryoff(&src, ADEID_DFORK, 1);
     ad_setentrylen(&src, ADEID_DFORK, AD_DATASZ2 - 1);
@@ -806,6 +843,8 @@ int main(int argc, char *argv[])
              "ad_copy_header copies a valid FinderInfo entry");
     TEST_int(utest_ad_copy_header_bounds_finderinfo(), 0,
              "ad_copy_header rejects oversized FinderInfo without overwriting destination");
+    TEST_int(utest_ad_copy_header_rejects_before_writing(), 0,
+             "ad_copy_header leaves the destination untouched when an entry is rejected");
     TEST_int(utest_ad_copy_header_skips_dfork(), 0,
              "ad_copy_header does not copy data-fork entries");
     /* DSI unit tests: frame acceptance, write handoff, quantum shaping. */
@@ -981,6 +1020,8 @@ int main(int argc, char *argv[])
                      "cnid_find: search results never carry a truncated id");
     TEST_int_or_skip(utest_cnid_dup_row_no_truncated_delete(vol), 0,
                      "cnid_lookup: duplicate cleanup never deletes through a truncated id");
+    TEST_int_or_skip(utest_cnid_uuid_case_keeps_table(vol), 0,
+                     "cnid_open: a case-flipped volume UUID reuses the live table");
     /* Last of the CNID group: recovering from the reset empties the volume's
      * table, so anything expecting a CNID minted earlier must run before it */
     TEST_int_or_skip(utest_cnid_add_depletion_resets(vol), 0,


### PR DESCRIPTION
A review of the commits merged to main between 2026-09-08 and 2026-09-12 found four defects worth fixing before the next release. Each sits at a seam between two commits that were correct on their own; none is an individual mistake.

## Defects and fixes

| # | Module | Defect | Why | Fix |
|---|---|---|---|---|
| 1 | cnid | A volume UUID differing from the stored row only in letter case looked stale, and the cleanup dropped the live CNID table before recreating it empty | SQLite table names are case-insensitive while `volumes.VolUUID` compares bytewise; `afp_voluuid.conf` entries are upper-cased on read, a `volume uuid` in `afp.conf` is stored as typed | A `COLLATE NOCASE` lookup before the stale scan adopts the on-disk spelling for the session. The duplicate table-name predicate and the drop-loop branch it made unreachable are removed |
| 2 | dbd | `dbd -f` aborted the whole rebuild, after wiping the database, when any directory held a regular file or symlink named `.AppleDouble` | 59d1d8a8 opens the directory with `O_NOFOLLOW \| O_DIRECTORY`; the resulting `ENOTDIR` or `O_NOFOLLOW` errno reused the fatal return path | `check_addir()` reports a skip, only a negative result is fatal, ea volumes never stop on it, and the per-file EA check is gated on the same result |
| 3 | adouble | `ad_copy_header()` could fail with earlier entries already copied; `exchangefiles` runs it on live open forks | e788a360 validated each destination inside the copy loop | Validate every entry through the new `ad_entry_fits()`, then copy. `ad_entry()` is built on the same predicate. `copyfile()` maps the failure to `AFPERR_MISC` and keeps an earlier fork-copy errno |
| 4 | unicode | `precompose_w()` left one unwritten unit before its terminator after a composed surrogate pair | The surrogate branch advanced `out` twice; c0a11612 (2011). The NUL always stayed in bounds and callers use the returned length | Extra advance removed. Companion to f43ed6c9 on the `decompose_w()` side |

## Behaviour changes

- A volume whose configured UUID differs only in case from the stored one logs once at info level and keeps its table.
- `dbd -f` logs and skips the AppleDouble checks of a directory whose `.AppleDouble` is not a directory, and completes the volume.
- FPCopyFile of a source whose header entry does not fit the destination returns `AFPERR_MISC` instead of `AFPERR_PARAM`.

## Testing

Alpine container matching CI: zero compiler warnings, full `meson test` green, astyle 3.6.18 compliant. The four SonarCloud findings on the first revision are resolved.

Unit tests, each red with its fix reverted:

- `cnid_open: a case-flipped volume UUID reuses the live table`
- `ad_copy_header leaves the destination untouched when an entry is rejected`

Tool run:

- `dbd -f` on an `adouble = ea` volume with a regular file named `.AppleDouble` and a `v2` volume with a symlink of that name: both exit 0, every later entry is indexed, the stray and its target are untouched.

## Not in this PR

- `write_fork()` computes `offset + reqcount` before its guard, the pattern e16c2495 removed from `read_fork()`.
- A configured `volume uuid` is not checked for hex form before it names a sqlite table.
- The MySQL backend has the same bytewise stale scan. Canonicalising case at the config source would fix both backends but needs a migration path for existing MySQL tables.
